### PR TITLE
Pinned docutils to 0.16 in docker files to fix sphinx decode error du…

### DIFF
--- a/Docs/CMakeLists.txt
+++ b/Docs/CMakeLists.txt
@@ -49,7 +49,7 @@ add_custom_target(doc
       "${AIMET_LD_LIBRARY_PATH}"
       "${AIMET_PYTHONPATH}"
       "SW_VERSION=${SW_VERSION}"
-      sphinx-build -b html ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+      sphinx-build -v -T -b html ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 add_custom_target(copy_doc_source
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_BINARY_DIR}/Docs_SOURCE)

--- a/Jenkins/Dockerfile
+++ b/Jenkins/Dockerfile
@@ -140,6 +140,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \

--- a/Jenkins/Dockerfile.tf-cpu
+++ b/Jenkins/Dockerfile.tf-cpu
@@ -125,6 +125,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \

--- a/Jenkins/Dockerfile.tf-gpu
+++ b/Jenkins/Dockerfile.tf-gpu
@@ -125,6 +125,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \

--- a/Jenkins/Dockerfile.tf-torch-cpu
+++ b/Jenkins/Dockerfile.tf-torch-cpu
@@ -125,6 +125,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \

--- a/Jenkins/Dockerfile.torch-cpu
+++ b/Jenkins/Dockerfile.torch-cpu
@@ -125,6 +125,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \

--- a/Jenkins/Dockerfile.torch-gpu
+++ b/Jenkins/Dockerfile.torch-gpu
@@ -125,6 +125,7 @@ RUN pip3 --no-cache-dir install \
         cffi==1.12.3 \
         click==7.0 \
         cython==0.29.10 \
+        docutils==0.16 \
         h5py==2.9.0 \
         ipykernel==4.8.2 \
         keras==2.2.4 \


### PR DESCRIPTION
…ring make doc (version 0.17 causes the issue), added display of stack trace on console during sphinx build

Signed-off-by: Bharath Ramaswamy <quic_bharathr@quicinc.com>