### PR TITLE
Add support for MSE quantization scheme

### DIFF
--- a/ModelOptimizations/DlQuantization/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/CMakeLists.txt
@@ -52,6 +52,8 @@ add_library(MoDlQuantization STATIC
       src/trim_functions.cpp
       src/trim_functions.hpp
 
+      src/MseEncodingAnalyzer.cpp
+      src/MseEncodingAnalyzer.h
       src/PercentileEncodingAnalyzer.cpp
       src/PercentileEncodingAnalyzer.h
       src/TfEnhancedEncodingAnalyzer.cpp

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
@@ -71,6 +71,10 @@ enum QuantizationMode
     // Percentile calibration. Compute the encoding by adjusting the min/max range of the tensor
     // by clipping percentile of outliers.
     QUANTIZATION_PERCENTILE,
+
+    // Compute the encoding by adjusting the min/max range of the tensor based on the mean square
+    // error due to quantization of the tensor.
+    QUANTIZATION_MSE,
 };
 
 /**

--- a/ModelOptimizations/DlQuantization/src/MseEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/MseEncodingAnalyzer.cpp
@@ -1,0 +1,263 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <vector>
+
+
+#include "DlQuantization/Quantization.hpp"
+#include "math_functions.hpp"
+#include "quantization_utils.hpp"
+
+#include "MseEncodingAnalyzer.h"
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+std::vector<std::tuple<double, double>> MseEncodingAnalyzer<DTYPE>::getStatsHistogram() const
+{
+    // Return the collected histogram data.
+    return getCollectedHistogram(this->_stats);
+}
+
+template <typename DTYPE>
+void MseEncodingAnalyzer<DTYPE>::updateStats(const DTYPE* tensor, const size_t tensorSize,
+                                             ComputationMode tensorCpuGpuMode)
+{
+    this->_statsUpdated = true;
+
+    // update pdf
+    UpdatePdf(tensor, tensorSize, tensorCpuGpuMode, true, this->_stats);
+}
+
+template <typename DTYPE>
+TfEncoding MseEncodingAnalyzer<DTYPE>::computeEncoding(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                                                       bool useUnsignedSymmetric) const
+{
+    TfEncoding encoding = {0, 0, 0, 0, 0};
+    DTYPE numSteps      = pow(2, bw) - 1;
+
+    // For strict symmetric mode, we make even number of buckets
+    if (useSymmetricEncodings && useStrictSymmetric)
+    {
+        numSteps -= 1;
+    }
+
+    if (this->_stats.xLeft.size() == 0)
+    {
+        if (this->_statsUpdated)
+        {
+            // Histogram has not been initialized yet, we have seen all zero data
+            // We generate a valid encoding that covers float 0
+            encoding.min    = -1;
+            encoding.max    = 1;
+            encoding.delta  = (encoding.max - encoding.min) / int(numSteps);
+            encoding.offset = floor(encoding.min / encoding.delta);
+            encoding.min    = encoding.offset * encoding.delta;
+            encoding.max    = encoding.min + int(numSteps) * encoding.delta;
+            encoding.bw     = bw;
+
+            return encoding;
+        }
+        else
+        {
+            // Histogram has not been initialized yet because we have not seen any data
+            // We return a zero encoding - which is a failure indicator
+            return encoding;
+        }
+    }
+
+    // Find the adjusted min and max
+    DTYPE aMin, aMax;
+    std::tie(aMin, aMax) = _minimizeMSE(bw, useSymmetricEncodings, useStrictSymmetric, useUnsignedSymmetric);
+
+    // After Min and Max adjustment, the requirement that 0 be an exactly
+    // representable value must be met. Hence, extend the interval
+    // [aMin, aMax] to ensure that it contains 0.
+    aMin = std::min(aMin, DTYPE(0.f));
+    aMax = std::max(aMax, DTYPE(0.f));
+
+    assert(aMin <= aMax && "min must not be bigger than max");
+
+    return getComputedEncodings(bw, aMin, aMax, useSymmetricEncodings, useStrictSymmetric, useUnsignedSymmetric);
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> MseEncodingAnalyzer<DTYPE>::_findRangeOfAggregateStats() const
+{
+    return findOriginalRange<DTYPE>(this->_stats);
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> MseEncodingAnalyzer<DTYPE>::_minimizeMSE(uint8_t bw, bool useSymmetricEncodings,
+                                                                  bool useStrictSymmetric,
+                                                                  bool useUnsignedSymmetric) const
+{
+    // Histogram bin width.
+    const float histBinWidth = this->_stats.xLeft[1] - this->_stats.xLeft[0];
+    DTYPE histMin            = this->_stats.xLeft[0];
+    DTYPE histMax            = this->_stats.xLeft[PDF_SIZE - 1] + histBinWidth;
+
+    // Find the true range of our collected stats
+    DTYPE minVal, maxVal;
+    std::tie(minVal, maxVal) = _findRangeOfAggregateStats();
+    maxVal                   = maxVal + histBinWidth;
+
+    // Compute bin edges. They are used for selecting min-max candidates
+    std::vector<DTYPE> binEdges;
+    binEdges.push_back(minVal);
+    for (auto i = histMin; (i <= histMax); i += histBinWidth)
+    {
+        if ((i >= minVal) && (i <= maxVal))
+        {
+            binEdges.push_back(i);
+        }
+    }
+
+    // Select min-max candidates
+    std::vector<std::pair<DTYPE, DTYPE>> minMaxCandidates;
+    _pickMinMaxCandidatesMSECalib(binEdges, minVal, maxVal, minMaxCandidates);
+
+    // Compute the bin centers and correspongding pdf value. They are used for computing MSE cost
+    DTYPE pdfStart = this->_stats.xLeft[0];
+    DTYPE pdfStep  = this->_stats.xLeft[1] - this->_stats.xLeft[0];
+
+    const int numBinCenters = binEdges.size() - 1;
+    std::vector<std::pair<DTYPE, DTYPE>> binCentersPdf(numBinCenters);
+    binCentersPdf[0].first = minVal + histBinWidth / 2;
+    // Calculate the index of the bucket which contains the corresponding pdf value.
+    int pdfBinInd           = (int) std::floor((binCentersPdf[0].first - pdfStart) / pdfStep);
+    pdfBinInd               = std::min(std::max(0, pdfBinInd), PDF_SIZE - 1);
+    binCentersPdf[0].second = this->_stats.pdf[pdfBinInd];
+    for (auto i = 1; i < numBinCenters; i++)
+    {
+        binCentersPdf[i].first  = binCentersPdf[i - 1].first + histBinWidth;
+        pdfBinInd               = (int) std::floor((binCentersPdf[i].first - pdfStart) / pdfStep);
+        pdfBinInd               = std::min(std::max(0, pdfBinInd), PDF_SIZE - 1);
+        binCentersPdf[i].second = this->_stats.pdf[pdfBinInd];
+    }
+
+    // Compute MSE for each min-max candidate and find the optimal candidate for
+    // which MSE cost is least
+    float mseMin = std::numeric_limits<float>::max();
+    std::tuple<DTYPE, DTYPE> bestCandidate(minVal, maxVal);
+    for (auto& c: minMaxCandidates)
+    {
+        DTYPE mse = _computeMSECost(bw, binCentersPdf, c.first, c.second, useSymmetricEncodings, useStrictSymmetric,
+                                    useUnsignedSymmetric);
+        if (mse < mseMin)
+        {
+            mseMin        = mse;
+            bestCandidate = c;
+        }
+    }
+    return bestCandidate;
+}
+
+template <typename DTYPE>
+void MseEncodingAnalyzer<DTYPE>::_pickMinMaxCandidatesMSECalib(
+    std::vector<DTYPE>& candidates, DTYPE observedMin, DTYPE observedMax,
+    std::vector<std::pair<DTYPE, DTYPE>>& minMaxCandidates) const
+{
+    std::vector<DTYPE> minCandidates;
+    std::vector<DTYPE> maxCandidates;
+
+    // Assign all candidates less than 0 to 'Min' and all candidates greater than
+    // 0 to 'Max'. '0' is excluded because {0, 0} is not a valid min-max
+    // candidate.
+    for (auto& c: candidates)
+    {
+        if (c < 0)
+        {
+            minCandidates.push_back(c);
+        }
+        else if (c > 0)
+        {
+            maxCandidates.push_back(c);
+        }
+    }
+
+    // Include '0' in min and max candidates list. {0, 0} will be removed later.
+    minCandidates.push_back(0);
+    maxCandidates.push_back(0);
+    for (auto& i: minCandidates)
+    {
+        for (auto& j: maxCandidates)
+        {
+            minMaxCandidates.push_back({i, j});
+        }
+    }
+    // Remove the last element '{0, 0}' which is not suitable as min-max
+    // candidate.
+    minMaxCandidates.pop_back();
+}
+
+template <typename DTYPE>
+DTYPE MseEncodingAnalyzer<DTYPE>::_computeMSECost(uint8_t bw, std::vector<std::pair<DTYPE, DTYPE>>& binCentersPdf,
+                                                  DTYPE candidateMin, DTYPE candidateMax, bool useSymmetricEncodings,
+                                                  bool useStrictSymmetric, bool useUnsignedSymmetric) const
+{
+    // Compute the scale and offset based on the min and max provided
+    TfEncoding encoding = getComputedEncodings(bw, candidateMin, candidateMax, useSymmetricEncodings,
+                                               useStrictSymmetric, useUnsignedSymmetric);
+    // Apply Fake quantization on the bin centers and compute MSE cost
+    DTYPE weightedSquareErr = 0;
+    for (int i = 0; i < binCentersPdf.size(); i++)
+    {
+        // The floating point value in the middle of this bucket.
+        DTYPE floatVal        = binCentersPdf[i].first;
+        DTYPE clampedFloatVal = std::max(candidateMin, std::min(floatVal, candidateMax));
+        // The quantized equivalent.
+        int quantized = (int) round(clampedFloatVal / encoding.delta - encoding.offset);
+        // The de-quantized value: this is 'floatVal' plus the quantization error.
+        DTYPE dequantized = encoding.delta * (quantized + encoding.offset);
+        // The quantization cost is the MSE.
+        weightedSquareErr += binCentersPdf[i].second * pow(floatVal - dequantized, 2);
+    }
+    return weightedSquareErr;
+}
+
+// Explicit instantiations
+template class MseEncodingAnalyzer<double>;
+
+template class MseEncodingAnalyzer<float>;
+
+}   // namespace DlQuantization 

--- a/ModelOptimizations/DlQuantization/src/MseEncodingAnalyzer.h
+++ b/ModelOptimizations/DlQuantization/src/MseEncodingAnalyzer.h
@@ -1,0 +1,130 @@
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#ifndef DL_QUANTIZATION_MSE_ENCODING_ANALYZER_H
+#define DL_QUANTIZATION_MSE_ENCODING_ANALYZER_H
+
+#include "math_functions.hpp"
+#include <DlQuantization/IQuantizationEncodingAnalyzer.hpp>
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+class MseEncodingAnalyzer : public IQuantizationEncodingAnalyzer<DTYPE>
+{
+public:
+    /**
+     * Updates internal PDF stats given a tensor.
+     * Intent is to keep a histogram of all the values that we have seen over multiple instances of a tensor
+     * @param tensor Reference to a tensor
+     * @param tensorSize Size of the tensor (number of elements)
+     * @param tensorCpuGpuMode Indicates if the tensor is in CPU or GPU memory
+     */
+    void updateStats(const DTYPE* tensor, const size_t tensorSize, ComputationMode tensorCpuGpuMode) override;
+
+    /***
+     * Compute the encodings using the collected histogram stats by minimizing the mean square
+     * error due to quantization of the tensor.
+     * @param bw Bitwidth to use for computing encodings
+     * @param useSymmetricEncodings If true, compute symmetric encodings
+     * @param useStrictSymmetric If true, compute symmetric encodings with even number of buckets
+     * @param useUnsignedSymmetric If true, compute asymmetric encodings
+     * @return Computed encoding
+     */
+    TfEncoding computeEncoding(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                               bool useUnsignedSymmetric) const override;
+
+
+    /**
+     * @brief Returns a histogram that represents a PDF of tensor values seen by this encoding analyzer so far
+     *
+     * @return Histogram of statistics. The histogram returned is a vector of buckets. Each bucket is a tuple of
+     * two values - the float value representing the left edge of the bucket and a PDF of the values in this bucket
+     * relative to all the values seen across all buckets
+     */
+    std::vector<std::tuple<double, double>> getStatsHistogram() const override;
+
+private:
+    PDF _stats;
+    bool _statsUpdated = false;
+
+    /**
+     * Find range (min, max) of the aggregated stats
+     * @return Tuple of min and max values
+     */
+    std::tuple<DTYPE, DTYPE> _findRangeOfAggregateStats() const;
+
+    /**
+     * @brief Adjust the min/max range of tensor values  by minimizing MSE due to quantization
+     *
+     * @param bw Bitwidth to use for computing encodings
+     * @param useSymmetricEncodings If true, compute symmetric encodings
+     * @param useStrictSymmetric If true, compute symmetric encodings with even number of buckets
+     * @param useUnsignedSymmetric If true, compute asymmetric encodings
+     * @return Tuple of <best min, best max> to be used for calculating the best delta and offset
+     */
+    std::tuple<DTYPE, DTYPE> _minimizeMSE(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                                          bool useUnsignedSymmetric) const;
+
+    /**
+     * @brief Select min-max candidates from the bin edges
+     *
+     * @param candidates Bin edges computed from collected stats used for selecting min-max candidates
+     * @param observedMin Minimum value of the histogram stats collected
+     * @param observedMax  Maximum value of the histogram stats collected
+     * @param minMaxCandidates Vector of pair (min and max candidates)
+     */
+    void _pickMinMaxCandidatesMSECalib(std::vector<DTYPE>& candidates, DTYPE observedMin, DTYPE observedMax,
+                                       std::vector<std::pair<DTYPE, DTYPE>>& minMaxCandidates) const;
+
+    /**
+     * @brief Given a candidate min and max, find the mse by fake quantizing the bin centers.
+     *
+     * @param bw Bitwidth to use for computing encodings
+     * @param binCentersPdf Vector of pair (bin centers and correspongding pdf value)
+     * @param candidateMin Min value to be used for computing candidate scale and offset
+     * @param candidateMax Max value to be used for computing candidate scale and offset
+     * @return mse value computed for the given candidateMin and candidateMax
+     */
+    DTYPE _computeMSECost(uint8_t bw, std::vector<std::pair<DTYPE, DTYPE>>& binCentersPdf, DTYPE candidateMin,
+                          DTYPE candidateMax, bool useSymmetricEncodings, bool useStrictSymmetric,
+                          bool useUnsignedSymmetric) const;
+};
+
+}   // namespace DlQuantization
+
+#endif   // DL_QUANTIZATION_MSE_ENCODING_ANALYZER_H 

