### PR TITLE
Add support for Entropy quantization scheme

### DIFF
--- a/ModelOptimizations/DlQuantization/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/CMakeLists.txt
@@ -52,6 +52,8 @@ add_library(MoDlQuantization STATIC
       src/trim_functions.cpp
       src/trim_functions.hpp
 
+      src/EntropyEncodingAnalyzer.cpp
+      src/EntropyEncodingAnalyzer.h
       src/MseEncodingAnalyzer.cpp
       src/MseEncodingAnalyzer.h
       src/PercentileEncodingAnalyzer.cpp

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/Quantization.hpp
@@ -75,6 +75,10 @@ enum QuantizationMode
     // Compute the encoding by adjusting the min/max range of the tensor based on the mean square
     // error due to quantization of the tensor.
     QUANTIZATION_MSE,
+
+    // Compute the optimal quantization range (thresholds) for a tensor based on minimizing the
+    // Kullback-Leibler divergence.
+    QUANTIZATION_ENTROPY,
 };
 
 /**

--- a/ModelOptimizations/DlQuantization/src/EntropyEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/EntropyEncodingAnalyzer.cpp
@@ -1,0 +1,435 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <cassert>
+#include <cmath>
+#include <cstddef>
+#include <iostream>
+#include <numeric>
+#include <vector>
+
+
+#include "DlQuantization/Quantization.hpp"
+#include "math_functions.hpp"
+#include "quantization_utils.hpp"
+
+#include "EntropyEncodingAnalyzer.h"
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+std::vector<std::tuple<double, double>> EntropyEncodingAnalyzer<DTYPE>::getStatsHistogram() const
+{
+    // Return the collected histogram data.
+    PDF stats;
+    stats.xLeft.resize(PDF_SIZE);
+    stats.pdf.resize(PDF_SIZE);
+    double histMin      = this->_tensorProfilingParams.min;
+    double histMax      = this->_tensorProfilingParams.max;
+    double histBinWidth = (histMax - histMin) / PDF_SIZE;
+    double histSum      = std::accumulate(this->_tensorProfilingParams.histogram.begin(),
+                                     this->_tensorProfilingParams.histogram.end(), 0.f);
+    // Initialize the probability for each bucket and left sides of the buckets.
+    for (int i = 0; i < PDF_SIZE; ++i)
+    {
+        stats.pdf.push_back(this->_tensorProfilingParams.histogram[i] / histSum);
+    }
+    for (auto i = histMin; i <= histMax; i += histBinWidth)
+    {
+        stats.xLeft.push_back(i);
+    }
+
+    return getCollectedHistogram(stats);
+}
+
+template <typename DTYPE>
+void EntropyEncodingAnalyzer<DTYPE>::updateStats(const DTYPE* tensor, const size_t tensorSize,
+                                                 ComputationMode tensorCpuGpuMode)
+{
+    this->_statsUpdated = true;
+
+    // update Histogram
+    updateTensorHistogram(tensor, tensorSize, tensorCpuGpuMode, this->_tensorProfilingParams);
+}
+
+template <typename DTYPE>
+TfEncoding EntropyEncodingAnalyzer<DTYPE>::computeEncoding(uint8_t bw, bool useSymmetricEncodings,
+                                                           bool useStrictSymmetric, bool useUnsignedSymmetric) const
+{
+    TfEncoding encoding = {0, 0, 0, 0, 0};
+    DTYPE numSteps      = pow(2, bw) - 1;
+
+    // For strict symmetric mode, we make even number of buckets
+    if (useSymmetricEncodings && useStrictSymmetric)
+    {
+        numSteps -= 1;
+    }
+
+    if (this->_tensorProfilingParams.histogram.size() == 0)
+    {
+        if (this->_statsUpdated)
+        {
+            // Histogram has not been initialized yet, we have seen all zero data
+            // We generate a valid encoding that covers float 0
+            encoding.min    = -1;
+            encoding.max    = 1;
+            encoding.delta  = (encoding.max - encoding.min) / int(numSteps);
+            encoding.offset = floor(encoding.min / encoding.delta);
+            encoding.min    = encoding.offset * encoding.delta;
+            encoding.max    = encoding.min + int(numSteps) * encoding.delta;
+            encoding.bw     = bw;
+
+            return encoding;
+        }
+        else
+        {
+            // Histogram has not been initialized yet because we have not seen any data
+            // We return a zero encoding - which is a failure indicator
+            return encoding;
+        }
+    }
+
+    // Find the adjusted min and max
+    DTYPE aMin, aMax;
+
+    std::tie(aMin, aMax) = _optimizeKL(bw, useSymmetricEncodings, useStrictSymmetric, useUnsignedSymmetric);
+
+    // After Min and Max adjustment, the requirement that 0 be an exactly
+    // representable value must be met. Hence, extend the interval
+    // [aMin, aMax] to ensure that it contains 0.
+    aMin = std::min(aMin, DTYPE(0.f));
+    aMax = std::max(aMax, DTYPE(0.f));
+
+    assert(aMin <= aMax && "min must not be bigger than max");
+
+    return getComputedEncodings(bw, aMin, aMax, useSymmetricEncodings, useStrictSymmetric, useUnsignedSymmetric);
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> EntropyEncodingAnalyzer<DTYPE>::_findRangeOfAggregateStats() const
+{
+    return {this->_tensorProfilingParams.min, this->_tensorProfilingParams.max};
+}
+
+static void _conditionHistogram(double* hist, const size_t length)
+{
+    const double epsZero = 0.0001;
+    // If histogram is empty then return.
+    if (length == 0)
+    {
+        return;
+    }
+
+    // Get information about the zero values within the histogram.
+    std::vector<int> isZero(length);
+    size_t numZeros = 0;
+    for (size_t idx = 0, e = length; idx < e; idx++)
+    {
+        isZero[idx] = static_cast<int>(hist[idx] == 0.f);
+        numZeros += isZero[idx];
+    }
+
+    // If histogram is all zeros then return.
+    if (numZeros == length)
+    {
+        return;
+    }
+
+    // Compute epsilon to subtract from non-zero histogram values.
+    size_t numNonZeros = length - numZeros;
+    double epsNonZero  = epsZero * static_cast<double>(numZeros) / static_cast<double>(numNonZeros);
+
+    // If value to subtract from non-zero values is higher than 1.0 then return.
+    if (epsNonZero >= 1.0)
+    {
+        return;
+    }
+
+    // Perform histogram conditioning:
+    // - zero histogram values are increased with epsZero.
+    // - non-zero histogram values are decreased with epsNonZero.
+    for (size_t idx = 0, e = length; idx < e; idx++)
+    {
+        hist[idx] += epsZero * isZero[idx];
+        hist[idx] -= epsNonZero * (1 - isZero[idx]);
+    }
+}
+
+static double _computeKL(double* P, double* Q, size_t length)
+{
+    // Compute sum of P and Q to use for normalization.
+    double sumP = std::accumulate(P, P + length, 0.f);
+    double sumQ = std::accumulate(Q, Q + length, 0.f);
+
+    // optimizeKL function should stop KL divergence computation when P or Q
+    // distributions are all zeros. Hence P or Q distributions cannot be all
+    // zeros in computeKL function.
+    assert(sumP != 0 && "P distribution is all zeros!");
+    assert(sumQ != 0 && "Q distribution is all zeros!");
+
+    // Compute relative entropy.
+    double divergence = 0;
+    for (size_t idx = 0, e = length; idx < e; idx++)
+    {
+        P[idx] /= sumP;
+        Q[idx] /= sumQ;
+        if ((P[idx] > 0) && (Q[idx] > 0))
+        {
+            divergence += P[idx] * std::log(P[idx] / Q[idx]);
+        }
+    }
+    return divergence;
+}
+
+template <typename DTYPE>
+std::tuple<DTYPE, DTYPE> EntropyEncodingAnalyzer<DTYPE>::_optimizeKL(uint8_t bw, bool useSymmetricEncodings,
+                                                                     bool useStrictSymmetric,
+                                                                     bool useUnsignedSymmetric) const
+{
+    double histMin = this->_tensorProfilingParams.min;
+    double histMax = this->_tensorProfilingParams.max;
+
+    std::vector<double> hist;
+    // Incase of symmetric quantization adjust the histMin, histMax and rescale the hisogram.
+    if (useSymmetricEncodings && ((histMin < 0.0) || (!useUnsignedSymmetric)))
+    {
+        DTYPE absoluteMax = std::max(std::abs(histMax), std::abs(histMin));
+        DTYPE absoluteMin = -absoluteMax;
+        hist    = rescaleHistogram(this->_tensorProfilingParams.histogram, histMin, histMax, absoluteMin, absoluteMax);
+        histMin = absoluteMin;
+        histMax = absoluteMax;
+    }
+    else
+    {
+        hist = this->_tensorProfilingParams.histogram;
+    }
+
+    // Number of histogram bins.
+    const size_t numBins = hist.size();
+
+    // Number of quantized bins.
+    const size_t numQuantizedBins = 255;
+
+    // If the input histogram is empty or the number of histogram bins is smaller
+    // than numQuantizedBins then return the histogramthis->_tensorProfilingParams.histogram range.
+    if ((numBins == 0) || (numBins < numQuantizedBins) || (bw != 8))
+    {
+        return {histMin, histMax};
+    }
+
+    // Histogram bin width.
+    assert(histMin < histMax && "Invalid histogram min/max range!");
+    const double histBinWidth = (histMax - histMin) / (double) numBins;
+
+    // Optimal divergence value (minimum).
+    double divergenceOpt = std::numeric_limits<double>::infinity();
+
+    // Optimal threshold values for minimum divergence.
+    double thresholdMinOpt = histMin;
+    double thresholdMaxOpt = histMax;
+
+    // Initialize start/stop bin indices (inclusive) with the first and last bin.
+    size_t histWinIdxStart = 0;
+    size_t histWinIdxStop  = numBins - 1;
+
+    while ((histWinIdxStop - histWinIdxStart + 1) >= numQuantizedBins)
+    {
+        // Current histogram window size.
+        const size_t histWinSize = histWinIdxStop - histWinIdxStart + 1;
+
+        // Current histogram window raw pointer.
+        const double* histWinPtr = hist.data() + histWinIdxStart;
+
+        // Compute the reference distribution P as the input histogram saturated in
+        // the current window given by histWinIdxStart and histWinIdxStop.
+        std::vector<double> P(histWinSize);
+
+        // Saturate the histogram left.
+        double leftSum = 0;
+        for (size_t histIdx = 0; histIdx <= histWinIdxStart; histIdx++)
+        {
+            leftSum += hist[histIdx];
+        }
+        P.front() += leftSum;
+
+        // Extract the non-saturated part of the histogram.
+        for (size_t histIdx = histWinIdxStart + 1; histIdx < histWinIdxStop; histIdx++)
+        {
+            P[histIdx - histWinIdxStart] = hist[histIdx];
+        }
+
+        // Saturate the histogram right.
+        double rightSum = 0;
+        for (size_t histIdx = histWinIdxStop; histIdx < numBins; histIdx++)
+        {
+            rightSum += hist[histIdx];
+        }
+        P.back() += rightSum;
+
+        const double numMergedBins = static_cast<double>(histWinSize) / static_cast<double>(numQuantizedBins);
+
+        // Compute Q.
+        std::vector<double> Q(histWinSize, 0);
+        for (size_t qIdx = 0; qIdx < numQuantizedBins; qIdx++)
+        {
+            // Histogram window bin start index (inclusive) for this quantized bin.
+            const size_t idxStart = ceil(qIdx * numMergedBins);
+
+            // Histogram window bin stop index (exclusive) for this quantized bin.
+            // If last quantized bin then go to the end of the window.
+            const size_t idxStop = (qIdx < (numQuantizedBins - 1)) ? ceil((qIdx + 1) * numMergedBins) : histWinSize;
+
+            // Sum all the values for this quantized bin.
+            // Count all the positive values for this quantized bin to use for
+            // normalization.
+            double sum  = 0;
+            double norm = 0;
+            for (size_t idx = idxStart; idx < idxStop; idx++)
+            {
+                sum += histWinPtr[idx];
+                norm += (histWinPtr[idx] != 0);
+            }
+
+            // Compute Q by expanding and normalizing the quantized bins.
+            if (norm != 0)
+            {
+                for (size_t idx = idxStart; idx < idxStop; idx++)
+                {
+                    if (histWinPtr[idx])
+                    {
+                        Q[idx] = sum / static_cast<double>(norm);
+                    }
+                }
+            }
+        }
+
+        // For one sided distributions, there is a possibility that all the values
+        // in the shrinked histogram are zeros. In such cases, Q distribution is
+        // all zeros and the KL divergence value is infinity. Hence, shrinking of
+        // the histogram further and analyzing for minimum KL divergence value is
+        // redundant.
+        // Break the histogram shrinking and KL divergence computation when all
+        // elements in P or Q are zeros.
+        double sumP = std::accumulate(P.begin(), P.end(), 0.f);
+        double sumQ = std::accumulate(Q.begin(), Q.end(), 0.f);
+        if (sumP == 0 || sumQ == 0)
+        {
+            break;
+        }
+
+        // Compute the KL divergence metric and check for optimal values.
+        // Condition the histograms P and Q.
+        _conditionHistogram(P.data(), P.size());
+        _conditionHistogram(Q.data(), Q.size());
+
+        // Compute the divergence of P with respect to Q.
+        double divergence = _computeKL(P.data(), Q.data(), P.size());
+
+        // Check if current divergence is the new optimal.
+        if (divergence < divergenceOpt)
+        {
+            // Update optimal divergence with current divergence.
+            divergenceOpt = divergence;
+
+            // Update optimal thresholds with current thresholds.
+            thresholdMinOpt = histMin + histWinIdxStart * histBinWidth;
+            thresholdMaxOpt = histMin + (histWinIdxStop + 1) * histBinWidth;
+        }
+
+        // Update histogram window for next iteration.
+        if (useSymmetricEncodings || useStrictSymmetric)
+        {
+            // For symmetric schema we shrink the histogram window symmetrically.
+            histWinIdxStart++;
+            histWinIdxStop--;
+        }
+        else
+        {
+            // For asymmetric schema we shrink the histogram window either left-only,
+            // right-only or symmetrically depending on which case has minimum
+            // histogram data loss.
+            double symmLoss  = hist[histWinIdxStart] + hist[histWinIdxStop];
+            double leftLoss  = hist[histWinIdxStart] + hist[histWinIdxStart + 1];
+            double rightLoss = hist[histWinIdxStop] + hist[histWinIdxStop - 1];
+
+            std::vector<double> loss = {symmLoss, leftLoss, rightLoss};
+            auto lossMinIdx          = std::distance(loss.begin(), std::min_element(loss.begin(), loss.end()));
+
+            // The requirement that 0 be an exactly representable value must be met
+            // during min/max adjustments with calibration.
+            // If adjusted min > 0, shrink histogram only on the right
+            // If adjusted max < 0, shrink histogram only on the left
+            if ((lossMinIdx == 0 && (histMin + (histWinIdxStart + 1) * histBinWidth) > 0) ||
+                (lossMinIdx == 1 && (histMin + (histWinIdxStart + 2) * histBinWidth) > 0))
+            {
+                lossMinIdx = 2;
+            }
+            else if ((lossMinIdx == 0 && (histMin + histWinIdxStop * histBinWidth) < 0) ||
+                     (lossMinIdx == 2 && (histMin + (histWinIdxStop - 1) * histBinWidth) < 0))
+            {
+                lossMinIdx = 1;
+            }
+
+            if (lossMinIdx == 0)
+            {
+                // Saturate symmetrically.
+                histWinIdxStart++;
+                histWinIdxStop--;
+            }
+            else if (lossMinIdx == 1)
+            {
+                // Saturate left.
+                histWinIdxStart += 2;
+            }
+            else
+            {
+                // Saturate right.
+                histWinIdxStop -= 2;
+            }
+        }
+    }
+
+    return {thresholdMinOpt, thresholdMaxOpt};
+}
+
+// Explicit instantiations
+template class EntropyEncodingAnalyzer<double>;
+
+template class EntropyEncodingAnalyzer<float>;
+
+}   // namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/EntropyEncodingAnalyzer.h
+++ b/ModelOptimizations/DlQuantization/src/EntropyEncodingAnalyzer.h
@@ -1,0 +1,106 @@
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#ifndef DL_QUANTIZATION_ENTROPY_ENCODING_ANALYZER_H
+#define DL_QUANTIZATION_ENTROPY_ENCODING_ANALYZER_H
+
+#include "math_functions.hpp"
+#include <DlQuantization/IQuantizationEncodingAnalyzer.hpp>
+
+namespace DlQuantization
+{
+template <typename DTYPE>
+class EntropyEncodingAnalyzer : public IQuantizationEncodingAnalyzer<DTYPE>
+{
+public:
+    /**
+     * Updates internal PDF stats given a tensor.
+     * Intent is to keep a histogram of all the values that we have seen over multiple instances of a tensor
+     * @param tensor Reference to a tensor
+     * @param tensorSize Size of the tensor (number of elements)
+     * @param tensorCpuGpuMode Indicates if the tensor is in CPU or GPU memory
+     */
+    void updateStats(const DTYPE* tensor, const size_t tensorSize, ComputationMode tensorCpuGpuMode) override;
+
+    /***
+     * Compute the encodings using the collected histogram stats by minimizing the mean square
+     * error due to quantization of the tensor.
+     * @param bw Bitwidth to use for computing encodings
+     * @param useSymmetricEncodings If true, compute symmetric encodings
+     * @param useStrictSymmetric If true, compute symmetric encodings with even number of buckets
+     * @param useUnsignedSymmetric If true, compute asymmetric encodings
+     * @return Computed encoding
+     */
+    TfEncoding computeEncoding(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                               bool useUnsignedSymmetric) const override;
+
+
+    /**
+     * @brief Returns a histogram that represents a PDF of tensor values seen by this encoding analyzer so far
+     *
+     * @return Histogram of statistics. The histogram returned is a vector of buckets. Each bucket is a tuple of
+     * two values - the float value representing the left edge of the bucket and a PDF of the values in this bucket
+     * relative to all the values seen across all buckets
+     */
+    std::vector<std::tuple<double, double>> getStatsHistogram() const override;
+
+private:
+    TensorProfilingParams _tensorProfilingParams;
+    bool _statsUpdated = false;
+
+    /**
+     * Find range (min, max) of the aggregated stats
+     * @return Tuple of min and max values
+     */
+    std::tuple<DTYPE, DTYPE> _findRangeOfAggregateStats() const;
+
+    /**
+     * @brief Adjust the min/max range of tensor values by minimizing KL divergence
+     *
+     * @param bw Bitwidth to use for computing encodings
+     * @param useSymmetricEncodings If true, compute symmetric encodings
+     * @param useStrictSymmetric If true, compute symmetric encodings with even number of buckets
+     * @param useUnsignedSymmetric If true, compute asymmetric encodings
+     * @return Tuple of <best min, best max> to be used for calculating the best delta and offset
+     */
+    std::tuple<DTYPE, DTYPE> _optimizeKL(uint8_t bw, bool useSymmetricEncodings, bool useStrictSymmetric,
+                                         bool useUnsignedSymmetric) const;
+};
+
+}   // namespace DlQuantization
+
+#endif   // DL_QUANTIZATION_ENTROPY_ENCODING_ANALYZER_H

