### PR TITLE
Add fp16 support in QcQuantizePerChannelOp

### DIFF
--- a/TrainingExtensions/tensorflow/CMakeLists.txt
+++ b/TrainingExtensions/tensorflow/CMakeLists.txt
@@ -46,7 +46,7 @@ add_library(TrainingExtensionsTf SHARED
         src/QcQuantizeRecurrentParamOp.cpp
         src/QcQuantizeOp.hpp
         src/QcQuantizeOp.cpp
-        )
+        src/AimetFp16OpUtils.h)
 
 target_include_directories(TrainingExtensionsTf PRIVATE
         ${TF_LIB_DIR}/include

--- a/TrainingExtensions/tensorflow/src/AimetFp16OpUtils.h
+++ b/TrainingExtensions/tensorflow/src/AimetFp16OpUtils.h
@@ -1,0 +1,146 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#ifndef AIMET_FP16_OP_UTILS_H
+#define AIMET_FP16_OP_UTILS_H
+
+#include "AimetOpUtils.h"
+
+#define EIGEN_USE_THREADS
+
+// below forward declaration is done to remove the dependency of "cast_op_impl.h" for TF1.15
+namespace tensorflow {
+typedef std::function<void(OpKernelContext*, const Tensor&, Tensor*,
+                           bool trunc)> CastFunctorType;
+
+CastFunctorType GetCpuCastFromFloat(DataType dst_dtype);
+CastFunctorType GetCpuCastFromHalf(DataType dst_dtype);
+CastFunctorType GetGpuCastFromHalf(DataType dst_dtype);
+CastFunctorType GetGpuCastFromFloat(DataType dst_dtype);
+}
+
+template <typename Device>
+class QuantizeDequantizeFp16Functor
+{
+    /*
+    class to quantize the input tensor to fp16 and dequantize it to fp32. This class has a specialized implementation
+    for GPUDevice and CPUDevice. Tensorflow internal functions are called for each of them.
+    fp16 type supported as part of this operation is IEEE float16.
+    */
+};
+
+template <>
+class QuantizeDequantizeFp16Functor <CPUDevice>
+{
+    // truncate, if set to true would truncate the inputs before casting to fp16. If set to true, tensorflow backend
+    // calls LSBZeroSetter which does the truncate operation
+    bool _truncate = false;
+
+    public:
+    void operator()(OpKernelContext* context, const Tensor& inTensor, Tensor* outTensor)
+    {
+        Tensor tempTensorFp16;
+        OP_REQUIRES_OK(context, context->allocate_temp(DT_HALF, inTensor.shape(), &tempTensorFp16));
+
+        GetCpuCastFromFloat(DT_HALF)(context, inTensor, &tempTensorFp16, _truncate);
+        GetCpuCastFromHalf(DT_FLOAT)(context, tempTensorFp16, outTensor, _truncate);
+    }
+};
+
+#ifdef GOOGLE_CUDA
+template <>
+class QuantizeDequantizeFp16Functor <GPUDevice>
+{
+    // truncate, if set to true would truncate the inputs before casting to fp16. If set to true, tensorflow backend
+    // calls LSBZeroSetter which does the truncate operation
+    bool _truncate = false;
+
+    public:
+    void operator()(OpKernelContext* context, const Tensor& inTensor, Tensor* outTensor)
+    {
+        Tensor tempTensorFp16;
+        OP_REQUIRES_OK(context, context->allocate_temp(DT_HALF, inTensor.shape(), &tempTensorFp16));
+
+        GetGpuCastFromFloat(DT_HALF)(context, inTensor, &tempTensorFp16, _truncate);
+        GetGpuCastFromHalf(DT_FLOAT)(context, tempTensorFp16, outTensor, _truncate);
+    }
+};
+#endif // GOOGLE_CUDA
+
+template <typename D, typename T>
+void modeSpecificActionFp16(OpKernelContext* context, const Tensor& inTensor, const uint64* tensorQuantizerRef,
+                            const int32* opMode, Tensor* outTensor)
+{
+    auto opModeHost = copyLiteralToHost<int32>(context->eigen_device<D>(), opMode);
+    auto opModeEnum = static_cast<const DlQuantization::TensorQuantizerOpMode>(opModeHost);
+
+    switch (opModeEnum)
+    {
+    case DlQuantization::TensorQuantizerOpMode::oneShotQuantizeDequantize:
+    {
+        QuantizeDequantizeFp16Functor<D> fp16Op;
+        fp16Op(context, inTensor, outTensor);
+        break;
+    }
+    case DlQuantization::TensorQuantizerOpMode::quantizeDequantize:
+    {
+        QuantizeDequantizeFp16Functor<D> fp16Op;
+        fp16Op(context, inTensor, outTensor);
+        break;
+    }
+    case DlQuantization::TensorQuantizerOpMode::updateStats:
+    {
+        copyInputTensorsToOutputTensors(context->eigen_device<D>(), inTensor.flat<T>().data(),
+                                            inTensor.NumElements(), outTensor->flat<T>().data());
+        break;
+    }
+    case DlQuantization::TensorQuantizerOpMode::passThrough:
+    {
+        copyInputTensorsToOutputTensors(context->eigen_device<D>(), inTensor.flat<T>().data(),
+                                            inTensor.NumElements(), outTensor->flat<T>().data());
+        break;
+    }
+    default:
+    {
+        std::cout << "encountered unknown TensorQuantizerOpMode" << std::endl;
+        assert(0);
+    }
+    }
+}
+
+#endif   // AIMET_FP16_OP_UTILS_H

--- a/TrainingExtensions/tensorflow/src/QcQuantizeOp.cpp
+++ b/TrainingExtensions/tensorflow/src/QcQuantizeOp.cpp
@@ -37,22 +37,12 @@
 //==============================================================================
 
 #include "QcQuantizeOp.hpp"
-#include "AimetOpUtils.h"
+#include "AimetFp16OpUtils.h"
+
 #include <type_traits>
 
 #define EIGEN_USE_THREADS
 using namespace tensorflow;
-
-// below forward declaration is done to remove the dependency of "cast_op_impl.h" for TF1.15
-namespace tensorflow {
-   typedef std::function<void(OpKernelContext*, const Tensor&, Tensor*,
-                           bool trunc)> CastFunctorType;
-
-   CastFunctorType GetCpuCastFromFloat(DataType dst_dtype);
-   CastFunctorType GetCpuCastFromHalf(DataType dst_dtype);
-   CastFunctorType GetGpuCastFromHalf(DataType dst_dtype);
-   CastFunctorType GetGpuCastFromFloat(DataType dst_dtype);
-}
 
 REGISTER_OP("QcQuantize")
     .Input("in_tensor: T")     // list of input tensors (weights/activations)
@@ -72,53 +62,7 @@ REGISTER_OP("QcQuantize")
         return Status::OK();
     });
 