--- a/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
+++ b/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
@@ -46,6 +46,7 @@
 #include "DlQuantization/Quantization.hpp"
 #include "DlQuantization/QuantizerFactory.hpp"
 #include "MainQuantizationClass.hpp"
+#include "MseEncodingAnalyzer.h"
 #include "PercentileEncodingAnalyzer.h"
 #include "TensorQuantizationSim.h"
 #include "TfEncodingAnalyzer.h"
@@ -73,6 +74,10 @@ std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>> getEncodingAnalyzerInstanc
     else if (quantization_mode == QUANTIZATION_PERCENTILE)
     {
         return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new PercentileEncodingAnalyzer<DTYPE>);
+    }
+    else if (quantization_mode == QUANTIZATION_MSE)
+    {
+        return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new MseEncodingAnalyzer<DTYPE>);
     }
     else
     {

--- a/ModelOptimizations/DlQuantization/test/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/test/CMakeLists.txt
@@ -53,7 +53,8 @@ add_executable(MoDlQuantizationTest
       TestTensorQuantizationSim.cpp
       TestTensorQuantizer.cpp
       TestUtilities.cpp
-      TestPercentileEncodingAnalyzer.cpp)
+      TestPercentileEncodingAnalyzer.cpp
+      TestMseEncodingAnalyzer.cpp)
 
 if (ENABLE_CUDA)
     target_compile_options(MoDlQuantizationTest

--- a/ModelOptimizations/DlQuantization/test/TestMseEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestMseEncodingAnalyzer.cpp
@@ -1,0 +1,318 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+#include "test_quantization_lib.hpp"
+#include <DlQuantization/TensorQuantizer.h>
+#include <MseEncodingAnalyzer.h>
+#include <TfEnhancedEncodingAnalyzer.h>
+using namespace DlQuantization;
+
+template <typename TypeParam>
+class TestMseEncodingAnalyzer : public ::testing::Test
+{
+};
+// Test on CPU and GPU with float and double
+TYPED_TEST_CASE(TestMseEncodingAnalyzer, TestDataTypesAndDevices);
+
+TYPED_TEST(TestMseEncodingAnalyzer, Asymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::min();
+    // Use larger tensor size to avoid ending up with calibrated min, max same as
+    // original min, max 100000
+    unsigned int tensorCount = 100000;
+    //  unsigned int tensorCount = 100;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        min       = std::min(min, double(tensor[i]));
+        max       = std::max(max, double(tensor[i]));
+    }
+
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, false, false, false);
+
+    std::cout << "Absolute Min: " << min << std::endl;
+    std::cout << "Absolute Max: " << max << std::endl;
+
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    // We know we have a normal distribution. We expect the encoding to cover
+    // at least 2 standard deviations, and at most 6.
+    std::cout << "mean - 6 * stddev: " << mean - 6 * stddev << "\n";
+    std::cout << "mean - 2 * stddev: " << mean - 2 * stddev << "\n";
+    std::cout << "mean + 2 * stddev: " << mean + 2 * stddev << "\n";
+    std::cout << "mean + 6 * stddev: " << mean + 6 * stddev << "\n";
+    EXPECT_GT(encoding.min, mean - 6 * stddev);
+    EXPECT_LT(encoding.min, mean - 2 * stddev);
+    EXPECT_GT(encoding.max, mean + 2 * stddev);
+    EXPECT_LT(encoding.max, mean + 6 * stddev);
+
+    EXPECT_GT(encoding.min, min);
+    EXPECT_LT(encoding.max, max);
+}
+
+TYPED_TEST(TestMseEncodingAnalyzer, Symmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -128);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestMseEncodingAnalyzer, StrictSymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = -2;
+    float stddev = 1;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, true, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 254);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -127);
+    EXPECT_EQ(encoding.bw, 8);
+    EXPECT_EQ(encoding.min, -encoding.max);
+}
+
+TYPED_TEST(TestMseEncodingAnalyzer, SymmetricUnsigned)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = -2;
+    float stddev = 1;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        tensor[i] = std::max(tensor[i], (dataType) 0.0);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, true);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << "Encoding Min: " << encoding.min << std::endl;
+    std::cout << "Encoding Max: " << encoding.max << std::endl;
+    std::cout << "Encoding Delta: " << encoding.delta << std::endl;
+    std::cout << "Encoding Offset: " << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_EQ(encoding.min, 0);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestMseEncodingAnalyzer, AllSameValuesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer1;
+
+    unsigned int tensorCount = 100;
+    std::vector<dataType> tensor1(tensorCount, 4);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding1.min, 0);   // 0 is included
+    EXPECT_GE(encoding1.max, 3.9);
+
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer2;
+
+    std::vector<dataType> tensor2(tensorCount, -5);
+    Blob<TypeParam> tensorBlob2(tensor2.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer2.updateStats(tensorBlob2.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding2 = analyzer2.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding2.min, -4.99992);
+    EXPECT_GE(encoding2.max, 0);   // 0 is included
+}
+
+TYPED_TEST(TestMseEncodingAnalyzer, AllZeroesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate MseEncodingAnalyzer
+    DlQuantization::MseEncodingAnalyzer<dataType> analyzer1;
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor1(tensorCount, 0);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+
+    EXPECT_NEAR(encoding1.min, -1.00392, 0.0001);
+    EXPECT_NEAR(encoding1.max, 0.996078, 0.0001);
+    EXPECT_EQ(encoding1.offset, -128);
+    EXPECT_EQ(encoding1.bw, 8);
+} 

