### PR TITLE
bokeh fix to enable web socket connections originating from additional hosts in visualization api

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -222,7 +222,7 @@ def start_bokeh_server_session(port: int):
 
     host_name = socket.gethostname()
     bokeh_serve_command = "bokeh serve  --allow-websocket-origin=" + \
-                          host_name + ":" + str(port) + " --port=" + str(port) + " &"
+                          host_name + ":" + str(port) + " --allow-websocket-origin=localhost:" + str(port) + " --port=" + str(port) + " &"
     process = subprocess.Popen(bokeh_serve_command,  # pylint: disable=subprocess-popen-preexec-fn
                                shell=True,
                                preexec_fn=os.setsid)


### PR DESCRIPTION
Fixes issue #406. 

Added " --allow-websocket-origin=localhost:" + str(port) in the bokeh_serve_command to fix this issue.

Also, docker needs to be run with the following flag **docker run -p port-id:port-id** to achieve port forwarding for the bokeh server to work from docker

example command:
```
port_id= "<any-port-id>"

docker run -p ${port_id}:${port_id} --rm -it -u $(id -u ${USER}):$(id -g ${USER}) \
  -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
  -v ${HOME}:${HOME} -v ${WORKSPACE}:${WORKSPACE} \
  -v "/local/mnt/workspace":"/local/mnt/workspace" \
  --entrypoint /bin/bash -w ${WORKSPACE} --hostname aimet-dev ${docker_image_name}
```