### PR TITLE
Align Tensor Quantizer and Main Quantization Class

### DIFF
--- a/ModelOptimizations/DlQuantization/include/DlQuantization/ITensorQuantizationSim.h
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/ITensorQuantizationSim.h
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2019, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2019 - 2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -55,6 +55,50 @@ public:
     virtual void quantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount, DTYPE* outputTensorData,
                                 double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
                                 bool use_cuda, bool shiftToSigned) = 0;
+    /**
+     * @brief Convert a tensor from DTYPE to quantized 8-bit packed format
+     */
+    virtual void quantizeTensorPacked(const DTYPE* inputTensorData, size_t inputTensorCount, std::vector<uint8_t>& outputTensorData,
+                                      double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
+                                      bool useCuda, bool shiftToSigned) = 0;
+
+    /**
+     * @brief Convert a tensor from quantized 8-bit format into DTYPE
+     */
+    virtual void dequantizeTensor(const uint8_t* inputTensorData, size_t inputTensorCount, DTYPE* output,
+                                  double encodingMin, double encodingMax, uint8_t bw, bool shiftToSigned) = 0;
+
+    /**
+     * @brief Performs per channel quantization for each split in splits, and concatenates the result into a quantized
+     *        int output before de-quantizing back to float.
+     * @relates quantizeDequantizeTensor
+     */
+    virtual void quantizeDequantizePerChannelTensor( std::vector <std::vector<DTYPE>>& splits,
+                                                    std::vector <uint32_t> splitShape,
+                                                    uint32_t axis, DTYPE* outputTensorData,
+                                                    const std::vector <TfEncoding> &encodings,
+                                                    uint8_t bw, RoundingMode roundMode,
+                                                    bool useCuda) = 0;
+    /**
+     * @brief Performs per channel quantization for each split in splits, and concatenates the result into a quantized
+     *         output before de-quantizing. Output is packed 8 bit quantized data.
+     * @relates quantizeDequantizePerChannelTensor
+     * @param[in/out] Unsigned 8 bit output tensor
+     */
+    virtual void quantizePerChannelTensorPacked(std::vector <std::vector<DTYPE>>& splits,
+                                                std::vector <uint32_t> splitShape,
+                                                uint32_t axis, std::vector<uint8_t>& outputTensorData,
+                                                const std::vector <TfEncoding> &encodings,
+                                                uint8_t bw, RoundingMode roundMode,
+                                                bool useCuda, bool shiftToSigned) = 0;
+
+    /**
+     * @brief Convert a tensor from quantized 8-bit format into DTYPE, by splitting the data into channels and
+     *        dequantizing independently, before concatenating the final result into the output tensor.
+     */
+    virtual void dequantizePerChannelTensor(const uint8_t* inputTensorData, const std::vector<uint32_t> &inputShape, uint32_t axis,
+                                            DTYPE* outputTensorData, uint8_t bw, const std::vector<TfEncoding> &encodings,
+                                            bool shiftToSigned) = 0;
 
     virtual void fillQuantizeInfo(TfEncoding& encoding, DlQuantization::ComputationMode& cpuGpuMode, uint8_t bw,
                           double encodingMin, double encodingMax, bool use_cuda) = 0;

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
@@ -55,17 +55,47 @@ class TensorQuantizationSim : public ITensorQuantizationSim<DTYPE>
 {
 public:
     explicit TensorQuantizationSim();
+
     void gateMinMax(double& encodingMin, double& encodingMax);
+
     void quantizeDequantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount, DTYPE* outputTensorData,
                                   double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
                                   bool use_cuda) override;
+
     void quantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount, DTYPE* outputTensorData,
                         double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode, bool use_cuda,
                         bool shiftToSigned)
                         override;
+
+    void quantizeTensorPacked(const DTYPE* inputTensorData, size_t inputTensorCount, std::vector<uint8_t>& outputTensorData,
+                              double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
+                              bool useCuda, bool shiftToSigned) override;
+
+    void quantizeDequantizePerChannelTensor(std::vector <std::vector<DTYPE>>& splits,
+                                            std::vector <uint32_t> splitShape,
+                                            uint32_t axis, DTYPE* outputTensorData,
+                                            const std::vector <TfEncoding> &encodings,
+                                            uint8_t bw, RoundingMode roundMode,
+                                            bool useCuda) override;
+
+    void quantizePerChannelTensorPacked(std::vector <std::vector<DTYPE>>& splits,
+                                        std::vector <uint32_t> splitShape,
+                                        uint32_t axis, std::vector<uint8_t>& outputTensorData,
+                                        const std::vector <TfEncoding> &encodings,
+                                        uint8_t bw, RoundingMode roundMode,
+                                        bool useCuda, bool shiftToSigned) override;
+
+    void dequantizeTensor(const uint8_t* inputTensorData, size_t inputTensorCount, DTYPE* output,
+                         double encodingMin, double encodingMax, uint8_t bw, bool shiftToSigned) override;
+
+    void dequantizePerChannelTensor(const uint8_t* inputTensorData, const std::vector<uint32_t> &inputShape, uint32_t axis,
+                                    DTYPE* outputTensorData, uint8_t bw, const std::vector<TfEncoding> &encodings, bool shiftToSigned) override;
+
     void fillQuantizeInfo(TfEncoding& encoding, DlQuantization::ComputationMode& cpuGpuMode, uint8_t bw,
                           double encodingMin, double encodingMax, bool use_cuda)
                           override;
+
+    ~TensorQuantizationSim() = default;
 };
 
 }   // namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
+++ b/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
@@ -50,6 +50,15 @@ namespace DlQuantization
 TfEncoding getComputedEncodings(uint8_t bw, double min, double max, bool useSymmetricEncodings, bool useStrictSymmetric,
                                 bool useUnsignedSymmetric);
 
+
+// Function to slice a tensor along an axis, allocate and populate output buffers. Output shape will be the same for each slice.
+template <typename DTYPE>
+void slice(const DTYPE* data, const std::vector<uint32_t>& inputShape, int32_t axis, std::vector<std::vector<DTYPE>>& output, std::vector<uint32_t>& splitShape);
+
+// Function to concatenate from slice along an axis. Should be the same shape as the original input shape to slice.
+template<typename DTYPE>
+void concat(const std::vector<std::vector<DTYPE>>& data, const std::vector<uint32_t>& inputShape, int32_t axis, DTYPE* output, std::vector<uint32_t>& outputShape);
+
 }   // End of namespace DlQuantization
 
-#endif   // QUANTIZATION_UTILS_H_ 
+#endif   // QUANTIZATION_UTILS_H_

--- a/ModelOptimizations/DlQuantization/src/trim_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/trim_functions.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2016-2017, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -41,9 +41,11 @@
 #include <cstdint>
 #include <cmath>
 #include <stdexcept>
-#include <stdlib.h>
+#include <cstdlib>
+#include <climits>
 #include <thread>
 #include <vector>
+#include <functional>
 
 #include "DlQuantization/Quantization.hpp"
 #include "trim_functions.hpp"
@@ -52,10 +54,9 @@ namespace DlQuantization
 {
 using namespace std;
 
-template <typename DTYPE>
-inline DTYPE randUniformCpu()
+inline double randUniformCpu()
 {
-    return rand() / (RAND_MAX + static_cast<DTYPE>(1.0));
+    return rand() / (RAND_MAX + static_cast<double>(1.0));
 }
 
 double computeDelta(double encodingMin, double encodingMax, double numSteps)
@@ -156,7 +157,7 @@ inline void quantizeValueCpu(const DTYPE* in, DTYPE* out,
         }
         case ROUND_STOCHASTIC:
         {
-            *out = floor(*out + randUniformCpu<DTYPE>());
+            *out = floor(*out + randUniformCpu());
             break;
         }
         default:
@@ -187,6 +188,24 @@ void quantizeDequantizeCpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
 }
 
 template <typename DTYPE>
+void quantizeToFxpPacked(const DTYPE* in, int cnt, const TfEncoding& encoding,
+                         uint8_t* out, size_t out_size, ComputationMode mode_cpu_gpu,
+                         RoundingMode rounding_mode, bool shiftToSigned)
+{
+    switch (mode_cpu_gpu) {
+    case COMP_MODE_CPU:
+      quantizeToFxpPackedCpu(in, cnt, encoding, out, out_size, rounding_mode, shiftToSigned);
+      break;
+    case COMP_MODE_GPU:
+      throw runtime_error("GPU packed quantization not supported.");
+      break;
+    default:
+      throw runtime_error("Unknown computation mode.");
+      break;
+  }
+
+}
+template <typename DTYPE>
 void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                       bool shiftToSigned)
 {
@@ -205,6 +224,380 @@ void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYP
     }
 }
 
