### PR TITLE
Integration pytorch v 1 4 

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -520,8 +520,9 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         op.dotted_name = self._module_to_name[op.get_module()]
         _fill_conv_op_info(op, model)
 
-        # populating input and output shapes obtained via hook and forward pass
-        i, o = module_tensor_tuples_map[model]
+        # populating input and output shapes from xxx_tensor_tuple obtained via hook and forward pass
+        # xxx_tensor_tuple is a union(Tensor, tuple(Tensor)), obtain the shape of the Tensor (or first Tensor if Tuple)
+        i, o = module_tensor_tuples_map[model] # i -> input_tensor_tuple, o -> output_tensor_tuple
         output_shape = list(o[0].shape if isinstance(o, tuple) else o.shape)
         input_shape = list(i[0].shape if isinstance(i, tuple) else i.shape)
         _fill_and_check_op_product_shapes(op, input_shape, output_shape)

--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -521,10 +521,12 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         _fill_conv_op_info(op, model)
 
         # populating input and output shapes from xxx_tensor_tuple obtained via hook and forward pass
+        input_tensor_tuple, output_tensor_tuple = module_tensor_tuples_map[model]
         # xxx_tensor_tuple is a union(Tensor, tuple(Tensor)), obtain the shape of the Tensor (or first Tensor if Tuple)
-        i, o = module_tensor_tuples_map[model] # i -> input_tensor_tuple, o -> output_tensor_tuple
-        output_shape = list(o[0].shape if isinstance(o, tuple) else o.shape)
-        input_shape = list(i[0].shape if isinstance(i, tuple) else i.shape)
+        output_shape = list(
+            output_tensor_tuple[0].shape if isinstance(output_tensor_tuple, tuple) else output_tensor_tuple.shape)
+        input_shape = list(
+            input_tensor_tuple[0].shape if isinstance(input_tensor_tuple, tuple) else input_tensor_tuple.shape)
         _fill_and_check_op_product_shapes(op, input_shape, output_shape)
         return op
 

--- a/TrainingExtensions/torch/test/python/test_onnx_utils.py
+++ b/TrainingExtensions/torch/test/python/test_onnx_utils.py
@@ -69,4 +69,5 @@ class TestOnnxUtils(unittest.TestCase):
         self.assertEqual('relu', onnx_model.graph.node[2].name)
         self.assertEqual('maxpool', onnx_model.graph.node[3].name)
 
-        self.assertEqual('fc', onnx_model.graph.node[75].name)
+        # last op in the model is expected to be fully-connected layer
+        self.assertEqual('fc', onnx_model.graph.node[-1].name)


### PR DESCRIPTION
fixes the following unit tests failures on Pytorch 1.4
    onnx utils
    winnow mask propagation


redoing the PR with bias update changes removed., all changes are backward compatible to PT v1.4
