### PR TITLE
Add support for Percentile quantization scheme

### DIFF
--- a/ModelOptimizations/DlQuantization/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/CMakeLists.txt
@@ -1,7 +1,7 @@
 #==============================================================================
 #  @@-COPYRIGHT-START-@@
 #  
-#  Copyright (c) 2016-2017, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 #  
 #  Redistribution and use in source and binary forms, with or without 
 #  modification, are permitted provided that the following conditions are met:
@@ -42,6 +42,8 @@ add_library(MoDlQuantization STATIC
       src/MainQuantizationClass.hpp
       src/math_functions.cpp
       src/math_functions.hpp
+      src/quantization_utils.cpp
+      src/quantization_utils.hpp
       src/QuantizerFactory.cpp
       src/TfEnhancedQuantizer.cpp
       src/TfEnhancedQuantizer.hpp
@@ -50,6 +52,8 @@ add_library(MoDlQuantization STATIC
       src/trim_functions.cpp
       src/trim_functions.hpp
 
+      src/PercentileEncodingAnalyzer.cpp
+      src/PercentileEncodingAnalyzer.h
       src/TfEnhancedEncodingAnalyzer.cpp
       src/TfEnhancedEncodingAnalyzer.h
       src/TfEncodingAnalyzer.h

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2019, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2019-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -40,6 +40,7 @@
 #define I_QUANTIZATION_ENCODING_ANALYZER_HPP
 
 #include "Quantization.hpp"
+#include <cassert>
 #include <cstdint>
 
 namespace DlQuantization
@@ -89,6 +90,18 @@ public:
      * relative to all the values seen across all buckets
      */
     virtual std::vector<std::tuple<double, double>> getStatsHistogram() const = 0;
+
+    /**
+     * @brief Set the percentile value
+     *
+     * @param percentile Percentile value to be used while adjusting min and max
+     */
+    virtual void setPercentileValue(float percentile)
+    {
+        // TODO - check if there is a better way to do this.
+        // This method is applicable only for TfPercentileEncodingAnalyzer.
+        assert(0);
+    }
 };
 
 

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2016-2017, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -67,6 +67,10 @@ enum QuantizationMode
 
     // Ranges (min, max) are learnt during training
     QUANTIZATION_RANGE_LEARNING,
+
+    // Percentile calibration. Compute the encoding by adjusting the min/max range of the tensor
+    // by clipping percentile of outliers.
+    QUANTIZATION_PERCENTILE,
 };
 
 /**

--- a/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.cpp
@@ -1,0 +1,206 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+
+#include "DlQuantization/Quantization.hpp"
+#include "math_functions.hpp"
+#include "quantization_utils.hpp"
+
+#include "PercentileEncodingAnalyzer.h"
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+std::vector<std::tuple<double, double>> PercentileEncodingAnalyzer<DTYPE>::getStatsHistogram() const
+{
+    // Return the collected histogram data.
+    return getCollectedHistogram(this->_stats);
+}
+
+template <typename DTYPE>
+void PercentileEncodingAnalyzer<DTYPE>::updateStats(const DTYPE* tensor, const size_t tensorSize,
+                                                    ComputationMode tensorCpuGpuMode)
+{
+    this->_statsUpdated = true;
+
+    // update pdf
+    UpdatePdf(tensor, tensorSize, tensorCpuGpuMode, true, this->_stats);
+}
+
+template <typename DTYPE>
+TfEncoding PercentileEncodingAnalyzer<DTYPE>::computeEncoding(uint8_t bw, bool useSymmetricEncodings,
+                                                              bool useStrictSymmetric, bool useUnsignedSymmetric) const
+{
+    TfEncoding encoding = {0, 0, 0, 0, 0};
+    DTYPE numSteps      = pow(2, bw) - 1;
+
+    // For strict symmetric mode, we make even number of buckets
+    if (useSymmetricEncodings && useStrictSymmetric)
+    {
+        numSteps -= 1;
+    }
+
+    if (this->_stats.xLeft.size() == 0)
+    {
+        if (this->_statsUpdated)
+        {
+            // Histogram has not been initialized yet, we have seen all zero data
+            // We generate a valid encoding that covers float 0
+            encoding.min    = -1;
+            encoding.max    = 1;
+            encoding.delta  = (encoding.max - encoding.min) / int(numSteps);
+            encoding.offset = floor(encoding.min / encoding.delta);
+            encoding.min    = encoding.offset * encoding.delta;
+            encoding.max    = encoding.min + int(numSteps) * encoding.delta;
+            encoding.bw     = bw;
+
+            return encoding;
+        }
+        else
+        {
+            // Histogram has not been initialized yet because we have not seen any data
+            // We return a zero encoding - which is a failure indicator
+            return encoding;
+        }
+    }
+
+    // Find the adjusted min and max
+    DTYPE aMin, aMax;
+    std::tie(aMin, aMax) = _computePercentileRange();
+
+    // After Min and Max adjustment, the requirement that 0 be an exactly
+    // representable value must be met.
+    // There is a possibility that 0 may not be present in the Percentile
+    // calibrated Min and Max range. Hence, extend the interval
+    // [aMin, aMax] to ensure that it contains 0.
+    aMin = std::min(aMin, DTYPE(0.f));
+    aMax = std::max(aMax, DTYPE(0.f));
+
+    assert(aMin <= aMax && "min must not be bigger than max");
+
+    return getComputedEncodings(bw, aMin, aMax, useSymmetricEncodings, useStrictSymmetric, useUnsignedSymmetric);
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> PercentileEncodingAnalyzer<DTYPE>::_computePercentileRange() const
+{
+    // Number of histogram bins.
+    const int numBins = PDF_SIZE;
+
+    // Find the range of our collected stats
+    DTYPE minVal, maxVal;
+    std::tie(minVal, maxVal) = _findRangeOfAggregateStats();
+
+    // Incase of percenitle value of 100 no need of calibration.
+    if (this->_percentile == 100.0f)
+    {
+        return std::tuple<DTYPE, DTYPE>(minVal, maxVal);
+    }
+
+    const float histBinWidth = this->_stats.xLeft[1] - this->_stats.xLeft[0];
+    DTYPE histMin            = this->_stats.xLeft[0];
+    DTYPE histMax            = this->_stats.xLeft[PDF_SIZE - 1] + histBinWidth;
+
+    DTYPE percentileMin = histMin;
+    DTYPE percentileMax = histMax;
+
+    // Copy the pdf collected and compute cdf.
+    std::vector<double> cdf(this->_stats.pdf);
+    for (auto i = 1; i < cdf.size(); i++)
+    {
+        cdf[i] += cdf[i - 1];
+    }
+
+    // Compute percentile calibration Min.
+    float leftPercentile = 1 - this->_percentile / 100;
+    for (auto i = 0; i < numBins; i++)
+    {
+        if (cdf[i] >= leftPercentile)
+        {
+            percentileMin = this->_stats.xLeft[i];
+            break;
+        }
+    }
+
+    // Compute percentile calibration Max.
+    float rightPercentile = this->_percentile / 100;
+    for (auto i = numBins - 1; i >= 0; i--)
+    {
+        if (cdf[i] < rightPercentile)
+        {
+            percentileMax = this->_stats.xLeft[i + 1];
+            break;
+        }
+    }
+
+    // Enforce difference between percentileMin and percentileMax to be atleast
+    // one bin width. This will ensure that percentileMin and percentileMax are
+    // not equal in the scenarios where most of the tensor values are concentrated
+    // in a single histogram bin. This will also ensure that percentileMin and
+    // percentileMax are edges of the single bin where most of the tensor elements
+    // are concentrated.
+    if (percentileMin == percentileMax)
+        percentileMax += histBinWidth;
+
+    return std::tuple<DTYPE, DTYPE>(percentileMin, percentileMax);
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> PercentileEncodingAnalyzer<DTYPE>::_findRangeOfAggregateStats() const
+{
+    return findOriginalRange<DTYPE>(this->_stats);
+}
+
+template <typename DTYPE>
+void PercentileEncodingAnalyzer<DTYPE>::setPercentileValue(float percentile)
+{
+    this->_percentile = percentile;
+}
+
+// Explicit instantiations
+template class PercentileEncodingAnalyzer<double>;
+
+template class PercentileEncodingAnalyzer<float>;
+
+}   // namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.h
+++ b/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.h
@@ -1,0 +1,108 @@
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#ifndef DL_QUANTIZATION_PERCENTILE_ENCODING_ANALYZER_H
+#define DL_QUANTIZATION_PERCENTILE_ENCODING_ANALYZER_H
+
+#include "math_functions.hpp"
+#include <DlQuantization/IQuantizationEncodingAnalyzer.hpp>
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+class PercentileEncodingAnalyzer : public IQuantizationEncodingAnalyzer<DTYPE>
+{
+public:
+    /**
+     * Updates internal PDF stats given a tensor.
+     * Intent is to keep a histogram of all the values that we have seen over multiple instances of a tensor
+     * @param tensor Reference to a tensor
+     * @param tensorSize Size of the tensor (number of elements)
+     * @param tensorCpuGpuMode Indicates if the tensor is in CPU or GPU memory
+     */
+    void updateStats(const DTYPE* tensor, const size_t tensorSize, ComputationMode tensorCpuGpuMode) override;
+
+    /***
+     * Compute the encodings using the collected histogram stats by clipping the outliers based on the percentile
+     * value
+     * @param bw Bitwidth to use for computing encodings
+     * @param useSymmetricEncodings If true, compute symmetric encodings
+     * @param useStrictSymmetric If true, compute symmetric encodings with even number of buckets
+     * @param useUnsignedSymmetric If true, compute asymmetric encodings
+     * @return Computed encoding
+     */
+    TfEncoding computeEncoding(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                               bool useUnsignedSymmetric) const override;
+
+
+    /**
+     * @brief Returns a histogram that represents a PDF of tensor values seen by this encoding analyzer so far
+     *
+     * @return Histogram of statistics. The histogram returned is a vector of buckets. Each bucket is a tuple of
+     * two values - the float value representing the left edge of the bucket and a PDF of the values in this bucket
+     * relative to all the values seen across all buckets
+     */
+    std::vector<std::tuple<double, double>> getStatsHistogram() const override;
+
+    /**
+     * @brief Set the Percentile Value
+     *
+     * @param percentile Percentile value to be used while adjusting min and max
+     */
+    void setPercentileValue(float percentile);
+
+private:
+    PDF _stats;
+    float _percentile  = 100;
+    bool _statsUpdated = false;
+
+    // Minimum range of quantization
+    static constexpr double MIN_RANGE = 0.01;
+
+    /**
+     * Find range (min, max) of the aggregated stats
+     * @return Tuple of min and max values
+     */
+    std::tuple<DTYPE, DTYPE> _findRangeOfAggregateStats() const;
+
+    // Adjust the min/max range of tensor values by clipping the percentile outliers
+    std::tuple<DTYPE, DTYPE> _computePercentileRange() const;
+};
+
+}   // namespace DlQuantization
+
+#endif   // DL_QUANTIZATION_PERCENTILE_ENCODING_ANALYZER_H 

