### PR TITLE
Qc quantize op does not clear statistics before computing encodings in one shot mode

### DIFF
--- a/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizerOpFacade.h
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizerOpFacade.h
@@ -64,6 +64,11 @@ class TensorQuantizerOpFacade
 {
 public:
     /**
+     * Reset stats being collected to compute encoding
+     */
+    virtual void resetEncodingStats() = 0;
+
+    /**
      * Update stats being collected to compute encoding
      * @param tensor Tensor to update the stats with
      * @param tensorSize Size of the tensor (number of tensor elements)

--- a/TrainingExtensions/tensorflow/src/QcQuantizeOp.cpp
+++ b/TrainingExtensions/tensorflow/src/QcQuantizeOp.cpp
@@ -147,7 +147,7 @@ void modeSpecificActionInt(const D& d, const T* inTensor, size_t count, T* outTe
     {
     case DlQuantization::TensorQuantizerOpMode::oneShotQuantizeDequantize:
     {
-
+        tensorQuantizer->resetEncodingStats();
         tensorQuantizer->updateStats(inTensor, count, useCuda);
         DlQuantization::TfEncoding initial_encoding = tensorQuantizer->computeEncoding(bitwidth, useSymmetricEncoding);
         tensorQuantizer->quantizeDequantize(inTensor, count, outTensor, initial_encoding.min, initial_encoding.max,

--- a/TrainingExtensions/tensorflow/test/python/eager/test_qc_quantize_wrapper_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/eager/test_qc_quantize_wrapper_keras.py
@@ -118,6 +118,7 @@ def test_wrapper():
 def test_wrapper_settings():
     if version.parse(tf.version.VERSION) >= version.parse("2.00"):
         tf.keras.backend.clear_session()
+        tf.random.set_seed(10)
         test_inp = np.array([[-3.0, -2.0, -1.0, 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 ,7.0, 8.0]])
         inp = tf.keras.layers.Input(shape=(12,))
         identity = tf.keras.layers.Lambda(lambda x: x)


### PR DESCRIPTION
Fixes #1343 