### PR TITLE
Upgrade to encodings spec 0.5.0

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim.py
@@ -47,8 +47,7 @@
 # Change in major revision should indicate substantial change to the format, updates to minor version indicates
 # additional information element being added to encoding format and might require update to fully consume the encodings.
 # The patching version shall be updated to indicate minor updates to quantization simulation e.g. bug fix etc.
-encoding_version = '0.4.0'
-
+encoding_version = '0.5.0'
 
 def gate_min_max(min_val: float, max_val: float)-> (float, float):
     """

--- a/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
@@ -58,6 +58,7 @@ from aimet_torch.qc_quantize_op import StaticGridQuantWrapper, QcQuantizeOpMode
 from aimet_torch.adaround.adaround_tensor_quantizer import AdaroundTensorQuantizer
 from aimet_torch.adaround.adaround_optimizer import AdaroundOptimizer
 from aimet_torch.adaround.adaround_loss import AdaroundHyperParameters
+from aimet_torch.tensor_quantizer import QuantizationDataType
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
 
@@ -347,7 +348,8 @@ class Adaround:
                                    'scale': enc.delta,
                                    'offset': enc.offset,
                                    'bitwidth': enc.bw,
-                                   'is_symmetric': str(quantizer.use_symmetric_encodings)})
+                                   'is_symmetric': str(quantizer.use_symmetric_encodings),
+                                   'dtype': 'int' if quantizer.data_type == QuantizationDataType.int else 'float'})
 
         return encodings_dict
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -48,6 +48,7 @@ from torchvision import datasets, transforms
 
 from aimet_common.defs import QuantScheme
 from aimet_common.utils import AimetLogger
+from aimet_torch.tensor_quantizer import QuantizationDataType
 import libpymo
 
 
@@ -605,7 +606,7 @@ def create_encoding_from_dict(encoding_dict: dict) -> (libpymo.TfEncoding, bool)
 
 
 def compute_encoding_for_given_bitwidth(data: np.ndarray, bitwidth: int, quant_scheme: QuantScheme,
-                                        is_symmetric: bool) -> Dict:
+                                        is_symmetric: bool, data_type: QuantizationDataType) -> Dict:
     """
     Return encoding dictionary for given bitwidth
     :param data: Numpy data
@@ -627,7 +628,8 @@ def compute_encoding_for_given_bitwidth(data: np.ndarray, bitwidth: int, quant_s
                 'scale': encoding.delta,
                 'offset': encoding.offset,
                 'bitwidth': encoding.bw,
-                'is_symmetric': str(is_symmetric)}
+                'is_symmetric': str(is_symmetric),
+                'dtype': 'int' if data_type == QuantizationDataType.int else 'float'}
 
     return {}
 

--- a/TrainingExtensions/torch/test/python/test_adaround_optimizer.py
+++ b/TrainingExtensions/torch/test/python/test_adaround_optimizer.py
@@ -55,6 +55,7 @@ from aimet_torch.adaround.adaround_weight import Adaround
 from aimet_torch.adaround.adaround_loss import AdaroundLoss
 from aimet_torch.adaround.adaround_optimizer import AdaroundOptimizer
 from aimet_torch.adaround.adaround_loss import AdaroundHyperParameters
+from aimet_torch.tensor_quantizer import QuantizationDataType
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Test)
 
@@ -131,7 +132,8 @@ class TestAdaroundOptimizer(unittest.TestCase):
 
         weight_data = np.random.rand(4, 4, 1, 1).astype(dtype='float32')
         encoding_dict = compute_encoding_for_given_bitwidth(weight_data, weight_bw,
-                                                            MAP_QUANT_SCHEME_TO_PYMO[quant_scheme], False)
+                                                            MAP_QUANT_SCHEME_TO_PYMO[quant_scheme], False,
+                                                            QuantizationDataType.int)
         encoding, _ = create_encoding_from_dict(encoding_dict)
 
         print(encoding_dict['scale'], encoding_dict['max'])


### PR DESCRIPTION
- Changed encoding version to 0.5.0
- float dtype encodings upon export to only contain dtype and bitwidth
- Add test case to check float datatype encodings generated

Signed-off-by: yathindra kota <quic_ykota@quicinc.com>