--- a/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
@@ -74,6 +74,7 @@ PYBIND11_MODULE(libpymo, m)
         .value("QUANTIZATION_TF_ENHANCED", QuantizationMode::QUANTIZATION_TF_ENHANCED)
         .value("QUANTIZATION_RANGE_LEARNING", QuantizationMode::QUANTIZATION_RANGE_LEARNING)
         .value("QUANTIZATION_PERCENTILE", QuantizationMode::QUANTIZATION_PERCENTILE)
+        .value("QUANTIZATION_MSE", QuantizationMode::QUANTIZATION_MSE)
         .export_values();
 
     py::enum_<LayerInOut>(m, "LayerInOut")

--- a/TrainingExtensions/torch/test/python/test_mse_quantization_scheme.py
+++ b/TrainingExtensions/torch/test/python/test_mse_quantization_scheme.py
@@ -1,0 +1,87 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+import pytest
+import torch
+import torch.nn as nn
+from aimet_torch.quantsim import QuantizationSimModel
+
+class TestMSESchemeStaticGrid:
+    """ Test MSE quantization scheme """ 
+
+    def test_model_with_mse_scheme(self):
+        """ Test MSE scheme """
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv1 = torch.nn.Conv2d(3, 16, 3, padding="same")
+                self.conv2 = torch.nn.Conv2d(16, 16, 3, padding="same")
+
+            def forward(self, *inputs):
+                x = self.conv1(inputs[0])
+                x = self.conv2(x)
+                return x
+
+        model = Model()
+        dummy_input = torch.rand(1, 3, 224, 224)
+
+        def forward_pass(model, args):
+            model.eval()
+            model(dummy_input)
+
+        sim1 = QuantizationSimModel(model, dummy_input, quant_scheme="tf")
+        sim1.compute_encodings(forward_pass, None)
+
+        sim2 = QuantizationSimModel(model, dummy_input, quant_scheme="tf")
+
+        # Overwrite the quantization scheme
+        import aimet_common.libpymo as libpymo
+        from aimet_common.defs import MAP_QUANT_SCHEME_TO_PYMO
+        MAP_QUANT_SCHEME_TO_PYMO['mse'] = libpymo.QuantizationMode.QUANTIZATION_MSE
+
+        for quant_wrapper in sim2.quant_wrappers():
+            for quantizer in quant_wrapper.input_quantizers:
+                quantizer.quant_scheme = 'mse'
+            for quantizer in quant_wrapper.output_quantizers:
+                quantizer.quant_scheme = 'mse'
+            for param_quantizer in quant_wrapper.param_quantizers.values():
+                param_quantizer.quant_scheme = 'mse'
+
+        sim2.compute_encodings(forward_pass, None)
+
+        # Compare the encoding max between tf and mse quantization scheme
+        assert sim1.model.conv1.output_quantizers[0].encoding.max != sim2.model.conv1.output_quantizers[0].encoding.max 


### PR DESCRIPTION
Signed-off-by: Gopinath Rathinam <quic_grathina@quicinc.com>

Summary:
Percentile calibration scheme adjust the min and max ranges of the tensor to be quantized by computing the MSE cost using multiple candidate min, max values and choose the optimal candidate for which MSE cost is least.

Following are the differences between MSE and Tf_enhanced,

Candidate Min-Max selection:
Tf_enhanced chooses 101 candidate deltas, equally spaced between 1deltaMax/100 and 101deltaMax/100 for symmetric and 17 candidate deltas, equally spaced between 1deltaMax/16 and 17deltaMax/16 for asymmetric quantization.
mse calibration chooses candidate min-max pairs using bin edges calculated from the collected histogram. Here the amount of candidates explored is more than the tf_enhanced scheme.
Tf_enhanced gives more weightage(3 times) to saturation cost whereas mse calibration gives same weightage for both quantization and saturation cost

Documentation: None