-template <typename Device>
-class QuantizeDequantizeFp16Functor
-{
-    /*
-    class to quantize the input tensor to fp16 and dequantize it to fp32. This class has a specialized implementation
-    for GPUDevice and CPUDevice. Tensorflow internal functions are called for each of them.
-    fp16 type supported as part of this operation is IEEE float16.
-    */
-};
 
-template <>
-class QuantizeDequantizeFp16Functor <CPUDevice>
-{
-    // truncate, if set to true would truncate the inputs before casting to fp16. If set to true, tensorflow backend
-    // calls LSBZeroSetter which does the truncate operation
-    bool _truncate = false;
-
-    public:
-    void operator()(OpKernelContext* context, const Tensor& inTensor, Tensor* outTensor)
-    {
-        Tensor tempTensorFp16;
-        OP_REQUIRES_OK(context, context->allocate_temp(DT_HALF, inTensor.shape(), &tempTensorFp16));
-
-        GetCpuCastFromFloat(DT_HALF)(context, inTensor, &tempTensorFp16, _truncate);
-        GetCpuCastFromHalf(DT_FLOAT)(context, tempTensorFp16, outTensor, _truncate);
-    }
-};
-
-#ifdef GOOGLE_CUDA
-template <>
-class QuantizeDequantizeFp16Functor <GPUDevice>
-{
-    // truncate, if set to true would truncate the inputs before casting to fp16. If set to true, tensorflow backend
-    // calls LSBZeroSetter which does the truncate operation
-    bool _truncate = false;
-
-    public:
-    void operator()(OpKernelContext* context, const Tensor& inTensor, Tensor* outTensor)
-    {
-        Tensor tempTensorFp16;
-        OP_REQUIRES_OK(context, context->allocate_temp(DT_HALF, inTensor.shape(), &tempTensorFp16));
-
-        GetGpuCastFromFloat(DT_HALF)(context, inTensor, &tempTensorFp16, _truncate);
-        GetGpuCastFromHalf(DT_FLOAT)(context, tempTensorFp16, outTensor, _truncate);
-    }
-};
-#endif // GOOGLE_CUDA
 
 template <typename D, typename T>
 void modeSpecificActionInt(const D& d, const T* inTensor, size_t count, T* outTensor,
@@ -177,48 +121,6 @@ void modeSpecificActionInt(const D& d, const T* inTensor, size_t count, T* outTe
     }
     }
 
