### PR TITLE
Add support of dumping histogram data

### DIFF
--- a/ModelOptimizations/DlQuantization/src/TfEnhancedEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/TfEnhancedEncodingAnalyzer.cpp
@@ -53,15 +53,15 @@ template <typename DTYPE>
 std::vector<std::tuple<double, double>> TfEnhancedEncodingAnalyzer<DTYPE>::getStatsHistogram() const
 {
     // Allocate a vector to hold tuples of left edges and pdf for each bucket
-    auto histogram = std::vector<std::tuple<double, double>>(this->_stats.xLeft.size());
+    std::vector<std::tuple<double, double>> histogram;
 
     // Assert that the stats structure is well formed
-    assert(this->_stats.xLeft.size() == this->_stats.pdf.size());
+    assert(this->_stats.xLeft.size() == this->_stats.hist.size());
 
     unsigned index = 0;
     for (auto entry: this->_stats.xLeft)
     {
-        histogram.push_back(std::make_tuple(entry, this->_stats.pdf[index]));
+        histogram.push_back(std::make_tuple(entry, (int)this->_stats.hist[index]));
         index++;
     }
     return histogram;

--- a/ModelOptimizations/DlQuantization/src/math_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cpp
@@ -320,6 +320,7 @@ void UpdatePdfSigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         }
         // Initialize the rest of the PDF structure.
         pdf.pdf.resize(PDF_SIZE);
+        pdf.hist.resize(PDF_SIZE);
         pdf.iterations = 0;
     }
 
@@ -328,6 +329,7 @@ void UpdatePdfSigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
     DTYPE min_val     = pdf.xLeft[0];
     DTYPE bucket_size = pdf.xLeft[1] - pdf.xLeft[0];
     vector<DTYPE> pdf_this_iter(PDF_SIZE, 0);
+    vector<DTYPE> hist_this_iter(PDF_SIZE, 0);
     // This offset is used to help map numbers to histogram buckets.
     DTYPE pdf_offset = min_val / bucket_size;
     // Go through all data points and add them to the histogram.
@@ -339,6 +341,7 @@ void UpdatePdfSigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         if (index >= 0 && index < PDF_SIZE)
         {
             pdf_this_iter[index] += 1;
+            hist_this_iter[index] += 1;
         }
     }
 
@@ -349,6 +352,7 @@ void UpdatePdfSigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         pdf_this_iter[i] /= cnt;
         // Average this PDF into the running average.
         pdf.pdf[i] = (pdf.pdf[i] * pdf.iterations + pdf_this_iter[i]) / (pdf.iterations + 1);
+        pdf.hist[i] += hist_this_iter[i];
     }
     pdf.iterations++;
 }
@@ -389,12 +393,14 @@ void UpdatePdfUnsigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         }
         // Initialize the rest of the PDF structure.
         pdf.pdf.resize(PDF_SIZE);
+        pdf.hist.resize(PDF_SIZE);
         pdf.iterations = 0;
     }
 
     // Create the histogram of this number distribution.
     DTYPE bucket_size = pdf.xLeft[1] - pdf.xLeft[0];
     vector<DTYPE> pdf_this_iter(PDF_SIZE, 0);
+    vector<DTYPE> hist_this_iter(PDF_SIZE, 0);
     // Go through all data points and add them to the histogram.
     for (int i = 0; i < cnt; ++i)
     {
@@ -404,6 +410,7 @@ void UpdatePdfUnsigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         if (index >= 0 && index < PDF_SIZE)
         {
             pdf_this_iter[index] += 1;
+            hist_this_iter[index] += 1;
         }
     }
 
@@ -414,6 +421,7 @@ void UpdatePdfUnsigned_cpu(const DTYPE* data, int cnt, PDF& pdf)
         pdf_this_iter[i] /= cnt;
         // Average this PDF into the running average.
         pdf.pdf[i] = (pdf.pdf[i] * pdf.iterations + pdf_this_iter[i]) / (pdf.iterations + 1);
+        pdf.hist[i] = (pdf.hist[i] * pdf.iterations + hist_this_iter[i]) / (pdf.iterations + 1);
     }
     pdf.iterations++;
 }

--- a/ModelOptimizations/DlQuantization/src/math_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.hpp
@@ -62,6 +62,8 @@ struct PDF
     std::vector<double> xLeft;
     // The probability for each bucket.
     std::vector<double> pdf;
+    // The histogram for each bucket.
+    std::vector<double> hist;
     // This PDF holds the average data for this many iterations.
     int iterations;
 };

--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -253,6 +253,16 @@ def log_package_info():
         # Log Product.
         logging.info("%s", Product)
 
+def save_hist_yaml(encoding_file_path: str, encodings_dict: dict):
+    """
+    Function which saves encoding in YAML and JSON file format
+    :param encoding_file_path: file name to use to generate the yaml and json file
+    :param encodings_dict: dictionary containing the encoding
+    """
+    encoding_file_path_yaml = encoding_file_path + '.yaml'
+    with open(encoding_file_path_yaml, 'w') as encoding_fp_yaml:
+        yaml.dump(encodings_dict, encoding_fp_yaml, default_flow_style=None, allow_unicode=True)
+
 
 def save_json_yaml(encoding_file_path: str, encodings_dict: dict):
     """

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -623,6 +623,22 @@ def create_encoding_dict(encoding: libpymo.TfEncoding, is_symmetric: bool) -> Un
                 'is_symmetric': str(is_symmetric)}
     return None
 
+def create_hist_dict(hist_data: List[Tuple]) -> Union[Dict, None]:
+    """
+    Create histogram dictionary from hist_data object
+    :hist: Number of occurance in given bucket
+    :xleft: Left boundary of each bucket
+    :return: Histogram Dictionary
+    """
+    hist_dict = {}
+    for xleft, hist in hist_data:
+        try:
+            hist_dict['hist'].append(hist)
+            hist_dict['xleft'].append(xleft)
+        except KeyError:
+            hist_dict['hist'] = [hist]
+            hist_dict['xleft'] = [xleft]
+    return hist_dict
 
 def compute_encoding_for_given_bitwidth(data: np.ndarray, bitwidth: int, quant_scheme: QuantScheme,
                                         is_symmetric: bool) -> Dict:


### PR DESCRIPTION
New Feature: Dump histogram in a separate YAML profile for ONNX and Pytorch models.
Updated: 
1. Updated the code to create the histogram with the number of occurrences instead of the pdf. 
2. Updated the histogram initialization as previously it was creating a double size vector.

Testing: Not yet added