--- a/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
+++ b/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2016-2017, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -46,6 +46,7 @@
 #include "DlQuantization/Quantization.hpp"
 #include "DlQuantization/QuantizerFactory.hpp"
 #include "MainQuantizationClass.hpp"
+#include "PercentileEncodingAnalyzer.h"
 #include "TensorQuantizationSim.h"
 #include "TfEncodingAnalyzer.h"
 #include "TfEnhancedEncodingAnalyzer.h"
@@ -68,6 +69,10 @@ std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>> getEncodingAnalyzerInstanc
     if (quantization_mode == QUANTIZATION_TF_ENHANCED)
     {
         return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new TfEnhancedEncodingAnalyzer<DTYPE>);
+    }
+    else if (quantization_mode == QUANTIZATION_PERCENTILE)
+    {
+        return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new PercentileEncodingAnalyzer<DTYPE>);
     }
     else
     {

--- a/ModelOptimizations/DlQuantization/src/TfEnhancedEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/TfEnhancedEncodingAnalyzer.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2019-2021, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2019-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -52,20 +52,8 @@ namespace DlQuantization
 template <typename DTYPE>
 std::vector<std::tuple<double, double>> TfEnhancedEncodingAnalyzer<DTYPE>::getStatsHistogram() const
 {
-    // Allocate a vector to hold tuples of left edges and pdf for each bucket
-    std::vector<std::tuple<double, double>> histogram;
-    histogram.reserve(this->_stats.xLeft.size());
-
-    // Assert that the stats structure is well formed
-    assert(this->_stats.xLeft.size() == this->_stats.pdf.size());
-
-    unsigned index = 0;
-    for (auto entry: this->_stats.xLeft)
-    {
-        histogram.push_back(std::make_tuple(entry, this->_stats.pdf[index]));
-        index++;
-    }
-    return histogram;
+    // Return the collected histogram data.
+    return getCollectedHistogram(this->_stats);
 }
 
 template <typename DTYPE>

--- a/ModelOptimizations/DlQuantization/src/math_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.hpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2016-2021, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -149,6 +149,15 @@ void UpdatePdfSigned_cpu(const DTYPE* data, int cnt, bool signed_vals, PDF& pdf)
 
 template <typename DTYPE>
 void UpdatePdfUnsigned_cpu(const DTYPE* data, int cnt, bool signed_vals, PDF& pdf);
+
+/**
+ * @brief Returns a histogram that represents a PDF of tensor values seen so far.
+ * @param pdf Probability density function.
+ */
+std::vector<std::tuple<double, double>> getCollectedHistogram(const PDF& pdf);
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> findOriginalRange(const PDF& pdf);
 
 // GPU implementations...
 #ifdef GPU_QUANTIZATION_ENABLED

--- a/ModelOptimizations/DlQuantization/src/quantization_utils.cpp
+++ b/ModelOptimizations/DlQuantization/src/quantization_utils.cpp
@@ -1,0 +1,111 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+
+#include "quantization_utils.hpp"
+#include "DlQuantization/Quantization.hpp"
+
+
+namespace DlQuantization
+{
+using namespace std;
+
+TfEncoding getComputedEncodings(uint8_t bw, double min, double max, bool useSymmetricEncodings, bool useStrictSymmetric,
+                                bool useUnsignedSymmetric)
+{
+    TfEncoding encoding;
+
+    double numSteps = pow(2, bw) - 1;
+    if (useSymmetricEncodings && useStrictSymmetric)
+    {
+        numSteps -= 1;
+    }
+    encoding.bw = bw;
+
+    // Special case for symmetric encodings. If all values are positive or 0, we can treat the
+    // symmetric encodings as unsigned, which essentially translates to asymmetric
+
+    // This is a complex check: here is the explanation
+    // If min < 0, then unsigned symmetric mode is immaterial
+    // Also if user can explicitly requested to disable unsigned-symmetric mode, then we use regular symmetric
+    if (useSymmetricEncodings && ((min < 0.0) || (!useUnsignedSymmetric)))
+    {
+        // If we desire symmetric encodings then we need to expand either the min or max to be mirrors of each other
+        // centered around 0
+        max                           = std::max(std::abs(max), std::abs(min));
+        unsigned int numPositiveSteps = std::floor(numSteps / 2);
+        encoding.delta                = max / numPositiveSteps;
+        encoding.offset               = -std::ceil(numSteps / 2);
+        encoding.min                  = encoding.offset * encoding.delta;
+        encoding.max                  = encoding.delta * numPositiveSteps;
+    }
+    else
+    {
+        // Unsigned symmetric handling is the same as asymmetric from this point forward
+
+        encoding.delta = (max - min) / numSteps;
+        if (min < 0 && max > 0)
+        {
+            // Need to make sure 0-value is exactly quantizable
+            // Quantization of q into b is given by:
+            //     b = q / delta - offset, where
+            //                             delta = (max - min)/#steps
+            //                             offset = min / delta
+            // For q = 0: b = -min / delta
+            // Find the closest round b, and set q=0 for it
+            double bZero    = round(-min / encoding.delta);
+            bZero           = std::min(numSteps, std::max(0.0, bZero));   // just to be safe
+            encoding.offset = -bZero;
+        }
+        else
+        {
+            // One of min or max is guaranteed to be zero, so 0 is exactly quantizable already
+            encoding.offset = round(min / encoding.delta);
+        }
+
+        // Calculate 'min' and 'max' based on 'delta' and 'offset'.
+        // Note this min and max can vary from the one in 'stats'. This min and max
+        // can really be represented with the integer offset.
+        encoding.min = encoding.delta * encoding.offset;
+        // We want to calculate: max = delta * numSteps + min.
+        // To avoid numerical accuracy issues on Linaro, we simplify the math.
+        encoding.max = max - min + encoding.min;
+    }
+    return encoding;
+}
+}   // End of namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
+++ b/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
@@ -1,0 +1,55 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+
+#ifndef QUANTIZATION_UTILS_H_
+#define QUANTIZATION_UTILS_H_
+
+#include <math.h>
+#include <stdint.h>
+
+#include "DlQuantization/Quantization.hpp"
+
+namespace DlQuantization
+{
+TfEncoding getComputedEncodings(uint8_t bw, double min, double max, bool useSymmetricEncodings, bool useStrictSymmetric,
+                                bool useUnsignedSymmetric);
+
+}   // End of namespace DlQuantization
+
+#endif   // QUANTIZATION_UTILS_H_ 

--- a/ModelOptimizations/DlQuantization/test/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 #==============================================================================
 #  @@-COPYRIGHT-START-@@
 #  
-#  Copyright (c) 2018, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2018-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 #  
 #  Redistribution and use in source and binary forms, with or without 
 #  modification, are permitted provided that the following conditions are met:
@@ -51,7 +51,8 @@ add_executable(MoDlQuantizationTest
       TestTfEnhancedEncodingAnalyzer.cpp
       TestTfEncodingAnalyzer.cpp
       TestTensorQuantizationSim.cpp
-      TestTensorQuantizer.cpp)
+      TestTensorQuantizer.cpp
+      TestPercentileEncodingAnalyzer.cpp)
 
 if (ENABLE_CUDA)
     target_compile_options(MoDlQuantizationTest

--- a/ModelOptimizations/DlQuantization/test/TestPercentileEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestPercentileEncodingAnalyzer.cpp
@@ -1,0 +1,370 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+#include "test_quantization_lib.hpp"
+#include <DlQuantization/TensorQuantizer.h>
+#include <PercentileEncodingAnalyzer.h>
+
+using namespace DlQuantization;
+
+template <typename TypeParam>
+class TestPercentileEncodingAnalyzer : public ::testing::Test
+{
+};
+// Test on CPU and GPU with float and double
+TYPED_TEST_CASE(TestPercentileEncodingAnalyzer, TestDataTypesAndDevices);
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, Asymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer;
+    analyzer.setPercentileValue(99.9999);
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::min();
+    // Use larger tensor size to avoid ending up with calibrated min, max same as
+    // original min, max
+    unsigned int tensorCount = 100000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        min       = std::min(min, double(tensor[i]));
+        max       = std::max(max, double(tensor[i]));
+    }
+
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, false, false, false);
+
+    std::cout << "Absolute Min: " << min << std::endl;
+    std::cout << "Absolute Max: " << max << std::endl;
+
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    // We know we have a normal distribution. We expect the encoding to cover
+    // at least 2 standard deviations, and at most 6.
+    std::cout << "mean - 6 * stddev: " << mean - 6 * stddev << "\n";
+    std::cout << "mean - 2 * stddev: " << mean - 2 * stddev << "\n";
+    std::cout << "mean + 2 * stddev: " << mean + 2 * stddev << "\n";
+    std::cout << "mean + 6 * stddev: " << mean + 6 * stddev << "\n";
+    EXPECT_GT(encoding.min, mean - 6 * stddev);
+    EXPECT_LT(encoding.min, mean - 2 * stddev);
+    EXPECT_GT(encoding.max, mean + 2 * stddev);
+    EXPECT_LT(encoding.max, mean + 6 * stddev);
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, Symmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer;
+    analyzer.setPercentileValue(99.9);
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -128);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, StrictSymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer;
+    analyzer.setPercentileValue(99.9);
+
+    float mean   = -2;
+    float stddev = 1;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, true, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 254);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -127);
+    EXPECT_EQ(encoding.bw, 8);
+    EXPECT_EQ(encoding.min, -encoding.max);
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, SymmetricUnsigned)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer;
+    analyzer.setPercentileValue(99.9999);
+
+    float mean   = -2;
+    float stddev = 1;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        tensor[i] = std::max(tensor[i], (dataType) 0.0);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, true);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << "Encoding Min: " << encoding.min << std::endl;
+    std::cout << "Encoding Max: " << encoding.max << std::endl;
+    std::cout << "Encoding Delta: " << encoding.delta << std::endl;
+    std::cout << "Encoding Offset: " << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_EQ(encoding.min, 0);
+    EXPECT_NEAR(encoding.max, absoluteMax, 0.015);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, Symmetric_Percentile100)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer;
+    analyzer.setPercentileValue(100);
+
+    float mean   = -1;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -128);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, AllSameValuesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer1;
+    analyzer1.setPercentileValue(99.9999);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor1(tensorCount, 4);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding1.min, 0);   // 0 is included
+    EXPECT_GE(encoding1.max, 3.99006);
+
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer2;
+    analyzer2.setPercentileValue(99.9999);
+
+    std::vector<dataType> tensor2(tensorCount, -5);
+    Blob<TypeParam> tensorBlob2(tensor2.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer2.updateStats(tensorBlob2.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding2 = analyzer2.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding2.min, -4.99992);
+    EXPECT_GE(encoding2.max, 0);   // 0 is included
+}
+
+TYPED_TEST(TestPercentileEncodingAnalyzer, AllZeroesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate PercentileEncodingAnalyzer
+    DlQuantization::PercentileEncodingAnalyzer<dataType> analyzer1;
+    analyzer1.setPercentileValue(99.9999);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor1(tensorCount, 0);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+
+    EXPECT_NEAR(encoding1.min, -1.00392, 0.0001);
+    EXPECT_NEAR(encoding1.max, 0.996078, 0.0001);
+    EXPECT_EQ(encoding1.offset, -128);
+    EXPECT_EQ(encoding1.bw, 8);
+}