-}
-
-
-template <typename D, typename T>
-void modeSpecificActionFp16(OpKernelContext* context, const Tensor& inTensor, const uint64* tensorQuantizerRef,
-                            const int32* opMode, Tensor* outTensor)
-{
-    auto opModeHost = copyLiteralToHost<int32>(context->eigen_device<D>(), opMode);
-    auto opModeEnum = static_cast<const DlQuantization::TensorQuantizerOpMode>(opModeHost);
-
-    switch (opModeEnum)
-    {
-    case DlQuantization::TensorQuantizerOpMode::oneShotQuantizeDequantize:
-    {
-        QuantizeDequantizeFp16Functor<D> fp16Op;
-        fp16Op(context, inTensor, outTensor);
-        break;
-    }
-    case DlQuantization::TensorQuantizerOpMode::quantizeDequantize:
-    {
-        QuantizeDequantizeFp16Functor<D> fp16Op;
-        fp16Op(context, inTensor, outTensor);
-        break;
-    }
-    case DlQuantization::TensorQuantizerOpMode::updateStats:
-    {
-        copyInputTensorsToOutputTensors(context->eigen_device<D>(), inTensor.flat<T>().data(),
-                                            inTensor.NumElements(), outTensor->flat<T>().data());
-        break;
-    }
-    case DlQuantization::TensorQuantizerOpMode::passThrough:
-    {
-        copyInputTensorsToOutputTensors(context->eigen_device<D>(), inTensor.flat<T>().data(),
-                                            inTensor.NumElements(), outTensor->flat<T>().data());
-        break;
-    }
-    default:
-    {
-        std::cout << "encountered unknown TensorQuantizerOpMode" << std::endl;
-        assert(0);
-    }
-    }
 }
 
 // OpKernel definition.

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
@@ -1336,6 +1336,7 @@ class QuantizationSimModel:
                                                    encoding_min=encoding_min,
                                                    encoding_max=encoding_max,
                                                    bit_width=bit_width,
+                                                   is_int_data_type=is_int_data_type,
                                                    use_symmetric_encoding=use_symmetric_encoding,
                                                    axis_handling=quantization_axis_handling, is_training=is_training)
             else:

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/utils/constants.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/utils/constants.py
@@ -89,7 +89,7 @@ class QuantizeOpIndices():
     use_symmetric_encoding = 6
     time_steps = 7
     is_int_data_type = 7
-    axis_handling = 7
+    axis_handling = 8
 
 class BNOpParamType():
     """ BN OP Param types """

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_per_channel_quantization.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_per_channel_quantization.py
@@ -117,6 +117,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
                 use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+                is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
                 mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                        trainable=False, dtype=tf.int32)
@@ -126,7 +127,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                           encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                          axis_handling.initializer])
+                          is_int_data_type.initializer, axis_handling.initializer])
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
                                                                                  tensor_quantizer_reference=tensor_quant_ref,
@@ -134,6 +135,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 
@@ -153,6 +155,125 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
             expected_output[:, :, :, 2] *= 2.5
             self.assertTrue(np.allclose(out_data, expected_output, rtol=0.01))
             sess.close()