--- a/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
+++ b/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
@@ -45,6 +45,7 @@
 #include "DlQuantization/IQuantizer.hpp"
 #include "DlQuantization/Quantization.hpp"
 #include "DlQuantization/QuantizerFactory.hpp"
+#include "EntropyEncodingAnalyzer.h"
 #include "MainQuantizationClass.hpp"
 #include "MseEncodingAnalyzer.h"
 #include "PercentileEncodingAnalyzer.h"
@@ -78,6 +79,10 @@ std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>> getEncodingAnalyzerInstanc
     else if (quantization_mode == QUANTIZATION_MSE)
     {
         return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new MseEncodingAnalyzer<DTYPE>);
+    }
+    else if (quantization_mode == QUANTIZATION_ENTROPY)
+    {
+        return std::unique_ptr<IQuantizationEncodingAnalyzer<DTYPE>>(new EntropyEncodingAnalyzer<DTYPE>);
     }
     else
     {

--- a/ModelOptimizations/DlQuantization/src/math_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cpp
@@ -474,6 +474,210 @@ std::tuple<DTYPE, DTYPE> findOriginalRange(const PDF& pdf)
     return std::tuple<DTYPE, DTYPE>(minVal, maxVal);
 }
 
+template <typename DTYPE>
+void updateTensorHistogram(const DTYPE* data, int tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp)
+{
+    switch (mode_cpu_gpu)
+    {
+    case COMP_MODE_CPU:
+        updateTensorHistogram_cpu(data, tensorSize, tpp);
+        break;
+    case COMP_MODE_GPU:
+    {
+#ifdef GPU_QUANTIZATION_ENABLED
+        // Fall back to CPU mode.
+        DTYPE* data_h = (DTYPE*) malloc(sizeof(DTYPE) * tensorSize);
+        CudaMemCpy(data_h, data, tensorSize * sizeof(DTYPE), CudaMemcpyDirection::DEVICE_TO_HOST);
+        updateTensorHistogram_cpu(data_h, tensorSize, tpp);
+        free(data_h);
+#else
+        throw runtime_error("Not compiled for GPU mode.");
+#endif
+    }
+    break;
+    default:
+        throw runtime_error("Unknown computation mode.");
+        break;
+    }
+}
+
+/// Gen a bin number to insert \p value into the histogram which has \p nBins
+/// with \p minValue and binWidth in histogram.
+static size_t getBin(size_t nBins, float binWidth, float minValue, float value)
+{
+    size_t result = binWidth == 0 ? 0 : std::min(static_cast<size_t>((value - minValue) / binWidth), nBins - 1);
+    return result;
+}
+
+template <typename DTYPE>
+void updateTensorHistogram_cpu(const DTYPE* data, int tensorSize, TensorProfilingParams& tpp)
+{
+    double minInput = GetMin(data, tensorSize, COMP_MODE_CPU);
+    double maxInput = GetMax(data, tensorSize, COMP_MODE_CPU);
+
+    if ((minInput == 0) && (maxInput == 0))
+    {
+        // Special case, we don't have a histogram initialized, but we have a zero tensor here
+        // No point in trying to initialize the histogram using this
+        return;
+    }
+
+    // Make sure we have a non-zero range.
+    if (minInput == maxInput)
+    {
+        maxInput = std::max(maxInput, minInput + (DTYPE) 0.01);
+    }
+
+    // Check if we need to initialize the Histogram
+    if (0 == tpp.histogram.size())
+    {
+        tpp.histogram = std::vector<double>(PDF_SIZE, 0);
+        tpp.min       = minInput;
+        tpp.max       = maxInput;
+    }
+
+    // Check if we need to rescale histogram.
+    if (minInput < tpp.min || maxInput > tpp.max)
+    {
+        double newMin = std::min(minInput, tpp.min);
+        double newMax = std::max(maxInput, tpp.max);
+
+        double destBinWidth = (static_cast<double>(newMax) - newMin) / PDF_SIZE;
+        double srcBinWidth  = (static_cast<double>(tpp.max) - tpp.min) / PDF_SIZE;
+
+        std::vector<double> scaledHistogram(PDF_SIZE, 0);
+
+        for (size_t i = 0; i < PDF_SIZE; ++i)
+        {
+            if (tpp.histogram[i] == 0)
+                continue;
+
+            double srcBinBegin = tpp.min + srcBinWidth * i;
+            size_t destBin     = (srcBinBegin - newMin) / destBinWidth;
+            double destBinEnd  = newMin + destBinWidth * (destBin + 1);
+
+            double srcBinEnd = srcBinBegin + srcBinWidth;
+
+            // Calculate how much we need to redistribute.
+            double dstBinCnt =
+                std::min(static_cast<double>(round((destBinEnd - srcBinBegin) / srcBinWidth * tpp.histogram[i])),
+                            tpp.histogram[i]);
+
+            size_t newBin = getBin(PDF_SIZE, destBinWidth, newMin, srcBinBegin);
+            scaledHistogram[newBin] += dstBinCnt;
+
+            if (dstBinCnt < tpp.histogram[i])
+            {
+                size_t newBin = getBin(PDF_SIZE, destBinWidth, newMin, srcBinBegin + destBinWidth);
+                scaledHistogram[newBin] += tpp.histogram[i] - dstBinCnt;
+            }
+        }
+
+        // Copy scaled histogram back to the existing histogram.
+        for (size_t i = 0, e = scaledHistogram.size(); i < e; ++i)
+        {
+            assert(scaledHistogram[i] >= 0 && "Invalid rescaled histogram value, it must be non-negative.");
+            tpp.histogram[i] = scaledHistogram[i];
+        }
+
+        // Update global min and max.
+        tpp.min = newMin;
+        tpp.max = newMax;
+    }
+
+    float binWidth = (tpp.max - tpp.min) / PDF_SIZE;
+    // Go through all data points and add them to the histogram.
+    for (int i = 0; i < tensorSize; ++i)
+    {
+        size_t newBin = getBin(PDF_SIZE, binWidth, tpp.min, data[i]);
+        tpp.histogram[newBin] += 1;
+    }
+    tpp.iterations++;
+}
+
+std::vector<double> rescaleHistogram(const std::vector<double>& srcHist, const double srcHistMin,
+                                     const double srcHistMax, const double destHistMin, const double destHistMax)
+{
+    // If histogram is empty then return.
+    if (srcHist.size() == 0)
+    {
+        return srcHist;
+    }
+
+    // Check if we need to rescale the histogram.
+    assert(srcHistMin < srcHistMax && "Invalid source histogram min/max range!");
+    assert(destHistMin < destHistMax && "Invalid destination histogram min/max range!");
+    if ((srcHistMin == destHistMin) && (srcHistMax == destHistMax))
+    {
+        return srcHist;
+    }
+
+    // Number of histogram bins and bin widths.
+    const size_t numBins      = srcHist.size();
+    const double srcBinWidth  = (static_cast<double>(srcHistMax) - srcHistMin) / numBins;
+    const double destBinWidth = (static_cast<double>(destHistMax) - destHistMin) / numBins;
+
+    // Iterate the source bins and distribute into the destination bins.
+    std::vector<double> destHist(numBins, 0);
+    for (size_t srcBinIdx = 0; srcBinIdx < numBins; srcBinIdx++)
+    {
+        // Get current source bin value.
+        double srcBinVal = srcHist[srcBinIdx];
+        if (srcBinVal == 0)
+        {
+            continue;
+        }
+
+        // Get source bin start/stop values for this bin.
+        double srcBinStart = srcHistMin + srcBinIdx * srcBinWidth;
+        double srcBinStop  = srcHistMin + (srcBinIdx + 1) * srcBinWidth;
+
+        // Get destination bin indices (inclusive) which overlap with the current
+        // source bin.
+        double dstBinIdxStartF = std::floor((srcBinStart - destHistMin) / destBinWidth);
+        double dstBinIdxStopF  = std::ceil((srcBinStop - destHistMin) / destBinWidth);
+        size_t dstBinIdxStart  = static_cast<size_t>(std::max(dstBinIdxStartF, 0.0));
+        size_t dstBinIdxStop   = static_cast<size_t>(std::max(dstBinIdxStopF, 0.0));
+
+        // Upper saturate the destination bin indices.
+        if (dstBinIdxStart >= numBins)
+        {
+            dstBinIdxStart = numBins - 1;
+        }
+        if (dstBinIdxStop >= numBins)
+        {
+            dstBinIdxStop = numBins - 1;
+        }
+
+        // Redistribute the source bin into all the destination bins.
+        // Only integer values will be distributed.
+        double srcBinRem = srcBinVal;
+        for (size_t destBinIdx = dstBinIdxStart; destBinIdx <= dstBinIdxStop; destBinIdx++)
+        {
+            // Get destination bin start/stop values for this bin.
+            double destBinStart = destHistMin + destBinIdx * destBinWidth;
+            double destBinStop  = destHistMin + (destBinIdx + 1) * destBinWidth;
+
+            // Get source/destination overlap boundaries and ratio.
+            double overlapStart = std::max(srcBinStart, destBinStart);
+            double overlapStop  = std::min(srcBinStop, destBinStop);
+            double overlapRatio = (overlapStop - overlapStart) / srcBinWidth;
+            overlapRatio        = overlapRatio >= 0.0f ? overlapRatio : 0.0f;
+            overlapRatio        = overlapRatio <= 1.0f ? overlapRatio : 1.0f;
+
+            // Compute distribution value.
+            double distVal = std::round(overlapRatio * srcBinVal);
+            distVal        = distVal <= srcBinRem ? distVal : srcBinRem;
+
+            // Distribute value.
+            destHist[destBinIdx] += distVal;
+            srcBinRem -= distVal;
+        }
+    }
+
+    return destHist;
+}
+
 // Explicit instantiations
 template double GetMax(const double* data, int cnt, ComputationMode mode_cpu_gpu);
 
