### PR TITLE
Add gating rules for min max variables in TF Quantize op

### DIFF
--- a/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.cpp
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.cpp
@@ -47,6 +47,23 @@ TensorQuantizationSim<DTYPE>::TensorQuantizationSim()
 }
 
 template <typename DTYPE>
+void TensorQuantizationSim<DTYPE>::gateMinMax(double& encodingMin, double& encodingMax)
+{
+
+        double epsilon = 1e-5;
+        // Additional handling to retain zero in range
+        // encodingMin can be at maximum 0.0
+        encodingMin = std::min(encodingMin, 0.0);
+
+        // encodingMax can be at minimum 0.0
+        encodingMax = std::max(encodingMax, 0.0);
+
+        // handle case where encodingMin == encodingMax
+        encodingMax = std::max(encodingMax, encodingMin + epsilon);
+}
+
+
+template <typename DTYPE>
 void TensorQuantizationSim<DTYPE>::quantizeDequantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount,
                                                             DTYPE* outputTensorData, double encodingMin,
                                                             double encodingMax, uint8_t bw, RoundingMode roundingMode,
@@ -54,6 +71,7 @@ void TensorQuantizationSim<DTYPE>::quantizeDequantizeTensor(const DTYPE* inputTe
 {
     DlQuantization::ComputationMode cpuGpuMode;
     TfEncoding encoding;
+    gateMinMax(encodingMin, encodingMax);
     encoding.min = encodingMin;
     encoding.max = encodingMax;
     // compute offset and delta on the fly

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
@@ -55,7 +55,7 @@ class TensorQuantizationSim : public ITensorQuantizationSim<DTYPE>
 {
 public:
     explicit TensorQuantizationSim();
-
+    void gateMinMax(double& encodingMin, double& encodingMax);
     void quantizeDequantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount, DTYPE* outputTensorData,
                                   double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
                                   bool use_cuda) override;

--- a/ModelOptimizations/DlQuantization/test/TestTensorQuantizationSim.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestTensorQuantizationSim.cpp
@@ -71,3 +71,87 @@ TEST(TestTensorQuantizationSim, SanityTest)
         EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
     }
 }
+
+TEST(TestTensorQuantizationSim, SanityTestWithGatedMin)
+{
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    // min is greater than 0, this will be gated at 0.0
+    // New range will be 0 to 1.0
+    double min    = 0.5;
+    double max    = 1.0;
+
+    sim.quantizeDequantizeTensor(tensor.data(), tensor.size(), outputTensor.data(), min, max, bw,
+                                 DlQuantization::RoundingMode::ROUND_NEAREST,  false);
+
+    std::vector<float> expectedOutput = {0.0, 0.0, 0.0, 0.25098041,  0.50196081, 0.74901962};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
+    }
+}
+
+TEST(TestTensorQuantizationSim, SanityTestWithGatedMinMaxEqual)
+{
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    // min max are equal
+    // New range will be 0.5 to 0.5+1e-5
+    double min    = 0.5;
+    double max    = 0.5;
+
+    sim.quantizeDequantizeTensor(tensor.data(), tensor.size(), outputTensor.data(), min, max, bw,
+                                 DlQuantization::RoundingMode::ROUND_NEAREST,  false);
+
+    std::vector<float> expectedOutput = {0.0, 0.0, 0.0, 0.25098041,  0.5, 0.5};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
+    }
+}
+
+TEST(TestTensorQuantizationSim, SanityTestWithGatedMax)
+{
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    // min is greater than 0, this will be gated at 0.0
+    // New range will be -0.5 to 0.0
+    double min    = -0.5;
+    double max    = -0.1;
+
+    sim.quantizeDequantizeTensor(tensor.data(), tensor.size(), outputTensor.data(), min, max, bw,
+                                 DlQuantization::RoundingMode::ROUND_NEAREST,  false);
+
+    std::vector<float> expectedOutput = {-0.5, -0.25098041, 0.0, 0.0, 0.0, 0.0};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
+    }
+}


### PR DESCRIPTION
Signed-off-by: Sangeetha Siddegowda <quic_ssiddego@quicinc.com>