--- a/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
@@ -73,6 +73,7 @@ PYBIND11_MODULE(libpymo, m)
         .value("QUANTIZATION_TF", QuantizationMode::QUANTIZATION_TF)
         .value("QUANTIZATION_TF_ENHANCED", QuantizationMode::QUANTIZATION_TF_ENHANCED)
         .value("QUANTIZATION_RANGE_LEARNING", QuantizationMode::QUANTIZATION_RANGE_LEARNING)
+        .value("QUANTIZATION_PERCENTILE", QuantizationMode::QUANTIZATION_PERCENTILE)
         .export_values();
 
     py::enum_<LayerInOut>(m, "LayerInOut")

--- a/TrainingExtensions/common/src/python/aimet_common/defs.py
+++ b/TrainingExtensions/common/src/python/aimet_common/defs.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2019, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2019-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -63,6 +63,9 @@ class QuantScheme(Enum):
     """ For a Tensor, the encoding values are initialized with the post_training_tf_enhanced scheme. Then, the encodings
     are learned during training. """
     training_range_learning = 5
+    post_training_percentile = 6
+    """ For a Tensor, adjusted minimum and maximum values are selected based on the percentile value passed.
+    The Quantization encodings are calculated using the adjusted minimum and maximum value."""
 
 MAP_QUANT_SCHEME_TO_PYMO = {QuantScheme.post_training_tf: libpymo.QuantizationMode.QUANTIZATION_TF,
                             QuantScheme.post_training_tf_enhanced:
@@ -70,7 +73,9 @@ MAP_QUANT_SCHEME_TO_PYMO = {QuantScheme.post_training_tf: libpymo.QuantizationMo
                             QuantScheme.training_range_learning_with_tf_init:
                                 libpymo.QuantizationMode.QUANTIZATION_TF,
                             QuantScheme.training_range_learning_with_tf_enhanced_init:
-                                libpymo.QuantizationMode.QUANTIZATION_TF_ENHANCED}
+                                libpymo.QuantizationMode.QUANTIZATION_TF_ENHANCED,
+                            QuantScheme.post_training_percentile:
+                                libpymo.QuantizationMode.QUANTIZATION_PERCENTILE}
 MAP_ROUND_MODE_TO_PYMO = {'nearest': libpymo.RoundingMode.ROUND_NEAREST,
                           'stochastic': libpymo.RoundingMode.ROUND_STOCHASTIC}
 

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2020, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2020-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -153,17 +153,19 @@ def validate_quantsim_inputs(
 ):
     """
     Perform sanity checks on inputs to QuantSim
-    :param quant_scheme: Quantization scheme. Supported options are 'tf_enhanced' or 'tf' or using Quant Scheme Enum
-                         QuantScheme.post_training_tf or QuantScheme.post_training_tf_enhanced
+    :param quant_scheme: Quantization scheme. Supported options are 'tf_enhanced' or 'tf' or 'percentile'
+                         or using Quant Scheme Enum QuantScheme.post_training_tf or QuantScheme.post_training_tf_enhanced
+                         or QuantScheme.post_training_percentile
     :param rounding_mode: Rounding mode. Supported options are 'nearest' or 'stochastic'
     :param default_output_bw: Default bitwidth (4-31) to use for quantizing layer inputs and outputs
     :param default_param_bw: Default bitwidth (4-31) to use for quantizing layer parameters
     :param data_type: Data type of the quantized values (int or float).
     """
     # sanity checks