@@ -490,5 +694,11 @@ template void UpdatePdf(const float* data, int cnt, ComputationMode mode_cpu_gpu
 template std::tuple<double, double> findOriginalRange(const PDF& pdf);
 
 template std::tuple<float, float> findOriginalRange(const PDF& pdf);
+
+template void updateTensorHistogram(const double* data, int tensorSize, ComputationMode mode_cpu_gpu,
+                                    TensorProfilingParams& tpp);
+
+template void updateTensorHistogram(const float* data, int tensorSize, ComputationMode mode_cpu_gpu,
+                                    TensorProfilingParams& tpp);
 
 }   // End of namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/math_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.hpp
@@ -66,6 +66,16 @@ struct PDF
     int iterations;
 };
 
+// Profiling parameters of a tensor consisting in the global minimum and global
+// maximum values and also the histogram obtained during profiling.
+struct TensorProfilingParams
+{
+    double min;
+    double max;
+    std::vector<double> histogram;
+    int iterations;
+};
+
 // Number of buckets in histogram which we use to capture the dynamic range.
 const int PDF_SIZE = 512;
 
@@ -158,6 +168,28 @@ std::vector<std::tuple<double, double>> getCollectedHistogram(const PDF& pdf);
 
 template <typename DTYPE>
 std::tuple<DTYPE, DTYPE> findOriginalRange(const PDF& pdf);