+
+    def _test_qc_quantize_fp16_helper(self, device: str):
+        """
+        test custom op which is operating in fp16 mode
+        """
+        np.random.seed(0)
+        zero_out_module = tf.load_op_library('libaimet_tf_ops.so')
+        graph = tf.Graph()
+        config = tf.compat.v1.ConfigProto(log_device_placement=False)
+        sess = tf.compat.v1.Session(graph=graph, config=config)
+        bitwidth = 16
+        use_symm_encoding = True
+
+        with graph.as_default():
+            # placeholder for the input
+            num_output_channels = 3
+            inp = tf.compat.v1.placeholder(tf.float32, shape=[10, num_output_channels], name='input')
+            # Assuming 3 output channels
+            tensor_quantizer_int64 = [None] * num_output_channels
+            tensor_quantizers = [None] * num_output_channels
+            # Create a tensor_quantizer per channel
+            for i in range(num_output_channels):
+                tensor_quantizer = libpymo.TensorQuantizer(libpymo.QuantizationMode.QUANTIZATION_TF_ENHANCED,
+                                                           libpymo.RoundingMode.ROUND_NEAREST)
+
+                tensor_quantizers[i] = tensor_quantizer
+                val = libpymo.PtrToInt64(tensor_quantizer)
+                tensor_quantizer_int64[i] = val
+
+            tensor_quant_ref = tf.Variable(tensor_quantizer_int64, trainable=False, dtype=tf.int64)
+
+            en_min = (np.zeros(num_output_channels)).tolist()
+            en_max = [1.0, 2.0, 2.5]
+            encoding_min = tf.Variable(en_min,
+                                       trainable=True, dtype=tf.double)
+            encoding_max = tf.Variable(en_max,
+                                       trainable=True, dtype=tf.double)
+
+            bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
+            use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+            is_int_data_type = tf.Variable(initial_value=False, trainable=False, dtype=tf.bool)
+
+            mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
+                                   trainable=False, dtype=tf.int32)
+            # axis handling for getting number of channels.
+            axis_handling = tf.Variable(initial_value=AxisHandling.LAST_AXIS.value, trainable=False, dtype=tf.int32)
+            is_training = tf.keras.backend.learning_phase()
+
+            sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
+                      encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
+                      is_int_data_type.initializer, axis_handling.initializer])
+
+            with tf.device(device):
+                pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
+                                                                                 op_mode=mode_var,
+                                                                                 tensor_quantizer_reference=tensor_quant_ref,
+                                                                                 encoding_min=encoding_min,
+                                                                                 encoding_max=encoding_max,
+                                                                                 bit_width=bit_width,
+                                                                                 use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
+                                                                                 axis_handling=axis_handling,
+                                                                                 is_training=is_training)
+
+                inp_tensor = sess.graph.get_tensor_by_name('input:0')
+                inp_data = np.array([[0.78027296, 0.44164285, 0.6942797],
+                                     [0.69774085, 0.55863863, 0.29553035],
+                                     [0.219199, 0.09483732, 0.55075675],
+                                     [0.6348504, 0.78027296, 0.44164285],
+                                     [0.6942797, 0.69774085, 0.55863863],
+                                     [0.29553035, 0.219199, 0.09483732],
+                                     [0.55075675, 0.6348504, 0.78027296],
+                                     [0.44164285, 0.6942797, 0.69774085],
+                                     [0.55863863, 0.29553035, 0.219199],
+                                     [0.09483732, 0.55075675, 0.6348504]], dtype=np.float32)
+
+                out_exp_fp16 = np.array([[0.78027344, 0.4416504, 0.69433594],
+                                    [0.6977539, 0.55859375, 0.29541016],
+                                    [0.21923828, 0.09484863, 0.55078125],
+                                    [0.6347656, 0.78027344, 0.4416504],
+                                    [0.69433594, 0.6977539, 0.55859375],
+                                    [0.29541016, 0.21923828, 0.09484863],
+                                    [0.55078125, 0.6347656, 0.78027344],
+                                    [0.4416504, 0.69433594, 0.6977539],
+                                    [0.55859375, 0.29541016, 0.21923828],
+                                    [0.09484863, 0.55078125, 0.6347656]], dtype=np.float32)
+
+
+                # 1. verify that the output from the above op is as expected (mode: oneShotQuantizeDequantize)
+                out_data = sess.run(pass_through_op_output, feed_dict={inp_tensor: inp_data})
+                self.assertTrue(np.allclose(out_data, out_exp_fp16))
+
+                # 2. change the mode now to updateStats and verify that the output is the same as input
+                mode_var.load(int(libpymo.TensorQuantizerOpMode.updateStats), sess)
+                out_data = sess.run(pass_through_op_output, feed_dict={inp_tensor: inp_data})
+                self.assertTrue(np.allclose(out_data, inp_data))
+
+                # 3. change the mode now to quantizeDequantize and verify that the output is equal to out_exp_fp16
+                mode_var.load(int(libpymo.TensorQuantizerOpMode.quantizeDequantize), sess)
+                out_data = sess.run(pass_through_op_output, feed_dict={inp_tensor: inp_data})
+                self.assertTrue(np.allclose(out_data, out_exp_fp16))
+
+                # 4. change the mode now to passThrough and verify that the output is equal to input
+                mode_var.load(int(libpymo.TensorQuantizerOpMode.passThrough), sess)
+                out_data = sess.run(pass_through_op_output, feed_dict={inp_tensor: inp_data})
+                self.assertTrue(np.allclose(out_data, inp_data))
+
+    def test_qc_quantize_fp16_cpu(self):
+        """
+        test per-channel op in fp16 mode (cpu)
+        """
+        self._test_qc_quantize_fp16_helper(device="/device:CPU:0")
+
+    @pytest.mark.cuda
+    def test_qc_quantize_fp16_gpu(self):
+        """
+        test per-channel op in fp16 mode (gpu)
+        """
+        self._test_qc_quantize_fp16_helper(device="/device:GPU:0")
 
     @pytest.mark.cuda
     def test_qc_quantize_op_gpu_conv(self):