-    if quant_scheme not in ('tf_enhanced', 'tf') and not isinstance(quant_scheme, QuantScheme):
-        raise ValueError('Parameter quantization mode is not a valid selection. Valid selections are tf, '
-                         'tf_enhanced, QuantScheme.post_training_tf, QuantScheme.post_training_tf_enhanced')
+    if quant_scheme not in ('tf_enhanced', 'tf', 'percentile') and not isinstance(quant_scheme, QuantScheme):
+        raise ValueError('Parameter quantization mode is not a valid selection. Valid selections are '
+                         'tf, tf_enhanced, percentile, QuantScheme.post_training_tf, '
+                         'QuantScheme.post_training_tf_enhanced, QuantScheme.post_training_percentile')
 
     if rounding_mode not in ('nearest', 'stochastic'):
         raise ValueError('Parameter round mode is not a valid selection. Valid selections are nearest or '

--- a/TrainingExtensions/torch/src/AimetTensorQuantizer.cpp
+++ b/TrainingExtensions/torch/src/AimetTensorQuantizer.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2018, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2018-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -140,6 +140,14 @@ public:
         return histogram;
     }
 
+    void setPercentileValue(float percentile)
+    {
+        // Set percentile value only when quant scheme is percentile.
+        if (_quantizationScheme == DlQuantization::QuantizationMode::QUANTIZATION_PERCENTILE) {
+            _encodingAnalyzer->setPercentileValue(percentile);
+        }
+    }
+
 private:
     bool _isEncodingValid;
     DlQuantization::QuantizationMode _quantizationScheme;