+
+/**
+ * @brief Generate input tensor histogram based on the input tensor and existing
+ * histogram.
+ * @param data The number distribution for which we create a density function.
+ * @param tensorSize The number of data points.
+ * @param tpp histogram of float numbers seen so far.
+ */
+template <typename DTYPE>
+void updateTensorHistogram(const DTYPE* data, int tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp);
+
+template <typename DTYPE>
+void updateTensorHistogram_cpu(const DTYPE* data, int tensorSize, TensorProfilingParams& tpp);
+
+/**
+ * @brief Function to rescale the input histogram srcHist initially computed in the
+ * range srcHistMin and srcHistMax to a new range given by destHistMin
+ * and destHistMax. The rescaled histogram has the same number of bins as
+ * the input histogram.
+ */
+std::vector<double> rescaleHistogram(const std::vector<double>& srcHist, const double srcHistMin,
+                                     const double srcHistMax, const double destHistMin, const double destHistMax);
 
 // GPU implementations...
 #ifdef GPU_QUANTIZATION_ENABLED

--- a/ModelOptimizations/DlQuantization/test/CMakeLists.txt
+++ b/ModelOptimizations/DlQuantization/test/CMakeLists.txt
@@ -54,7 +54,8 @@ add_executable(MoDlQuantizationTest
       TestTensorQuantizer.cpp
       TestUtilities.cpp
       TestPercentileEncodingAnalyzer.cpp
-      TestMseEncodingAnalyzer.cpp)
+      TestMseEncodingAnalyzer.cpp
+      TestEntropyEncodingAnalyzer.cpp)
 
 if (ENABLE_CUDA)
     target_compile_options(MoDlQuantizationTest

--- a/ModelOptimizations/DlQuantization/test/TestEntropyEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestEntropyEncodingAnalyzer.cpp
@@ -1,0 +1,315 @@
+//==============================================================================
+//
+//  @@-COPYRIGHT-START-@@
+//
+//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without
+//  modification, are permitted provided that the following conditions are met:
+//
+//  1. Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//
+//  2. Redistributions in binary form must reproduce the above copyright notice,
+//     this list of conditions and the following disclaimer in the documentation
+//     and/or other materials provided with the distribution.
+//
+//  3. Neither the name of the copyright holder nor the names of its contributors
+//     may be used to endorse or promote products derived from this software
+//     without specific prior written permission.
+//
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+//  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+//  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+//  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+//  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+//  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+//  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+//  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+//  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+//  POSSIBILITY OF SUCH DAMAGE.
+//
+//  SPDX-License-Identifier: BSD-3-Clause
+//
+//  @@-COPYRIGHT-END-@@
+//
+//==============================================================================
+
+#include <gtest/gtest.h>
+#include <random>
+#include <vector>
+
+#include "test_quantization_lib.hpp"
+#include <DlQuantization/TensorQuantizer.h>
+#include <EntropyEncodingAnalyzer.h>
+#include <TfEnhancedEncodingAnalyzer.h>
+using namespace DlQuantization;
+
+template <typename TypeParam>
+class TestEntropyEncodingAnalyzer : public ::testing::Test
+{
+};
+// Test on CPU and GPU with float and double
+TYPED_TEST_CASE(TestEntropyEncodingAnalyzer, TestDataTypesAndDevices);
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, Asymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    double min = std::numeric_limits<double>::max();
+    double max = std::numeric_limits<double>::min();
+    // Use larger tensor size to avoid ending up with calibrated min, max same as
+    // original min, max 100000
+    unsigned int tensorCount = 100000;
+    //  unsigned int tensorCount = 20;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        min       = std::min(min, double(tensor[i]));
+        max       = std::max(max, double(tensor[i]));
+    }
+
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, false, false, false);
+
+    std::cout << "Absolute Min: " << min << std::endl;
+    std::cout << "Absolute Max: " << max << std::endl;
+
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    // We know we have a normal distribution. We expect the encoding to cover
+    // at least 2 standard deviations, and at most 6.
+    std::cout << "mean - 6 * stddev: " << mean - 6 * stddev << "\n";
+    std::cout << "mean - 2 * stddev: " << mean - 2 * stddev << "\n";
+    std::cout << "mean + 2 * stddev: " << mean + 2 * stddev << "\n";
+    std::cout << "mean + 6 * stddev: " << mean + 6 * stddev << "\n";
+    EXPECT_GT(encoding.min, mean - 6 * stddev);
+    EXPECT_LT(encoding.min, mean - 2 * stddev);
+    EXPECT_GT(encoding.max, mean + 2 * stddev);
+    EXPECT_LT(encoding.max, mean + 6 * stddev);
+}
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, Symmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 100000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -128);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, StrictSymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 100000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, true, false);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << encoding.min << std::endl;
+    std::cout << encoding.max << std::endl;
+    std::cout << encoding.delta << std::endl;
+    std::cout << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_GT(encoding.min, absoluteMin);
+    EXPECT_LT(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 254);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.offset, -127);
+    EXPECT_EQ(encoding.bw, 8);
+    EXPECT_EQ(encoding.min, -encoding.max);
+}
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, SymmetricUnsigned)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer;
+
+    float mean   = 2;
+    float stddev = 2;
+    std::normal_distribution<dataType> distribution(mean, stddev);
+    std::mt19937 generator(1);
+
+    unsigned int tensorCount = 100000;
+    std::vector<dataType> tensor(tensorCount);
+
+    for (unsigned int i = 0; i < tensorCount; i++)
+    {
+        tensor[i] = distribution(generator);
+        tensor[i] = std::max(tensor[i], (dataType) 0.0);
+    }
+    Blob<TypeParam> tensorBlob(tensor.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer.updateStats(tensorBlob.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding = analyzer.computeEncoding(8, true, false, true);
+
+    dataType absoluteMin = *std::min_element(tensor.begin(), tensor.end());
+    dataType absoluteMax = *std::max_element(tensor.begin(), tensor.end());
+
+    std::cout << "Absolute Min: " << absoluteMin << std::endl;
+    std::cout << "Absolute Max: " << absoluteMax << std::endl;
+    std::cout << "Encoding Min: " << encoding.min << std::endl;
+    std::cout << "Encoding Max: " << encoding.max << std::endl;
+    std::cout << "Encoding Delta: " << encoding.delta << std::endl;
+    std::cout << "Encoding Offset: " << encoding.offset << std::endl;
+
+    absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
+    absoluteMin = -absoluteMax;
+
+    EXPECT_EQ(encoding.min, 0);
+    EXPECT_LE(encoding.max, absoluteMax);
+
+    EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
+    EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);
+    EXPECT_EQ(encoding.bw, 8);
+}
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, AllSameValuesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer1;
+
+    unsigned int tensorCount = 100;
+    std::vector<dataType> tensor1(tensorCount, 4);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding1.min, 0);   // 0 is included
+    EXPECT_GE(encoding1.max, 3.9);
+
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer2;
+
+    std::vector<dataType> tensor2(tensorCount, -5);
+    Blob<TypeParam> tensorBlob2(tensor2.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer2.updateStats(tensorBlob2.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding2 = analyzer2.computeEncoding(8, false, false, false);
+    EXPECT_LE(encoding2.min, -4.99992);
+    EXPECT_GE(encoding2.max, 0);   // 0 is included
+}
+
+TYPED_TEST(TestEntropyEncodingAnalyzer, AllZeroesAsymmetric)
+{
+    typedef typename TypeParam::dataType dataType;
+
+    // Instantiate EntropyEncodingAnalyzer
+    DlQuantization::EntropyEncodingAnalyzer<dataType> analyzer1;
+
+    unsigned int tensorCount = 6000;
+    std::vector<dataType> tensor1(tensorCount, 0);
+    Blob<TypeParam> tensorBlob1(tensor1.data(), tensorCount);
+
+    // Update the stats using these tensor values
+    analyzer1.updateStats(tensorBlob1.getDataPtrOnDevice(), tensorCount, TypeParam::modeCpuGpu);
+
+    // Get the encodings
+    DlQuantization::TfEncoding encoding1 = analyzer1.computeEncoding(8, false, false, false);
+
+    EXPECT_NEAR(encoding1.min, -1.00392, 0.0001);
+    EXPECT_NEAR(encoding1.max, 0.996078, 0.0001);
+    EXPECT_EQ(encoding1.offset, -128);
+    EXPECT_EQ(encoding1.bw, 8);
+} 

--- a/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
@@ -75,6 +75,7 @@ PYBIND11_MODULE(libpymo, m)
         .value("QUANTIZATION_RANGE_LEARNING", QuantizationMode::QUANTIZATION_RANGE_LEARNING)
         .value("QUANTIZATION_PERCENTILE", QuantizationMode::QUANTIZATION_PERCENTILE)
         .value("QUANTIZATION_MSE", QuantizationMode::QUANTIZATION_MSE)
+        .value("QUANTIZATION_ENTROPY", QuantizationMode::QUANTIZATION_ENTROPY)
         .export_values();
 
     py::enum_<LayerInOut>(m, "LayerInOut")

--- a/TrainingExtensions/torch/test/python/test_entropy_quantization_scheme.py
+++ b/TrainingExtensions/torch/test/python/test_entropy_quantization_scheme.py
@@ -1,0 +1,87 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+import pytest
+import torch
+import torch.nn as nn
+from aimet_torch.quantsim import QuantizationSimModel
+
+class TestEntropySchemeStaticGrid:
+    """ Test Entropy quantization scheme """ 
+
+    def test_model_with_entropy_scheme(self):
+        """ Test entropy scheme """
+
+        class Model(nn.Module):
+            def __init__(self):
+                super(Model, self).__init__()
+                self.conv1 = torch.nn.Conv2d(3, 16, 3, padding="same")
+                self.conv2 = torch.nn.Conv2d(16, 16, 3, padding="same")
+
+            def forward(self, *inputs):
+                x = self.conv1(inputs[0])
+                x = self.conv2(x)
+                return x
+
+        model = Model()
+        dummy_input = torch.rand(1, 3, 224, 224)
+
+        def forward_pass(model, args):
+            model.eval()
+            model(dummy_input)
+
+        sim1 = QuantizationSimModel(model, dummy_input, quant_scheme="tf")
+        sim1.compute_encodings(forward_pass, None)
+
+        sim2 = QuantizationSimModel(model, dummy_input, quant_scheme="tf")
+
+        # Overwrite the quantization scheme
+        import aimet_common.libpymo as libpymo
+        from aimet_common.defs import MAP_QUANT_SCHEME_TO_PYMO
+        MAP_QUANT_SCHEME_TO_PYMO['entropy'] = libpymo.QuantizationMode.QUANTIZATION_ENTROPY
+
+        for quant_wrapper in sim2.quant_wrappers():
+            for quantizer in quant_wrapper.input_quantizers:
+                quantizer.quant_scheme = 'entropy'
+            for quantizer in quant_wrapper.output_quantizers:
+                quantizer.quant_scheme = 'entropy'
+            for param_quantizer in quant_wrapper.param_quantizers.values():
+                param_quantizer.quant_scheme = 'entropy'
+
+        sim2.compute_encodings(forward_pass, None)
+
+        # Compare the encoding max between tf and entropy quantization scheme
+        assert sim1.model.conv1.output_quantizers[0].encoding.max != sim2.model.conv1.output_quantizers[0].encoding.max


### PR DESCRIPTION
Signed-off-by: Gopinath Rathinam <quic_grathina@quicinc.com>

Summary:
Entropy calibration scheme adjust the min and max ranges of the tensor to be quantized by computing the KL divergence using multiple candidate distributions and choose the optimal candidate for which KL divergence value is least.

This PR also includes new histogram collection method which is required for entropy calibration.