@@ -196,6 +317,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
             use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+            is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
             mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                    trainable=False, dtype=tf.int32)
@@ -204,7 +326,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                       encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                      axis_handling.initializer])
+                      is_int_data_type.initializer, axis_handling.initializer])
             with tf.device("/device:GPU:0"):
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
@@ -213,6 +335,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 
@@ -280,6 +403,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
             use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+            is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
             mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                    trainable=False, dtype=tf.int32)
@@ -290,7 +414,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                       encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                      axis_handling.initializer])
+                      is_int_data_type.initializer, axis_handling.initializer])
             with tf.device("/device:GPU:0"):
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
@@ -299,6 +423,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 
@@ -366,6 +491,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
                 use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+                is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
                 mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                        trainable=False, dtype=tf.int32)
@@ -374,7 +500,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                           encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                          axis_handling.initializer])
+                          is_int_data_type.initializer, axis_handling.initializer])
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
                                                                                  tensor_quantizer_reference=tensor_quant_ref,
@@ -382,6 +508,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 
@@ -439,6 +566,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
                 use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+                is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
                 mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.updateStats),
                                        trainable=False, dtype=tf.int32)
@@ -447,7 +575,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                           encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                          axis_handling.initializer])
+                          is_int_data_type.initializer, axis_handling.initializer])
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
                                                                                  tensor_quantizer_reference=tensor_quant_ref,
@@ -455,6 +583,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_time_comparision_between_cpp_ops.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_time_comparision_between_cpp_ops.py
@@ -219,6 +219,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
                 use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+                is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
                 mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                        trainable=False, dtype=tf.int32)
@@ -227,7 +228,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
                 sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                           encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                          axis_handling.initializer])
+                          is_int_data_type.initializer, axis_handling.initializer])
 
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
@@ -236,6 +237,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 
@@ -377,6 +379,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             bit_width = tf.Variable(initial_value=bitwidth, trainable=False, dtype=tf.int8)
             use_symmetric_encoding = tf.Variable(initial_value=use_symm_encoding, trainable=False, dtype=tf.bool)
+            is_int_data_type = tf.Variable(initial_value=True, trainable=False, dtype=tf.bool)
 
             mode_var = tf.Variable(initial_value=int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize),
                                    trainable=False, dtype=tf.int32)
@@ -385,7 +388,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
 
             sess.run([mode_var.initializer, tensor_quant_ref.initializer, encoding_min.initializer,
                       encoding_max.initializer, bit_width.initializer, use_symmetric_encoding.initializer,
-                      axis_handling.initializer])
+                      is_int_data_type.initializer, axis_handling.initializer])
             with tf.device("/device:GPU:0"):
                 pass_through_op_output = zero_out_module.qc_quantize_per_channel(name='quant_op', in_tensor=inp,
                                                                                  op_mode=mode_var,
@@ -394,6 +397,7 @@ class TestTrainingExtensionsQcQuantizeOpPerChannel(unittest.TestCase):
                                                                                  encoding_max=encoding_max,
                                                                                  bit_width=bit_width,
                                                                                  use_symmetric_encoding=use_symmetric_encoding,
+                                                                                 is_int_data_type=is_int_data_type,
                                                                                  axis_handling=axis_handling,
                                                                                  is_training=is_training)
 


### PR DESCRIPTION
- this support is being added to facilitate using per-channel op in
  mixed precision mode(both int and fp16)
- Move fp16 common code to AimetFp16OpUtils

Signed-off-by: yathindra kota <quic_ykota@quicinc.com>