@@ -157,5 +165,6 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m)
         .def("quantize", &AimetTensorQuantizer::quantize)
         .def("getEncoding", &AimetTensorQuantizer::getEncoding)
         .def("resetEncodingStats", &AimetTensorQuantizer::resetEncodingStats)
-        .def("getStatsHistogram", &AimetTensorQuantizer::getStatsHistogram);
+        .def("getStatsHistogram", &AimetTensorQuantizer::getStatsHistogram)
+        .def("setPercentileValue", &AimetTensorQuantizer::setPercentileValue);
 }

--- a/TrainingExtensions/torch/src/python/aimet_torch/tensor_quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/tensor_quantizer.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2020, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2020-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -308,6 +308,13 @@ class StaticGridTensorQuantizer(TensorQuantizer):
             raise RuntimeError("Encoding can be frozen only when it is not None.")
 
         self._is_encoding_frozen = True
+
+    def set_percentile_value(self, percentile_value: float):
+        """
+        Set the percentile value to be used while computing encodings
+        """
+        for op in self._cppOp:
+            op.setPercentileValue(percentile_value)
 
 
 class StaticGridPerTensorQuantizer(StaticGridTensorQuantizer):

--- a/TrainingExtensions/torch/test/python/test_percentile_quantization_scheme.py
+++ b/TrainingExtensions/torch/test/python/test_percentile_quantization_scheme.py
@@ -1,0 +1,96 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+import pytest
+import torch
+import torch.nn as nn
+from aimet_torch.quantsim import QuantizationSimModel
+
+class TestPercentileSchemeStaticGrid:
+    """ Test Percentile quantization scheme """ 
+
+    def test_model_with_percentile_scheme(self):
+        """ Test pecentile scheme by setting different percentile values """
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv1 = torch.nn.Conv2d(3, 16, 3, padding="same")
+                self.conv2 = torch.nn.Conv2d(16, 16, 3, padding="same")
+
+            def forward(self, *inputs):
+                x = self.conv1(inputs[0])
+                x = self.conv2(x)
+                return x
+
+        model = Model()
+        dummy_input = torch.rand(1, 3, 224, 224)
+
+        def forward_pass(model, args):
+            model.eval()
+            model(dummy_input)
+
+        sim = QuantizationSimModel(model, dummy_input, quant_scheme="percentile")
+        # set same percentile value for all the activation tensors
+        sim.set_percentile_value(99.99)
+        sim.compute_encodings(forward_pass, None)
+
+        # Assign the same tensor for the outputs and check if the encodings are same
+        tensor = torch.rand(1, 3, 224, 224)
+        sim.model.conv1.output_quantizers[0].reset_encoding_stats()
+        sim.model.conv1.output_quantizers[0].update_encoding_stats(tensor)
+        sim.model.conv1.set_percentile_value(99.999)
+        sim.model.conv1.output_quantizers[0].compute_encoding()
+
+        sim.model.conv2.output_quantizers[0].reset_encoding_stats()
+        sim.model.conv2.output_quantizers[0].update_encoding_stats(tensor)
+        sim.model.conv2.set_percentile_value(99.999)
+        sim.model.conv2.output_quantizers[0].compute_encoding()
+        assert sim.model.conv1.output_quantizers[0].encoding.max == sim.model.conv2.output_quantizers[0].encoding.max
+        assert sim.model.conv1.output_quantizers[0].encoding.delta == sim.model.conv2.output_quantizers[0].encoding.delta
+
+        # Set different percentile values for each layer and verify that the encoding are not same
+        sim.model.conv1.output_quantizers[0].reset_encoding_stats()
+        sim.model.conv1.output_quantizers[0].update_encoding_stats(tensor)
+        sim.model.conv1.set_percentile_value(99)
+        sim.model.conv1.output_quantizers[0].compute_encoding()
+
+        sim.model.conv2.output_quantizers[0].reset_encoding_stats()
+        sim.model.conv2.output_quantizers[0].update_encoding_stats(tensor)
+        sim.model.conv2.set_percentile_value(99.999)
+        sim.model.conv2.output_quantizers[0].compute_encoding()
+        assert sim.model.conv1.output_quantizers[0].encoding.max != sim.model.conv2.output_quantizers[0].encoding.max
+        assert sim.model.conv1.output_quantizers[0].encoding.delta != sim.model.conv2.output_quantizers[0].encoding.delta 


### PR DESCRIPTION
Signed-off-by: Gopinath Rathinam <quic_grathina@quicinc.com>

Summary:
Percentile calibration scheme adjust the min and max ranges of the tensor to be quantized by clipping the outliers in the
histogram based on the percentile value.