### PR TITLE
Fix bug for fp16 compute encodings

### DIFF
--- a/NightlyTests/torch/test_for_QAT_and_finetuning_MNIST.py
+++ b/NightlyTests/torch/test_for_QAT_and_finetuning_MNIST.py
@@ -171,6 +171,8 @@ class QuantizationSimAcceptanceTests(unittest.TestCase):
                                    default_param_bw=16,
                                    dummy_input=torch.rand(1, 1, 28, 28).cuda())
 
+        sim.compute_encodings(self.forward_pass, forward_pass_callback_args=5)
+
         # train the model for entire one epoch
         mnist_model.train(model=sim.model, epochs=1, num_batches=3,
                           batch_callback=check_if_layer_weights_are_updating, use_cuda=True)

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -232,10 +232,6 @@ class QuantizationSimModel:
 
         """
 
-        if self._data_type == QuantizationDataType.float:
-            # do not compute any encodings for a fp16 models
-            return
-
         quantized_layers = self._get_qc_quantized_layers(self.model)
 
         for _, layer in quantized_layers:


### PR DESCRIPTION
- computing encodings for fp16 to go through the same control logic as the
  integer flow

Signed-off-by: yathindra kota <quic_ykota@quicinc.com>