+template <typename DTYPE>
+void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
+                           uint8_t* out, size_t out_size, RoundingMode rounding_mode, bool shiftToSigned)
+{
+    size_t min_out_size = ceil(max(encoding.bw, 8) * cnt / 8.0);
+    if (out_size < min_out_size)
+    {
+        throw runtime_error("Out buffer is too small");
+    }
+
+    int number_of_threads = 4;   // determined by testing
+
+#if 0
+  if(encoding.bw < 8) {
+    // Multi-threading not supported due to dependence between loop iterations
+    number_of_threads = 1;
+  }
+#endif
+    int iteration_per_threads = (int) ceil((double) cnt / (double) number_of_threads);
+    auto quantize_job         = [&](int thread_id)
+    {
+        int start = thread_id * iteration_per_threads;
+        int end   = std::min(start + iteration_per_threads, cnt);
+
+        double data_quantized;
+        for (int i = start; i < end; ++i)
+        {
+            // Saturate
+            data_quantized = max(min((double) in[i], encoding.max), encoding.min);
+            // Scale and add offset to get something in the range [0,2^bw-1]
+            data_quantized = data_quantized / encoding.delta - encoding.offset;
+
+            // Round
+            switch (rounding_mode)
+            {
+            case ROUND_NEAREST:
+            {
+                data_quantized = round(data_quantized);
+                break;
+            }
+            case ROUND_STOCHASTIC:
+            {
+                data_quantized = floor(data_quantized + randUniformCpu());
+                break;
+            }
+            default:
+            {
+                throw runtime_error("Unknown rounding mode.");
+                break;
+            }
+            }
+
+            // Pack the data according to the target bit-width and symmetry
+            if (!shiftToSigned)
+            {
+                switch (encoding.bw)
+                {
+                case 1:
+                case 2:
+                case 4:
+                {
+                    // Note: this case should not be parallelized because the OR operation introduces dependency
+                    // between iterations
+                    uint8_t* ptr          = &out[0];
+                    uint8_t data_shrinked = (uint8_t) data_quantized;
+// Currently unsupported packed case
+#if 0
+                      int bit_offset = encoding.bw * i;
+                      if (bit_offset % 8 == 0) {
+                        // zero-out buffer on first write to byte
+                        ptr[bit_offset / 8] = 0;
+                      }
+                      // OR-in data_shrinked
+                      ptr[bit_offset / 8] |= (data_shrinked << (bit_offset % 8));
+            // Supported one value per byte
+#else
+                    ptr[i] = (uint8_t) max(min((double) data_shrinked, double(pow(2, encoding.bw) - 1)), 0.0);
+
+#endif
+                    break;
+                }
+                case 8:
+                {
+                    uint8_t* ptr = &out[0];
+                    ptr[i]       = (uint8_t) max(min(data_quantized, double(UCHAR_MAX)), 0.0);
+                    break;
+                }
+                case 16:
+                {
+                    uint16_t* ptr = (uint16_t*) &out[0];
+                    ptr[i]        = (uint16_t) max(min(data_quantized, double(USHRT_MAX)), 0.0);
+                    break;
+                }
+                case 32:
+                {
+                    uint32_t* ptr = (uint32_t*) &out[0];
+                    ptr[i]        = (uint32_t) max(min(data_quantized, double(UINT_MAX)), 0.0);
+                    break;
+                }
+                default:
+                {
+                    throw runtime_error("Bit-width needs to be power of two and "
+                                        "between 1 and 32.");
+                }
+                }   // end of switch encoding.bw
+            }       // end of if (shiftToSigned)
+            else
+            {
+                // Using unsigned int to account for case of signed symmetric i.e in the case of bw = 8, it will be -127 to 127
+                double shift = 0;
+                if (shiftToSigned) {
+                    shift = pow(2, encoding.bw - 1) - 1;
+                }
+                data_quantized -=shift;
+                // Pack the data according to the target bit-width ...
+                switch (encoding.bw) {
+                case 1:
+                case 2:
+                case 4:
+                {
+                    int8_t *ptr = (int8_t *) &out[0];
+                    int8_t data_shrinked = (int8_t) data_quantized;
+// Currently unsupported packed case
+#if 0
+              int bit_offset = encoding.bw * i;
+              if (bit_offset % 8 == 0) ptr[bit_offset / 8] = 0; // zero-out buffer on first write to byte
+              // OR-in data_shrinked
+              ptr[bit_offset / 8] |= (data_shrinked * (int8_t)pow(2, (bit_offset % 8)));
+#else
+                    // Mask off the lower bw bits as a single byte
+                    ptr[i] = data_shrinked & (int8_t)(pow(2,encoding.bw)-1);
+#endif
+                    break;
+                }
+                case 8: {
+                    int8_t *ptr = (int8_t *) &out[0];
+                    ptr[i] = (int8_t) max(min(data_quantized, double(SCHAR_MAX)), double(SCHAR_MIN));
+                    break;
+                }
+                case 16: {
+                    int16_t *ptr = (int16_t *) &out[0];
+                    ptr[i] = (int16_t) max(min(data_quantized, double(SHRT_MAX)), double(SHRT_MIN));
+                    break;
+                }
+                case 32: {
+                    int32_t *ptr = (int32_t *) &out[0];
+                    ptr[i] = (int32_t) max(min(data_quantized, double(INT_MAX)), double(INT_MIN));
+                    break;
+                }
+                default: {
+                    throw runtime_error("Bit-width needs to be power of two and "
+                                        "between 1 and 32.");
+                }
+                } // End of switch(encoding.bw).
+            }
+        } // end of for loop
+    };
+    parallelize(number_of_threads, quantize_job);
+}
+
+
+
+template <typename DTYPE>
+void dequantizeFromPackedFxp(const uint8_t* input, int cnt,
+                             const TfEncoding& encoding, DTYPE* output,
+                             ComputationMode mode_cpu_gpu, bool shiftToSigned) {
+    switch (mode_cpu_gpu) {
+    case COMP_MODE_CPU:
+        dequantizeFromPackedFxpCpuMt(input, cnt, encoding, output, shiftToSigned);
+        break;
+    case COMP_MODE_GPU:
+        throw runtime_error("GPU de-quantization not supported.");
+        break;
+    default:
+        throw runtime_error("Unknown computation mode.");
+        break;
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt,
+                                  const TfEncoding& encoding, DTYPE* output,
+                                  bool shiftToSigned)
+{
+    int32_t num_threads = std::max(1, std::min(cnt/120000 , 4));
+    int32_t chunkSize = cnt/num_threads;
+    int32_t bw_adj    = encoding.bw/8;
+
+    if (cnt % num_threads) {
+        // add one to distribute remainder size evenly
+        chunkSize++;
+    }
+    std::vector<std::thread> threads;
+    for (int i = 0; i < num_threads; ++i) {
+        int chunkStart = chunkSize*i;
+        int chunkEnd   = std::min(chunkStart + chunkSize, cnt);
+        threads.push_back(std::thread(dequantizeFromPackedFxpCpu<DTYPE>,
+                                      input+(chunkStart*bw_adj),
+                                      chunkEnd - chunkStart,
+                                      encoding,
+                                      output+chunkStart,
+                                      shiftToSigned));
+    }
+    std::for_each(threads.begin(), threads.end(), std::mem_fn(&thread::join));
+}
+
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpTfBitsCpu(const uint8_t* input, int cnt,
+                                       const TfEncoding& encoding, DTYPE* output) {
+    double data_quantized;
+    for (int i = 0; i < cnt; ++i) {
+        // Extract next value from packed data stream
+        // The packed data is unsigned in TF-style quantization
+        int bit_offset = encoding.bw * i;
+        uint32_t tmp = input[bit_offset / 8] >> (bit_offset % 8);
+        data_quantized = (double)(tmp & (uint32_t)((1 << encoding.bw)-1));
+
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * (data_quantized + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpTf8Cpu(const uint8_t* input, int cnt,
+                                   const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)input[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpTf16Cpu(const uint16_t* input, int cnt,
+                                     const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)input[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpTf32Cpu(const uint32_t* input, int cnt,
+                                     const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)input[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpSymmetricBitsCpu(const uint8_t* input, int cnt,
+                                              const TfEncoding& encoding, DTYPE* output) {
+    double data_quantized;
+    for (int i = 0; i < cnt; ++i) {
+// Removed packed support, no current use case
+#if 0
+    // Extract next value from packed data stream
+    // The packed data is signed for Qmn quantization
+    int bit_offset = encoding.bw * i;
+    int8_t* ptr = (int8_t*)input;
+    // We need to extract a signed number from this byte. Take the byte,
+    // shift it left until the MSB reaches the byte boundary, and shift it
+    // down so the LSB reaches the byte boundary.
+    int8_t tmp = ptr[bit_offset / 8] <<
+                 (8 - bit_offset % 8 - encoding.bw);
+    data_quantized = (double)(tmp >> (8 - encoding.bw));
+#else
+        int8_t* ptr = (int8_t*)input;
+        // Mask the sign bit 2^(bw-1) and f negative apply to the upper MSB bits while retaining the
+        // LSB for 2^(bw-1)-1. Eg 4bit # 0b00001011 is negative, and should become 0b11111011
+        if (ptr[i] & (int8_t)pow(2,encoding.bw-1)) {
+            data_quantized = ~((int8_t)pow(2,encoding.bw)-1) | ptr[i];
+        } else {
+            data_quantized = ptr[i];
+        }
+
+#endif
+
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * (data_quantized + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpSymmetric8Cpu(const uint8_t* input, int cnt,
+                                           const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        int8_t* ptr = (int8_t*)input;
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)ptr[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpSymmetric16Cpu(const int16_t* input, int cnt,
+                                            const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)input[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpSymmetric32Cpu(const int32_t* input, int cnt,
+                                           const TfEncoding& encoding, DTYPE* output) {
+
+    for (int i = 0; i < cnt; ++i) {
+        // De-quantize the data and write it to output vector.
+        output[i] = ( encoding.delta * ((double)input[i] + encoding.offset));
+    }
+}
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpCpu(const uint8_t* input, int cnt,
+                                const TfEncoding& encoding, DTYPE* output,
+                                bool shiftToSigned)
+{
+    if (!shiftToSigned)
+    {
+        // Unpacking the data is bit-width specific
+        switch (encoding.bw)
+        {
+            case 1:
+            case 2:
+            case 4:
+                // Removing packed support since there's no current use case
+                // Fall through to standard unsigned tf8 dequant since there's no difference
+
+                // DeQuantizeFromPackedFxpTfBitsCpu(input, cnt, encoding, output);
+            case 8:
+                dequantizeFromPackedFxpTf8Cpu(input, cnt, encoding, output);
+                break;
+            case 16:
+                dequantizeFromPackedFxpTf16Cpu((const uint16_t*) input, cnt, encoding, output);
+                break;
+            case 32:
+                dequantizeFromPackedFxpTf32Cpu((const uint32_t*) input, cnt, encoding, output);
+                break;
+            default:
+            {
+                throw runtime_error("Bit-width needs to be power of two and "
+                                    "between 1 and 32.");
+            }
+        }
+    } else {
+        // Unpacking the data is bit-width specific
+        switch(encoding.bw) {
+            case 1:
+            case 2:
+            case 4:
+                dequantizeFromPackedFxpSymmetricBitsCpu(input, cnt, encoding, output);
+                break;
+            case 8:
+                dequantizeFromPackedFxpSymmetric8Cpu(input, cnt, encoding, output);
+                break;
+            case 16:
+                dequantizeFromPackedFxpSymmetric16Cpu((const int16_t*)input, cnt, encoding, output);
+                break;
+            case 32:
+                dequantizeFromPackedFxpSymmetric32Cpu((const int32_t*)input, cnt, encoding, output);
+                break;
+            default: {
+                throw runtime_error("Bit-width needs to be power of two and "
+                                    "between 1 and 32.");
+            }
+        }
+    }
+}
 
 // Explicit instantiations
 template void quantizeDequantize(const double* in, int cnt, const TfEncoding& encoding, double* out,
@@ -218,5 +611,18 @@ template void quantizeToFxp(const double* in, int cnt, const TfEncoding& encodin
 
 template void quantizeToFxp(const float* in, int cnt, const TfEncoding& encoding, float* out,
                             ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
+
+template void quantizeToFxpPacked(const float* in, int cnt, const TfEncoding& encoding,
+                                 uint8_t* out, size_t out_size, ComputationMode mode_cpu_gpu,
+                                 RoundingMode rounding_mode, bool shiftToSigned);
+template void quantizeToFxpPacked(const double* in, int cnt, const TfEncoding& encoding,
+                                  uint8_t* out, size_t out_size, ComputationMode mode_cpu_gpu,
+                                  RoundingMode rounding_mode, bool shiftToSigned);
+template void dequantizeFromPackedFxp(const uint8_t* input, int cnt,
+                                      const TfEncoding& encoding, double* output,
+                                      ComputationMode mode_cpu_gpu, bool shiftToSigned);
+template void dequantizeFromPackedFxp(const uint8_t* input, int cnt,
+                                      const TfEncoding& encoding, float* output,
+                                      ComputationMode mode_cpu_gpu, bool shiftToSigned);
 
 }   // End of namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/trim_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/trim_functions.hpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2016-2017, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2016-2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -58,12 +58,35 @@ void quantizeToFxp(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* 
                    RoundingMode rounding_mode, bool shiftToSigned);
 
 template <typename DTYPE>
+void quantizeToFxpPacked(const DTYPE* in, int cnt, const TfEncoding& encoding,
+                         uint8_t* out, size_t out_size, ComputationMode mode_cpu_gpu,
+                         RoundingMode rounding_mode, bool shiftToSigned);
+
+template <typename DTYPE>
+void dequantizeFromPackedFxp(const uint8_t* input, int cnt,
+                             const TfEncoding& encoding, DTYPE* output,
+                             ComputationMode mode_cpu_gpu, bool shiftToSigned);
+
+template <typename DTYPE>
 void quantizeDequantizeCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out,
                            RoundingMode rounding_mode);
 
 template <typename DTYPE>
 void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                       bool shiftToSigned);
+
+template <typename DTYPE>
+void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
+                            DTYPE* out, size_t out_size, RoundingMode rounding_mode, bool shiftToSigned);
+
+// Multi-threading implementation
+template <typename DTYPE>
+void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt,
+                                   const TfEncoding& encoding, DTYPE* output, bool shiftToSigned);
+
+template <typename DTYPE>
+void dequantizeFromPackedFxpCpu(const uint8_t* input, int cnt,
+                                const TfEncoding& encoding, DTYPE* output, bool shiftToSigned);
 
 double computeDelta(double encodingMin, double encodingMax, double numSteps);
 double computeOffset(double encodingMin, double delta);

--- a/ModelOptimizations/DlQuantization/test/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/test/CMakeLists.txt
@@ -1,36 +1,36 @@
 #==============================================================================
 #  @@-COPYRIGHT-START-@@
-#  
+#
 #  Copyright (c) 2018-2022, Qualcomm Innovation Center, Inc. All rights reserved.
-#  
-#  Redistribution and use in source and binary forms, with or without 
+#
+#  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
-#  
-#  1. Redistributions of source code must retain the above copyright notice, 
+#
+#  1. Redistributions of source code must retain the above copyright notice,
 #     this list of conditions and the following disclaimer.
-#  
-#  2. Redistributions in binary form must reproduce the above copyright notice, 
-#     this list of conditions and the following disclaimer in the documentation 
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
 #     and/or other materials provided with the distribution.
-#  
-#  3. Neither the name of the copyright holder nor the names of its contributors 
-#     may be used to endorse or promote products derived from this software 
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
 #     without specific prior written permission.
-#  
-#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE 
-#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE 
-#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE 
-#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
-#  
+#
 #  SPDX-License-Identifier: BSD-3-Clause
-#  
+#
 #  @@-COPYRIGHT-END-@@
 #==============================================================================
 cmake_minimum_required(VERSION 3.5)
@@ -52,6 +52,7 @@ add_executable(MoDlQuantizationTest
       TestTfEncodingAnalyzer.cpp
       TestTensorQuantizationSim.cpp
       TestTensorQuantizer.cpp
+      TestUtilities.cpp
       TestPercentileEncodingAnalyzer.cpp)
 
 if (ENABLE_CUDA)

--- a/ModelOptimizations/DlQuantization/test/TestTensorQuantizationSim.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestTensorQuantizationSim.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2019, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2019 - 2022, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -182,6 +182,31 @@ TEST(TestTensorQuantizationSim, SanityTestWithQuantizeOnlyUnsigned)
     }
 }
 
+TEST(TestTensorQuantizationSim, SanityTestWithDeQuantizeOnlyUnsigned)
+{
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    std::vector<uint8_t> tensor = {0, 45, 99, 153, 207, 255};
+    const std::vector<float> expectedOutput = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    double min    = -0.46;
+    double max    = 0.72;
+
+    sim.dequantizeTensor(tensor.data(), tensor.size(), outputTensor.data(), min, max, bw,
+                         false);
+
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++) {
+        EXPECT_NEAR(outputTensor[i], expectedOutput[i], 0.06);
+    }
+}
+
 TEST(TestTensorQuantizationSim, SanityTestWithQuantizeOnlySigned)
 {
     // Instantiate TensorQuantizationSim
@@ -204,6 +229,162 @@ TEST(TestTensorQuantizationSim, SanityTestWithQuantizeOnlySigned)
 
     for (int i = 0; i < outputTensor.size(); i++) {
         EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
+    }
+}
+
+TEST(TestTensorQuantizationSim, SanityTestWithQuantizePackedOnlyUnsigned)
+{
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<uint8_t> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    double min    = -0.46;
+    double max    = 0.72;
+
+    sim.quantizeTensorPacked(tensor.data(), tensor.size(), outputTensor, min, max, bw,
+                       DlQuantization::RoundingMode::ROUND_NEAREST, false, false);
+
+    std::vector<float> expectedOutput = {0, 45, 99, 153, 207, 255};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++) {
+        EXPECT_FLOAT_EQ(outputTensor[i], expectedOutput[i]);
+    }
+}
+
+
+TEST(TestTensorQuantizationSim, SanityTestWithQuantizePerChannelUnsigned)
+{
+
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    std::vector<uint8_t> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    double min    = -0.46;
+    double max    = 0.72;
+
+
+    uint32_t axis = 3;
+    std::vector<uint32_t> inputShape{1, 1, 2, 3};
+
+    std::vector<DlQuantization::TfEncoding> encodings;
+    std::vector<uint32_t> splitShape{1, 1, 1, 3};
+    std::vector<std::vector<float>> splitParams(2, std::vector<float>(3));
+
+    splitParams[0] = {-0.5f, -0.25f, 0};
+    splitParams[1] = { 0.25, 0.5, 0.75};
+    encodings.resize(splitParams.size());
+    encodings[0] = {min, max, 0, 0};
+    encodings[1] = {min, max, 0, 0};
+
+    ASSERT_EQ(encodings.size(), 2);
+    ASSERT_EQ(splitParams.size(), 2);
+
+    std::vector<float> params_quantized(tensor.size());
+    sim.quantizePerChannelTensorPacked(splitParams, splitShape, axis, outputTensor, encodings, bw,
+                                           DlQuantization::RoundingMode::ROUND_NEAREST,  false, false);
+
+    std::vector<uint8_t> expectedOutput = {0, 45, 99, 153, 207, 255};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_NEAR(outputTensor[i], expectedOutput[i], 1e-3);
+    }
+}
+
+TEST(TestTensorQuantizationSim, SanityTestWithQuantizeDequantizePerChannel)
+{
+
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    const std::vector<float> tensor = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75,
+                                        0, 0.25, 0.5, 0.75,-0.5f, -0.25f};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    // min is greater than 0, this will be gated at 0.0
+    // New range will be -0.5 to 0.0
+    double min    = -0.5;
+    double max    = -0.1;
+    uint32_t axis = 2;
+    std::vector<uint32_t> inputShape{1, 1, 2, 6};
+
+    std::vector<DlQuantization::TfEncoding> encodings;
+    std::vector<uint32_t> splitShape{1, 6};
+    std::vector<std::vector<float>> splitParams(2, std::vector<float>(6));
+
+    splitParams[0] = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+    splitParams[1] = {0, 0.25, 0.5, 0.75,-0.5f, -0.25f};
+    encodings.resize(splitParams.size());
+    encodings[0] = {min, max, 0, 0};
+    encodings[1] = {min, max, 0, 0};
+
+    ASSERT_EQ(encodings.size(), 2);
+    ASSERT_EQ(splitParams.size(), 2);
+
+    std::vector<float> params_quantized(tensor.size());
+    sim.quantizeDequantizePerChannelTensor(splitParams, splitShape,axis, outputTensor.data(), encodings, bw,
+                                           DlQuantization::RoundingMode::ROUND_NEAREST,  false);
+
+    std::vector<float> expectedOutput = {-0.5f, 0, -0.24902f, 0, 0, 0,
+                                         0, 0, 0, -0.5f, 0, -0.24902f};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_NEAR(outputTensor[i], expectedOutput[i], 1e-3);
+    }
+}
+
+
+TEST(TestTensorQuantizationSim, SanityTestWithDequantizePerChannel)
+{
+
+    // Instantiate TensorQuantizationSim
+    DlQuantization::TensorQuantizationSim<float> sim;
+
+    // Create a dummy tensor
+    std::vector<uint8_t> tensor = {0, 45, 99, 153, 207, 255};
+    std::vector<float> outputTensor(tensor.size());
+
+    uint8_t bw     = 8;
+    double min    = -0.46;
+    double max    = 0.72;
+    uint32_t axis = 2;
+    std::vector<uint32_t> inputShape{1, 1, 2, 3};
+
+    std::vector<DlQuantization::TfEncoding> encodings;
+    encodings.resize(2);
+    encodings[0] = {min, max, 0, 0};
+    encodings[1] = {min, max, 0, 0};
+
+    ASSERT_EQ(encodings.size(), 2);
+
+    std::vector<float> params_quantized(tensor.size());
+    sim.dequantizePerChannelTensor(tensor.data(), inputShape, axis,
+                                   outputTensor.data(), bw, encodings, false);
+
+    std::vector<float> expectedOutput = {-0.5f, -0.25f, 0, 0.25, 0.5, 0.75};
+
+    EXPECT_EQ(outputTensor.size(), expectedOutput.size());
+
+    for (int i = 0; i < outputTensor.size(); i++)
+    {
+        EXPECT_NEAR(outputTensor[i], expectedOutput[i], 0.06);
     }
 }
 

--- a/ModelOptimizations/DlQuantization/test/TestTensorQuantizer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestTensorQuantizer.cpp
@@ -37,45 +37,85 @@
 //==============================================================================
 
 #include <random>
-#include <DlQuantization/TensorQuantizer.h>
 #include <gtest/gtest.h>
 
+#include "DlQuantization/TensorQuantizer.h"
 #include "test_quantization_lib.hpp"
 
 using namespace DlQuantization;
 
 class TestTensorQuantizer : public ::testing::Test
 {
+protected:
+
+    std::vector<float> data1, data2, data3, data4;
+    std::vector<uint32_t> shape1, shape2, shape3;
+    std::unique_ptr<TensorQuantizer> enhancedTensorQuant;
+    std::unique_ptr<TensorQuantizer> tfTensorQuant;
+
+    void SetUp() {
+        if(data1.size() == 0) {
+            data1.resize(24);
+            std::iota(std::begin(data1), std::end(data1), 0);
+            shape1 = {2,3,2,2};
+        }
+
+        if(data2.size() == 0) {
+            data2.resize(60);
+            float t = -15;
+            for(uint32_t i = 0; i < data2.size(); ++i) {
+                data2[i] = t;
+                t += 0.5;
+            }
+            shape2 = {1,4,5,3};
+        }
+
+        if(data3.size() == 0) {
+            shape3 = {2,5,4,1};
+            data3.resize(40);
+            std::mt19937 eng;
+            std::normal_distribution<float> dist;
+            for(auto& d : data3) {
+                d = dist(eng);
+            }
+            std::iota(std::begin(data1), std::end(data1), 0);
+        }
+
+        if (data4.size() == 0){
+            float mean   = 2;
+            float stddev = 2;
+            std::normal_distribution<float> distribution(mean, stddev);
+            std::mt19937 generator(1);
+
+            unsigned int tensorCount = 6000;
+            data4.resize(tensorCount);
+
+            for (unsigned int i = 0; i < tensorCount; i++)
+            {
+                data4[i] = distribution(generator);
+            }
+
+        }
+
+        enhancedTensorQuant.reset(new TensorQuantizer (QuantizationMode::QUANTIZATION_TF_ENHANCED, ROUND_NEAREST));
+        tfTensorQuant.reset(new TensorQuantizer(QuantizationMode::QUANTIZATION_TF, ROUND_NEAREST));
+    }
 };
 
-TEST(TestTensorQuantizer, SanityTestCpu)
+TEST_F(TestTensorQuantizer, SanityTestCpu)
 {
-    TensorQuantizer tensorQuantizer(QuantizationMode::QUANTIZATION_TF_ENHANCED, ROUND_NEAREST);
 
-    float mean   = 2;
-    float stddev = 2;
-    std::normal_distribution<float> distribution(mean, stddev);
-    std::mt19937 generator(1);
+    enhancedTensorQuant->setStrictSymmetric(false);
+    enhancedTensorQuant->setUnsignedSymmetric(false);
+    enhancedTensorQuant->updateStats(data4.data(), data4.size(), false);
+    EXPECT_FALSE(enhancedTensorQuant->isEncodingValid);
+    TfEncoding encoding = enhancedTensorQuant->computeEncoding(8, false);
+    EXPECT_TRUE(enhancedTensorQuant->isEncodingValid);
 
-    unsigned int tensorCount = 6000;
-    std::vector<float> statsTensor(tensorCount);
+    std::vector<float> inputTensor(data4.size(), 5);
+    std::vector<float> quantizedTensor(data4.size());
 
-    for (unsigned int i = 0; i < tensorCount; i++)
-    {
-        statsTensor[i] = distribution(generator);
-    }
-
-    tensorQuantizer.setStrictSymmetric(false);
-    tensorQuantizer.setUnsignedSymmetric(false);
-    tensorQuantizer.updateStats(statsTensor.data(), statsTensor.size(), false);
-    EXPECT_FALSE(tensorQuantizer.isEncodingValid);
-    TfEncoding encoding = tensorQuantizer.computeEncoding(8, false);
-    EXPECT_TRUE(tensorQuantizer.isEncodingValid);
-
-    std::vector<float> inputTensor(tensorCount, 5);
-    std::vector<float> quantizedTensor(tensorCount);
-
-    tensorQuantizer.quantizeDequantize(inputTensor.data(), inputTensor.size(), quantizedTensor.data(),
+    enhancedTensorQuant->quantizeDequantize(inputTensor.data(), inputTensor.size(), quantizedTensor.data(),
                                        encoding.min, encoding.max, 8, false);
 
     std::cout << "Encoding min=" << encoding.min << ", max=" << encoding.max
@@ -90,26 +130,12 @@ TEST(TestTensorQuantizer, SanityTestCpu)
     EXPECT_NEAR(quantizedTensor.data()[0], 5.0162, 0.001);
 }
 
-
-TEST(TestTensorQuantizer, SanityTestComputeEncodingFromDataAsymmetricTFEnhanced)
+TEST_F(TestTensorQuantizer, SanityTestComputeEncodingFromDataAsymmetricTFEnhanced)
 {
-    TensorQuantizer tensorQuantizer(QuantizationMode::QUANTIZATION_TF_ENHANCED, ROUND_NEAREST);
-
-    float mean   = 2;
-    float stddev = 2;
-    std::normal_distribution<float> distribution(mean, stddev);
-    std::mt19937 generator(1);
-
-    unsigned int tensorCount = 6000;
-    std::vector<float> paramTensor(tensorCount);
-
-    for (unsigned int i = 0; i < tensorCount; i++)
-    {
-        paramTensor[i] = distribution(generator);
-    }
-
+    auto paramTensor = this->data4;
+    auto tensorCount = paramTensor.size();
     TfEncoding encoding{};
-    tensorQuantizer.computeEncodingFromData(8, paramTensor.data(),
+    enhancedTensorQuant->computeEncodingFromData(8, paramTensor.data(),
                                             tensorCount, encoding, ComputationMode::COMP_MODE_CPU, false, false, false);
 
     std::cout << "Encoding min=" << encoding.min << ", max=" << encoding.max
@@ -118,25 +144,12 @@ TEST(TestTensorQuantizer, SanityTestComputeEncodingFromDataAsymmetricTFEnhanced)
     EXPECT_NEAR(encoding.max, 8.884, 0.001);
 }
 
-TEST(TestTensorQuantizer, SanityTestComputeEncodingFromDataSymmetricTF)
+TEST_F(TestTensorQuantizer, SanityTestComputeEncodingFromDataSymmetricTF)
 {
-    TensorQuantizer tensorQuantizer(QuantizationMode::QUANTIZATION_TF, ROUND_NEAREST);
-
-    float mean   = 2;
-    float stddev = 2;
-    std::normal_distribution<float> distribution(mean, stddev);
-    std::mt19937 generator(100);
-
-    unsigned int tensorCount = 6000;
-    std::vector<float> paramTensor(tensorCount);
-
-    for (int i = 0; i < tensorCount; i++)
-    {
-        paramTensor[i] = distribution(generator);
-    }
-
+    auto paramTensor = this->data4;
+    auto tensorCount = paramTensor.size();
     TfEncoding encoding{};
-    tensorQuantizer.computeEncodingFromData(8, paramTensor.data(),
+    tfTensorQuant->computeEncodingFromData(8, paramTensor.data(),
                                             tensorCount, encoding, ComputationMode::COMP_MODE_CPU,
                                             true, false, true);
 
@@ -161,10 +174,321 @@ TEST(TestTensorQuantizer, SanityTestComputeEncodingFromDataSymmetricTF)
     EXPECT_EQ(encoding.bw, 8);
 }
 
+TEST_F(TestTensorQuantizer, SANITY_GeneratePerChannelParams) {
+    int bw = 8;
+    int32_t axis = 1;
+
+    std::vector<TfEncoding> encodings;
+    std::vector<uint32_t> splitShape;
+    std::vector<std::vector<float>> splitParams;
+
+    TensorQuantizer tensorQuantizer(QuantizationMode::QUANTIZATION_TF, ROUND_NEAREST);
+    tensorQuantizer.generatePerChannelEncodings(data1.data(), shape1,
+                                                axis, encodings, bw, splitParams, splitShape, false);
+
+    ASSERT_EQ(encodings.size(), shape1[axis]);
+    ASSERT_EQ(splitParams.size(), shape1[axis]);
+
+    std::vector<uint32_t> expectedOutputShape = {2,1,2,2};
+    ASSERT_EQ(splitShape, expectedOutputShape);
+
+    std::vector<std::vector<float>> expectedOutputData(3);
+    expectedOutputData[0] = {0,  1,  2,  3, 12, 13, 14, 15 };
+    expectedOutputData[1] = {4,  5,  6,  7, 16, 17, 18, 19 };
+    expectedOutputData[2] = {8,  9, 10, 11, 20, 21, 22, 23 };
+
+    std::vector<TfEncoding> expectedEncodings(3);
+    expectedEncodings[0] = getTfEncoding(0, 15, 8);
+    expectedEncodings[1] = getTfEncoding(0, 19, 8);
+    expectedEncodings[2] = getTfEncoding(0, 23, 8);
+
+    ASSERT_EQ(splitParams.size(), expectedOutputData.size());
+    ASSERT_EQ(splitParams[0], expectedOutputData[0]);
+    ASSERT_EQ(splitParams[1], expectedOutputData[1]);
+    ASSERT_EQ(splitParams[2], expectedOutputData[2]);
+
+    for(uint32_t i = 0; i < encodings.size(); ++i) {
+        EXPECT_TRUE(compareEncodings(encodings[i], expectedEncodings[i]));
+    }
+}
+
+
+// 1. Quantize some per channel data using QuantizePerChannelParamsPacked()
+TEST_F(TestTensorQuantizer, SANITY_QuantizePerChannelTensorPackedAsymmetric) {
+    int bw = 8;
+    int32_t axis = 1;
+
+    std::vector<TfEncoding> expectedEncodings(4);
+    expectedEncodings[0] = getTfEncoding(-15, 0, 8);
+    expectedEncodings[1] = getTfEncoding(-7.5, 0, 8);
+    expectedEncodings[2] = getTfEncoding(0, 7, 8);
+    expectedEncodings[3] = getTfEncoding(0, 14.5, 8);
+    std::vector<uint8_t> expectedParams =
+        { 0, 9, 17, 26, 34, 43, 51, 60, 68, 77, 85, 94, 102, 111, 119, 0, 17, 34, 51, 68, 85, 102,
+         119, 136, 153, 170, 187, 204, 221, 238, 0, 18, 36, 55, 73, 91, 109, 128, 146, 164, 182, 200,
+         219, 237, 255, 132, 141, 149, 158, 167, 176, 185, 193, 202, 211, 220, 229, 237, 246, 255 };
+
+
+    std::vector<TfEncoding> encodings;
+    std::vector<uint8_t> params_quantized(this->data2.size());
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->quantizePerChannelTensorPacked(this->data2.data(), this->shape2, axis,
+                                                  params_quantized, encodings, bw,
+                                                  DlQuantization::RoundingMode::ROUND_NEAREST,
+                                                  false, false);
+
+    ASSERT_EQ(encodings.size(), this->shape2[axis]);
+    ASSERT_EQ(encodings.size(), expectedEncodings.size());
+    for(uint32_t i = 0; i < encodings.size(); ++i) {
+        EXPECT_TRUE(compareEncodings(encodings[i], expectedEncodings[i]));
+        printEncoding(encodings[i]);
+    }
+
+    EXPECT_TRUE(compareTensors(params_quantized.data(), expectedParams.data(), this->data2.size()));
+}
+
+// 1. Quantize some per channel data using QuantizePerChannelParamsPacked()
+TEST_F(TestTensorQuantizer, SANITY_QuantizePerChannelTensorPackedSymmetric) {
+    int bw = 8;
+    int32_t axis = 1;
+
+    std::vector<TfEncoding> expectedEncodings;
+    expectedEncodings.emplace_back(getTfSymmetricEncoding(15, 8));
+    expectedEncodings.emplace_back(getTfSymmetricEncoding(7.5, 8));
+    expectedEncodings.emplace_back(getTfSymmetricEncoding(7, 8));
+    expectedEncodings.emplace_back(getTfSymmetricEncoding(14.5, 8));
+    std::vector<int8_t> expectedParams =
+    { -127, -123, -119, -114, -110, -106, -102, -97, -93, -89, -85, -80, -76, -72, -68, -127, -119,
+      -110, -102, -93, -85, -76, -68, -59, -51, -42, -34, -25, -17, -8, 0, 9, 18, 27, 36, 45, 54, 64,
+      73, 82, 91, 100, 109, 118, 127, 66, 70, 74, 79, 83, 88, 92, 96, 101, 105, 109, 114, 118, 123, 127 };
+
+
+    std::vector<TfEncoding> encodings;
+    std::vector<uint8_t> params_quantized(this->data2.size());
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->quantizePerChannelTensorPacked(this->data2.data(), this->shape2, axis,
+                                                  params_quantized, encodings, bw,
+                                                  DlQuantization::RoundingMode::ROUND_NEAREST,
+                                                  false, true);
+
+    ASSERT_EQ(encodings.size(), this->shape2[axis]);
+    ASSERT_EQ(encodings.size(), expectedEncodings.size());
+    for(uint32_t i = 0; i < encodings.size(); ++i) {
+        EXPECT_TRUE(compareEncodings(encodings[i], expectedEncodings[i]));
+    }
+
+    EXPECT_TRUE(compareTensors((int8_t*)params_quantized.data(), expectedParams.data(), this->data2.size()));
+}
+
+// 1. QuantizeDequantize per channel using Asymmetric mode
+TEST_F(TestTensorQuantizer, SANITY_QuantizeDequantizePerChannelTensor) {
+    int bw = 8;
+    int32_t axis = 3;
+
+
+    std::vector<TfEncoding> expectedEncodings(3);
+    expectedEncodings[0]=getTfEncoding(-15, 13.5, 8);
+    expectedEncodings[1]=getTfEncoding(-14.5, 14, 8);
+    expectedEncodings[2]=getTfEncoding(-14, 14.5, 8);
+
+    std::vector<float> expectedParams =
+        {-14.9765, -14.5294, -13.9706, -13.5235, -12.9647, -12.5176, -11.9588, -11.5118, -10.9529, -10.5059,
+         -9.94706, -9.5, -9.05294, -8.49412, -8.04706, -7.48824, -7.04118, -6.48235, -6.03529, -5.47647, -5.02941,
+         -4.47059, -4.02353, -3.46471, -3.01765, -2.45882, -2.01176, -1.45294, -1.00588, -0.447059, 0, 0.447059, 1.00588,
+         1.45294, 2.01176, 2.45882, 3.01765, 3.46471, 4.02353, 4.47059, 5.02941, 5.47647, 6.03529, 6.48235, 7.04118, 7.48824,
+         8.04706, 8.49412, 9.05294, 9.5, 9.94706, 10.5059, 10.9529, 11.5118, 11.9588, 12.5176, 12.9647, 13.5235, 13.9706, 14.5294 };
+
+
+    std::vector<TfEncoding> encodings;
+    std::vector<float> params_quantized(this->data2.size());
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->quantizeDequantizePerChannelTensor(this->data2.data(), this->shape2, axis,
+                                                     params_quantized.data(), encodings, bw,
+                                                     DlQuantization::RoundingMode::ROUND_NEAREST,
+                                                     false, false);
+
+    ASSERT_EQ(encodings.size(), this->shape2[axis]);
+    ASSERT_EQ(encodings.size(), expectedEncodings.size());
+    for(uint32_t i = 0; i < encodings.size(); ++i) {
+        EXPECT_TRUE(compareEncodings(encodings[i], expectedEncodings[i]));
+    }
+
+    ASSERT_EQ(params_quantized.size(), expectedParams.size());
+    for(uint32_t i = 0; i<expectedParams.size(); ++i) {
+        EXPECT_NEAR(params_quantized[i], expectedParams[i], 0.001);
+        EXPECT_NEAR(params_quantized[i], this->data2[i], 0.06);
+    }
+}
+
+// 1. QuantizeDequantize per channel using Asymmetric mode
+TEST_F(TestTensorQuantizer, SANITY_QuantizeDequantizePerChannelTensorSymmetric) {
+    int bw = 8;
+    int32_t axis = 2;
+
+
+    std::vector<TfEncoding> expectedEncodings(5);
+    expectedEncodings[0]=getTfSymmetricEncoding(15, 8);
+    expectedEncodings[1]=getTfSymmetricEncoding(13.5, 8);
+    expectedEncodings[2]=getTfSymmetricEncoding(12, 8);
+    expectedEncodings[3]=getTfSymmetricEncoding(13, 8);
+    expectedEncodings[4]=getTfSymmetricEncoding(14.5, 8);
+
+    std::vector<float> expectedParams =
+        { -15, -14.5276, -14.0551, -13.5, -12.9685, -12.5433, -12, -11.5276, -10.9606, -10.5433, -10.0315,
+         -9.51968, -9.01968, -8.44882, -7.99213, -7.44094, -6.9685, -6.49606, -5.95276, -5.52756, -4.99606,
+         -4.53543, -3.9685, -3.49606, -2.9685, -2.45669, -2.04724, -1.48425, -1.02756, -0.456693, 0, 0.472441,
+         0.944882, 1.48819, 2.01969, 2.55118, 3.02362, 3.49606, 3.9685, 4.50394, 5.01575, 5.52756, 6.05118,
+         6.50787, 6.96457, 7.55906, 8.0315, 8.50394, 9.03543, 9.46063, 9.99213, 10.4882, 10.9606, 11.5276, 11.9764,
+         12.4882, 13, 13.4724, 14.0433, 14.5 };
+
+
+    std::vector<TfEncoding> encodings;
+    std::vector<float> params_quantized(this->data2.size());
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->quantizeDequantizePerChannelTensor(this->data2.data(), this->shape2, axis,
+                                                      params_quantized.data(), encodings, bw,
+                                                      DlQuantization::RoundingMode::ROUND_NEAREST,
+                                                      false, true);
+
+    ASSERT_EQ(encodings.size(), this->shape2[axis]);
+    ASSERT_EQ(encodings.size(), expectedEncodings.size());
+    for(uint32_t i = 0; i < encodings.size(); ++i) {
+        EXPECT_TRUE(compareEncodings(encodings[i], expectedEncodings[i]));
+    }
+
+    ASSERT_EQ(params_quantized.size(), expectedParams.size());
+    for(uint32_t i = 0; i<expectedParams.size(); ++i) {
+        EXPECT_NEAR(params_quantized[i], expectedParams[i], 0.0001);
+        EXPECT_NEAR(params_quantized[i], this->data2[i], 0.06);
+    }
+}
+
+
+//test parameter quantization for bw=8, number range: -50...80
+//also test encoding
+TEST_F(TestTensorQuantizer, SANITY_QuantizeTensorPackedAsymmetric) {
+    // Test data
+    float data[] = {-40,-1,0,1,2,-50,80};
+    uint8_t data_expected[] = {20,96,98,100,102,0,255};
+    int cnt = 7;
+    int bw = 8;
+
+    // Do quantization
+    TfEncoding encoding;
+    std::vector<uint8_t> output(cnt);
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->updateStats(data, cnt, false);
+    encoding = tfTensorQuant->computeEncoding(bw, false);
+    tfTensorQuant->quantizeTensorPacked(data, cnt, output, encoding.min, encoding.max, bw, DlQuantization::ROUND_NEAREST,
+                                        false, false);
+    // Check quantized values
+    for (int i = 0; i < cnt; ++i) {
+        EXPECT_EQ(output[i], data_expected[i]);
+    }
+    // Check encoding
+    TfEncoding encoding_expected;
+    getTfEncoding(-50, 80, bw);
+    EXPECT_TRUE(compareEncodings(encoding_expected, encoding));
+}
+
+
+// 1. Quantize some data using QuantizeParamsPacked()
+// 2. Dequantize the result using DeQuantize()
+// The final result will be close to the original data
+// Test both the vector and pointer API versions of QuantizeParamsPacked() and
+// DeQuantize().
+TEST_F(TestTensorQuantizer, SANITY_Dequantize) {
+    // Unquantized data
+    float data_unquantized[] = {-40,-1,0,1,2,-50,80};
+    // Expected quantized data
+    uint8_t data_quantized_expected[] = {20,96,98,100,102,0,255};
+    int cnt = 7;
+    int bw = 8;
+    // Do quantization
+    TfEncoding encoding;
+    std::vector<uint8_t> data_quantized(cnt);
+
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->updateStats(data_unquantized, cnt, false);
+    encoding = tfTensorQuant->computeEncoding(bw, false);
+    tfTensorQuant->quantizeTensorPacked(data_unquantized, cnt, data_quantized, encoding.min, encoding.max, bw, DlQuantization::ROUND_NEAREST,
+                                        false, false);
+
+    // Check quantized values
+    for (int i = 0; i < cnt; ++i) {
+        EXPECT_EQ(data_quantized[i], data_quantized_expected[i]);
+    }
+    // De-quantize values
+    std::vector<float> data_dequantized(cnt);
+    // Test the pointer API.
+    tfTensorQuant->dequantize(data_quantized.data(), cnt, encoding.min,
+                              encoding.max,bw, data_dequantized.data(), false);
+
+    // Check de-quantized values
+    float data_dequantized_expected[] = {-39.7647f, -1.01961f, 0, 1.01961f,
+                                             2.03922f, -49.9608f, 80.0392f};
+    for (int i = 0; i < cnt; ++i) {
+        EXPECT_NEAR(data_dequantized[i], data_dequantized_expected[i],
+                    1e-4);
+    }
+}
+
+
+// 1. Quantize some data using QuantizeParamsPacked()
+// 2. Dequantize the result using DeQuantize()
+// The final result will be close to the original data
+// Test both the vector and pointer API versions of QuantizeParamsPacked() and
+// DeQuantize().
+TEST_F(TestTensorQuantizer, SANITY_DequantizePerChannel)
+{
+    // Unquantized data
+    float data_unquantized[] = {-40, -1, 0, 1, 2, -50, 80, 1,
+                                30, 10, 25, 3, 2, -50, 70, 1};
+    // Expected quantized data
+    uint8_t data_quantized_expected[] = {20, 96, 98, 100, 102, 0, 255, 100,
+                                         170, 127, 159, 112, 110, 0, 255, 108};
+    int cnt                           = 16;
+    int bw                            = 8;
+    size_t axis = 2;
+
+    // Do quantization
+    TfEncoding encoding;
+    std::vector<uint8_t> data_quantized(cnt);
+    std::vector<uint32_t> inputShape{1, 1, 2, 8};
+
+    std::vector<TfEncoding> encodings;
+    tfTensorQuant->setUnsignedSymmetric(false);
+    tfTensorQuant->quantizePerChannelTensorPacked(data_unquantized, inputShape, axis,
+                                                  data_quantized, encodings, bw,
+                                                  DlQuantization::RoundingMode::ROUND_NEAREST,
+                                                  false, false);
+
+    // Check quantized values
+    for (int i = 0; i < cnt; ++i)
+    {
+        EXPECT_EQ(data_quantized[i], data_quantized_expected[i]);
+    }
+    // De-quantize values
+    std::vector<float> data_dequantized(cnt);
+    // Test the pointer API.
+    tfTensorQuant->dequantizePerChannelTensor(data_quantized.data(), inputShape, axis, encodings, bw, data_dequantized.data(),
+                                              false);
+
+    // Check de-quantized values
+    float data_dequantized_expected[] = {-39.7647f, -1.01961f, 0, 1.01961f,
+                                         2.03922f, -49.9608f, 80.0392f,1.01961f,
+                                         30.1176f, 9.88235f, 24.9412f, 2.82353f, 1.88235f,
+                                         -49.8824f, 70.1176f, 0.941176f};
+
+    for (int i = 0; i < cnt; ++i)
+    {
+        EXPECT_NEAR(data_dequantized[i], data_dequantized_expected[i], 1e-4);
+    }
+}
 
 #ifdef GPU_QUANTIZATION_ENABLED
 
-TEST(TestTensorQuantizer, SanityTestGpu)
+TEST_F(TestTensorQuantizer, SanityTestGpu)
 {
     TensorQuantizer tensorQuantizer(QuantizationMode::QUANTIZATION_TF_ENHANCED, ROUND_NEAREST);
 

--- a/ModelOptimizations/DlQuantization/test/TestUtilities.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestUtilities.cpp
@@ -1,0 +1,264 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <gtest/gtest.h>
+#include <random>
+#include "quantization_utils.hpp"
+
+using namespace DlQuantization;
+
+class TestUtilitiesCpu : public ::testing::Test
+{
+protected:
+
+    std::vector<float> data1, data2, data3, data4;
+    std::vector<uint32_t> shape1, shape2, shape3;
+
+    void SetUp() {
+        if(data1.size() == 0) {
+            data1.resize(24);
+            std::iota(std::begin(data1), std::end(data1), 0);
+            shape1 = {2,3,2,2};
+        }
+
+        if(data2.size() == 0) {
+            data2.resize(60);
+            float t = -15;
+            for(uint32_t i = 0; i < data2.size(); ++i) {
+                data2[i] = t;
+                t += 0.5;
+            }
+            shape2 = {1,4,5,3};
+        }
+
+        if(data3.size() == 0) {
+            shape3 = {2,5,4,1};
+            data3.resize(40);
+            std::mt19937 eng;
+            std::normal_distribution<float> dist;
+            for(auto& d : data3) {
+                d = dist(eng);
+            }
+            std::iota(std::begin(data1), std::end(data1), 0);
+        }
+
+        if (data4.size() == 0){
+            float mean   = 2;
+            float stddev = 2;
+            std::normal_distribution<float> distribution(mean, stddev);
+            std::mt19937 generator(1);
+
+            unsigned int tensorCount = 6000;
+            data4.resize(tensorCount);
+
+            for (unsigned int i = 0; i < tensorCount; i++)
+            {
+                data4[i] = distribution(generator);
+            }
+
+        }
+
+    }
+};
+//Slice testing
+TEST_F(TestUtilitiesCpu, SANITY_SliceAndDice) {
+
+    // Test data1, axis 1
+    int32_t axis = 1;
+    std::vector<uint32_t> outputShape;
+    std::vector<uint32_t> expectedOutputShape = {2,1,2,2};
+    std::vector<std::vector<float>> outputData;
+    std::vector<std::vector<float>> expectedOutputData(3);
+    expectedOutputData[0] = {0,  1,  2,  3, 12, 13, 14, 15 };
+    expectedOutputData[1] = {4,  5,  6,  7, 16, 17, 18, 19 };
+    expectedOutputData[2] = {8,  9, 10, 11, 20, 21, 22, 23 };
+
+    slice(this->data1.data(), this->shape1, axis, outputData, outputShape);
+    ASSERT_EQ(outputData.size(), expectedOutputData.size());
+    ASSERT_EQ(outputData[0], expectedOutputData[0]);
+    ASSERT_EQ(outputData[1], expectedOutputData[1]);
+    ASSERT_EQ(outputData[2], expectedOutputData[2]);
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_SliceAndDice2) {
+
+    int32_t axis = 3;
+    std::vector<uint32_t> outputShape;
+    std::vector<uint32_t> expectedOutputShape= {2,3,2,1};
+    std::vector<std::vector<float>> outputData;
+    std::vector<std::vector<float>> expectedOutputData(2);
+    expectedOutputData[0] = {0,  2,  4,  6,  8, 10, 12, 14, 16, 18, 20, 22 };
+    expectedOutputData[1] = {1,  3,  5,  7,  9, 11, 13, 15, 17, 19, 21, 23 };
+
+    slice(this->data1.data(), this->shape1, axis, outputData, outputShape);
+    ASSERT_EQ(outputData.size(), expectedOutputData.size());
+    ASSERT_EQ(outputData[0], expectedOutputData[0]);
+    ASSERT_EQ(outputData[1], expectedOutputData[1]);
+
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_SliceAndDice3) {
+
+    int32_t axis = 1;
+    std::vector<uint32_t> outputShape;
+    std::vector<uint32_t> expectedOutputShape= {1,1,5,3};
+    std::vector<std::vector<float>> outputData;
+    std::vector<std::vector<float>> expectedOutputData(4);
+    expectedOutputData[0] = {-15., -14.5, -14., -13.5, -13., -12.5, -12., -11.5, -11., -10.5, -10., -9.5, -9., -8.5, -8.};
+    expectedOutputData[1] = {-7.5, -7. , -6.5, -6. , -5.5, -5. , -4.5, -4. , -3.5, -3. , -2.5, -2. , -1.5, -1. , -0.5};
+    expectedOutputData[2] = {0. , 0.5, 1. , 1.5, 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. , 5.5, 6. , 6.5, 7.};
+    expectedOutputData[3] = {7.5,  8. ,  8.5,  9. ,  9.5, 10. , 10.5, 11. , 11.5, 12. , 12.5, 13. , 13.5, 14. , 14.5};
+
+    slice(this->data2.data(), this->shape2, axis, outputData, outputShape);
+    ASSERT_EQ(outputData.size(), expectedOutputData.size());
+    ASSERT_EQ(outputData[0], expectedOutputData[0]);
+    ASSERT_EQ(outputData[1], expectedOutputData[1]);
+    ASSERT_EQ(outputData[2], expectedOutputData[2]);
+    ASSERT_EQ(outputData[3], expectedOutputData[3]);
+
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_SliceAndDice4) {
+
+    int32_t axis = -2;
+    std::vector<uint32_t> outputShape;
+    std::vector<uint32_t> expectedOutputShape= {1,4,1,3};
+    std::vector<std::vector<float>> outputData;
+    std::vector<std::vector<float>> expectedOutputData(5);
+    expectedOutputData[0] = {-15. , -14.5, -14. ,  -7.5,  -7. ,  -6.5,   0. ,   0.5,   1. ,  7.5,   8. ,   8.5};
+    expectedOutputData[1] = {-13.5, -13. , -12.5,  -6. ,  -5.5,  -5. ,   1.5,   2. ,   2.5,  9. ,   9.5,  10.};
+    expectedOutputData[2] = {-12. , -11.5, -11. ,  -4.5,  -4. ,  -3.5,   3. ,   3.5,   4., 10.5,  11. ,  11.5};
+    expectedOutputData[3] = {-10.5, -10. ,  -9.5,  -3. ,  -2.5,  -2. ,   4.5,   5. ,   5.5, 12. ,  12.5,  13.};
+    expectedOutputData[4] = {-9. , -8.5, -8. , -1.5, -1. , -0.5,  6. ,  6.5,  7. , 13.5, 14., 14.5};
+
+    slice(this->data2.data(), this->shape2, axis, outputData, outputShape);
+    ASSERT_EQ(outputData.size(), expectedOutputData.size());
+    ASSERT_EQ(outputData[0], expectedOutputData[0]);
+    ASSERT_EQ(outputData[1], expectedOutputData[1]);
+    ASSERT_EQ(outputData[2], expectedOutputData[2]);
+    ASSERT_EQ(outputData[3], expectedOutputData[3]);
+    ASSERT_EQ(outputData[4], expectedOutputData[4]);
+
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_SliceAndDiceSingleDim) {
+
+    int32_t axis = 3;
+    std::vector<uint32_t> outputShape;
+    std::vector<uint32_t> expectedOutputShape= {2,5,4,1};
+    std::vector<std::vector<float>> outputData;
+
+    // Slicing on an axis where the dimension == 1 means the output "slice" is really just the input
+    slice(this->data3.data(), this->shape3, axis, outputData, outputShape);
+    ASSERT_EQ(outputData.size(), 1);
+    ASSERT_EQ(outputData[0].size(), this->data3.size());
+    ASSERT_EQ(outputData[0], this->data3);
+}
+
+//Concat testing
+TEST_F(TestUtilitiesCpu, SANITY_Concat) {
+
+    int32_t axis = 1;
+    std::vector<uint32_t> outputShape;
+    std::vector<float> outputData(this->data1.size());
+    std::vector<uint32_t> splitShape = {2,1,2,2};
+    std::vector<std::vector<float>> inputData(3);
+    inputData[0] = {0,  1,  2,  3, 12, 13, 14, 15 };
+    inputData[1] = {4,  5,  6,  7, 16, 17, 18, 19 };
+    inputData[2] = {8,  9, 10, 11, 20, 21, 22, 23 };
+
+    concat(inputData, splitShape, axis, outputData.data(), outputShape);
+
+    ASSERT_EQ(outputData.size(), this->data1.size());
+    ASSERT_EQ(outputData, this->data1);
+    ASSERT_EQ(outputShape, this->shape1);
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_Concat2) {
+
+    int32_t axis = 1;
+    std::vector<uint32_t> outputShape;
+    std::vector<float> outputData(this->data2.size());;
+    std::vector<uint32_t> splitShape= {1,1,5,3};
+    std::vector<std::vector<float>> inputData(4);
+    inputData[0] = {-15., -14.5, -14., -13.5, -13., -12.5, -12., -11.5, -11., -10.5, -10., -9.5, -9., -8.5, -8.};
+    inputData[1] = {-7.5, -7. , -6.5, -6. , -5.5, -5. , -4.5, -4. , -3.5, -3. , -2.5, -2. , -1.5, -1. , -0.5};
+    inputData[2] = {0. , 0.5, 1. , 1.5, 2. , 2.5, 3. , 3.5, 4. , 4.5, 5. , 5.5, 6. , 6.5, 7.};
+    inputData[3] = {7.5,  8. ,  8.5,  9. ,  9.5, 10. , 10.5, 11. , 11.5, 12. , 12.5, 13. , 13.5, 14. , 14.5};
+
+    concat(inputData, splitShape, axis, outputData.data(), outputShape);
+
+    ASSERT_EQ(outputData.size(), this->data2.size());
+    ASSERT_EQ(outputData, this->data2);
+    ASSERT_EQ(outputShape, this->shape2);
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_Concat3) {
+
+    int32_t axis = 3;
+    std::vector<uint32_t> splitShape;
+    std::vector<std::vector<float>> splitData;
+    slice(this->data1.data(), this->shape1, axis, splitData, splitShape);
+
+    std::vector<uint32_t> outputShape;
+    std::vector<float> outputData(this->data1.size());
+    concat(splitData, splitShape, axis, outputData.data(), outputShape);
+
+    ASSERT_EQ(outputData.size(), this->data1.size());
+    ASSERT_EQ(outputData, this->data1);
+    ASSERT_EQ(outputShape, this->shape1);
+}
+
+TEST_F(TestUtilitiesCpu, SANITY_Concat4) {
+
+    int32_t axis = -2;
+    std::vector<uint32_t> splitShape;
+    std::vector<std::vector<float>> splitData;
+    slice(this->data2.data(), this->shape2, axis, splitData, splitShape);
+    std::vector<uint32_t> expectedOutputShape= {1,4,1,3};
+    ASSERT_EQ(splitShape, expectedOutputShape);
+
+    std::vector<uint32_t> outputShape;
+    std::vector<float> outputData(this->data2.size());
+    concat(splitData, splitShape, axis, outputData.data(), outputShape);
+
+    ASSERT_EQ(outputData.size(), this->data2.size());
+    ASSERT_EQ(outputData, this->data2);
+    ASSERT_EQ(outputShape, this->shape2);
+
+}


### PR DESCRIPTION
- Introduces packing functionality to tensor quantizer
  - A packed tensor is vector of uint8_t format
  - by extension new trim functions are introduced for packing (only cpu)
  - All functions are propagated down to TensorQuantizationSim
- Introduces per channel quant/dequant and quant functionality
   - Per channel quant is quantization per axis (i.e slices of a tensor)
   - Functions are propagated down to TensorQuantizationSim
   - By product is that utilities functions are added for concatenation and slicing tensors
- Introduces dequant/dequant per channel/dequant packed
   - Adds functionality to dequantize a tensor in packed or standard quant format
   - Enables dequantize per channel
   - All functions are propagated down to TensorQuantizationSim
- Adds tests for new features

Signed-off-by: Akin Solomon <quic_akinlawo@quicinc.com>