### PR TITLE
Add Compute Partial Encoding To TensorQuantizer

### DIFF
--- a/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
@@ -95,6 +95,16 @@ public:
                                  bool useUnsignedSymmetric, bool useStrictSymmetric);
 
     /**
+     * @brief Compute the encoding for this tensor given partial TfEncoding data i.e
+     *        bw, min/max and no delta/offset
+     *        bw, delta/offset and no min/max
+     * @param[in/out] encoding Partial encoding containing min, max, delta and offset values
+     * @relates EncodingAnalyzer::computeEncoding
+     */
+    void computePartialEncoding(uint8_t bw, TfEncoding& encoding, bool useSymmetricEncodings,
+                                bool useUnsignedSymmetric, bool useStrictSymmetric);
+
+    /**
      * Convert a tensor from float to quantized int and back to float
      * @param input Input tensor
      * @param tensorSize Size of the input tensor (number of tensor elements)

--- a/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
+++ b/ModelOptimizations/DlQuantization/src/QuantizerFactory.cpp
@@ -66,7 +66,8 @@ IQuantizer<DTYPE>* GetQuantizerInstance(const std::vector<std::string>& layer_na
 
 std::unique_ptr<GraphQuantizer> getGraphQuantizerInstance (const std::vector<std::string>& tensorNames,
                                                           ComputationMode modeCpuGpu,
-                                                          QuantizationMode quantMode){
+                                                          QuantizationMode quantMode)
+{
     return std::unique_ptr<GraphQuantizer>(new GraphQuantizer(tensorNames, modeCpuGpu, quantMode));
 }
 

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.cpp
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.cpp
@@ -56,21 +56,6 @@ TensorQuantizationSim<DTYPE>::TensorQuantizationSim()
 {
 }
 
-template <typename DTYPE>
-void TensorQuantizationSim<DTYPE>::gateMinMax(double& encodingMin, double& encodingMax)
-{
-
-        double epsilon = 1e-5;
-        // Additional handling to retain zero in range
-        // encodingMin can be at maximum 0.0
-        encodingMin = std::min(encodingMin, 0.0);
-
-        // encodingMax can be at minimum 0.0
-        encodingMax = std::max(encodingMax, 0.0);
-
-        // handle case where encodingMin == encodingMax
-        encodingMax = std::max(encodingMax, encodingMin + epsilon);
-}
 
 template <typename DTYPE>
 void TensorQuantizationSim<DTYPE>::fillQuantizeInfo(TfEncoding& encoding, DlQuantization::ComputationMode& cpuGpuMode,

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizationSim.h
@@ -56,8 +56,6 @@ class TensorQuantizationSim : public ITensorQuantizationSim<DTYPE>
 public:
     explicit TensorQuantizationSim();
 
-    void gateMinMax(double& encodingMin, double& encodingMax);
-
     void quantizeDequantizeTensor(const DTYPE* inputTensorData, size_t inputTensorCount, DTYPE* outputTensorData,
                                   double encodingMin, double encodingMax, uint8_t bw, RoundingMode roundMode,
                                   bool use_cuda) override;

--- a/ModelOptimizations/DlQuantization/src/quantization_utils.cpp
+++ b/ModelOptimizations/DlQuantization/src/quantization_utils.cpp
@@ -39,11 +39,11 @@
 
 #include "quantization_utils.hpp"
 #include "DlQuantization/Quantization.hpp"
-#include <stdexcept>
 #include <cmath>
 #include <cstdlib>
 #include <iostream>
 #include <numeric>
+#include <stdexcept>
 
 #include "math_functions.hpp"
 #ifdef GPU_QUANTIZATION_ENABLED
@@ -119,39 +119,125 @@ TfEncoding getComputedEncodings(uint8_t bw, double min, double max, bool useSymm
     return encoding;
 }
 
+void gateMinMax(double& encodingMin, double& encodingMax)
+{
+    // Additional handling to retain zero in range
+    // encodingMin can be at maximum 0.0
+    encodingMin = std::min(encodingMin, 0.0);
+
+    // encodingMax can be at minimum 0.0
+    encodingMax = std::max(encodingMax, 0.0);
+
+    // handle case where encodingMin == encodingMax
+    encodingMax = std::max(encodingMax, encodingMin + EPSILON);
+}
+
+void computeMinMaxRangeFromDeltaOffset(uint8_t bw, TfEncoding& encoding, bool useSymmetricEncodings,
+                                       bool useUnsignedSymmetric, bool useStrictSymmetric)
+{
+    auto origEncoding = encoding;
+    if (encoding.bw == 0)
+    {
+        throw std::invalid_argument("Encodings must have a valid non-zero bitwidth");
+    }
+
+    if (origEncoding.min != 0 && origEncoding.max != 0)
+    {
+        throw std::invalid_argument("Encoding min and max must be zero to use this function");
+    }
+
+    if (origEncoding.delta == 0 && origEncoding.offset > 0)
+    {
+        throw std::invalid_argument("Encoding must have a valid non-zero delta/offset if min and max are zero");
+    }
+
+
+    auto numSteps = pow(2, bw) - 1;
+
+    if (useSymmetricEncodings && useStrictSymmetric)
+    {
+        numSteps -= 1;
+    }
+
+    // set up min and max values
+    // Note delta and offset are assumed to allow for zero to be quantizable
+    encoding.min = encoding.offset * encoding.delta;
+
+    // factor in symmetry into max calculation
+    if (useSymmetricEncodings && ((encoding.min < 0.0) || (!useUnsignedSymmetric)))
+    {
+        auto numPositiveSteps = std::floor(numSteps / 2);
+        encoding.max          = encoding.delta * numPositiveSteps;
+    }
+    else
+    {
+        encoding.max = encoding.delta * numSteps + encoding.min;
+    }
+
+    // check that min, max are not too close
+    // It's unlikely but we can still gate if needed
+    if ((encoding.max - encoding.min < EPSILON))
+    {
+        gateMinMax(encoding.min, encoding.max);
+    }
+}
+
+void computeDeltaAndOffsetFromMinMax(uint8_t bw, TfEncoding& encoding, bool useSymmetricEncodings,
+                                     bool useUnsignedSymmetric, bool useStrictSymmetric)
+{
+    auto origEncoding = encoding;
+    if (encoding.bw == 0)
+    {
+        throw std::invalid_argument("Encodings must have a valid non-zero bitwidth");
+    }
+
+    if (origEncoding.delta != 0 && origEncoding.offset != 0)
+    {
+        throw std::invalid_argument("Encoding delta and offset must be zero to use this function");
+    }
+
+    // Compute delta and offset, which may also adjust min and max
+    // Note min, max is retained
+    encoding     = getComputedEncodings(bw, encoding.min, encoding.max, useSymmetricEncodings, useStrictSymmetric,
+                                        useUnsignedSymmetric);
+    encoding.min = origEncoding.min;
+    encoding.max = origEncoding.max;
+}
+
 // Function to slice a tensor along an axis. Output shape will be the same for each slice.
 template <typename DTYPE>
-void slice(const DTYPE* input,
-           const std::vector<uint32_t>& inputDim,
-           int32_t axis,
-           std::vector<std::vector<DTYPE>>& outputs,
-           std::vector<uint32_t>& outputDim) {
-
+void slice(const DTYPE* input, const std::vector<uint32_t>& inputDim, int32_t axis,
+           std::vector<std::vector<DTYPE>>& outputs, std::vector<uint32_t>& outputDim)
+{
     // Account for negative axis
-    uint32_t realAxis = (axis >= 0) ? axis : inputDim.size() + axis;
-    outputDim = inputDim;
+    uint32_t realAxis   = (axis >= 0) ? axis : inputDim.size() + axis;
+    outputDim           = inputDim;
     outputDim[realAxis] = 1;
 
-    // If input slice axis dimension size == 1, then it's already "sliced". Copy input->output as there is nothing to slice
-    uint32_t outputCnt = std::accumulate( outputDim.begin(), outputDim.end(), 1, std::multiplies<uint32_t>() );
-    if(inputDim[realAxis] == 1) {
-        outputs.emplace_back(input,input+outputCnt);
+    // If input slice axis dimension size == 1, then it's already "sliced". Copy input->output as there is nothing to
+    // slice
+    uint32_t outputCnt = std::accumulate(outputDim.begin(), outputDim.end(), 1, std::multiplies<uint32_t>());
+    if (inputDim[realAxis] == 1)
+    {
+        outputs.emplace_back(input, input + outputCnt);
         return;
     }
 
     // Add all the slices
     std::vector<uint32_t> slices;
-    for(uint32_t i = 1; i < inputDim[realAxis]; ++i) {
+    for (uint32_t i = 1; i < inputDim[realAxis]; ++i)
+    {
         slices.push_back(i);
     }
 
-    uint32_t sliceCnt = slices.size()+1;
+    uint32_t sliceCnt = slices.size() + 1;
 
-    //std::cout << "Slice axis: " << realAxis << std::endl;
-    //std::cout << "# slices: " << sliceCnt << std::endl;
+    // std::cout << "Slice axis: " << realAxis << std::endl;
+    // std::cout << "# slices: " << sliceCnt << std::endl;
 
     outputs.resize(sliceCnt);
-    for(uint32_t i = 0; i < outputs.size(); ++i) {
+    for (uint32_t i = 0; i < outputs.size(); ++i)
+    {
         outputs[i].resize(outputCnt);
     }
 
@@ -159,22 +245,24 @@ void slice(const DTYPE* input,
     // For e.g. input dim = {6, 3, 4}
     // strides = {12, 4, 1}
     std::vector<uint32_t> inputDimStrides(inputDim.size());
-    for(uint32_t i = inputDim.size(); i > 0; --i )
+    for (uint32_t i = inputDim.size(); i > 0; --i)
     {
-        inputDimStrides[i-1] = std::accumulate( inputDim.begin() + i, inputDim.end(), 1, std::multiplies<uint32_t>() );
-        //std::cout << "inputDimStrides[" << (i-1) << "]=" << inputDimStrides[i-1] << std::endl;
+        inputDimStrides[i - 1] = std::accumulate(inputDim.begin() + i, inputDim.end(), 1, std::multiplies<uint32_t>());
+        // std::cout << "inputDimStrides[" << (i-1) << "]=" << inputDimStrides[i-1] << std::endl;
     }
 
     // Compute num of slice runs
-    uint32_t numSliceRuns =  std::accumulate( inputDim.begin(), inputDim.begin() + realAxis, 1, std::multiplies<uint32_t>() );
-    //std::cout << "No. of slice runs : " << numSliceRuns << std::endl;
+    uint32_t numSliceRuns =
+        std::accumulate(inputDim.begin(), inputDim.begin() + realAxis, 1, std::multiplies<uint32_t>());
+    // std::cout << "No. of slice runs : " << numSliceRuns << std::endl;
 
     // Compute the distane to move during each run for a given slice.
     // It is the same for each slice.
-    uint32_t sliceRunStride = (realAxis == 0) ? 0 : inputDimStrides[realAxis-1];
-    //std::cout << "Slice run stride : " <<  sliceRunStride << std::endl;
+    uint32_t sliceRunStride = (realAxis == 0) ? 0 : inputDimStrides[realAxis - 1];
+    // std::cout << "Slice run stride : " <<  sliceRunStride << std::endl;
 
-    typedef struct {
+    typedef struct
+    {
         uint32_t inputStartOffset;
         uint32_t size;
     } SliceInfo;
@@ -182,104 +270,86 @@ void slice(const DTYPE* input,
     std::vector<SliceInfo> sliceInfos;
 
     // Compute slice info for each slice, using slice points, axis and input dim
-    for(uint32_t sliceIdx  = 0; sliceIdx < slices.size()+1; ++sliceIdx)
+    for (uint32_t sliceIdx = 0; sliceIdx < slices.size() + 1; ++sliceIdx)
     {
         SliceInfo sinfo;
 
-        if( sliceIdx == 0 ) // First slice
+        if (sliceIdx == 0)   // First slice
         {
-            sinfo.inputStartOffset =  0;
-            sinfo.size = slices[sliceIdx]*inputDimStrides[realAxis];
+            sinfo.inputStartOffset = 0;
+            sinfo.size             = slices[sliceIdx] * inputDimStrides[realAxis];
         }
-        else if ( sliceIdx == slices.size() ) // Last slice
+        else if (sliceIdx == slices.size())   // Last slice
         {
-            sinfo.inputStartOffset =  inputDimStrides[realAxis]*slices[sliceIdx-1];
-            sinfo.size = (inputDim[realAxis]-slices[sliceIdx-1])*inputDimStrides[realAxis];
+            sinfo.inputStartOffset = inputDimStrides[realAxis] * slices[sliceIdx - 1];
+            sinfo.size             = (inputDim[realAxis] - slices[sliceIdx - 1]) * inputDimStrides[realAxis];
         }
-        else  // Middle slices
+        else   // Middle slices
         {
-            sinfo.inputStartOffset =  inputDimStrides[realAxis]*slices[sliceIdx-1];
-            sinfo.size = (slices[sliceIdx]-slices[sliceIdx-1])*inputDimStrides[realAxis];
+            sinfo.inputStartOffset = inputDimStrides[realAxis] * slices[sliceIdx - 1];
+            sinfo.size             = (slices[sliceIdx] - slices[sliceIdx - 1]) * inputDimStrides[realAxis];
         }
         sliceInfos.push_back(sinfo);
-        //std::cout << "SliceInfo Idx " << sliceIdx << ", inputStartOffset: " << sinfo.inputStartOffset << ", size: " << sinfo.size << std::endl;
-
+        // std::cout << "SliceInfo Idx " << sliceIdx << ", inputStartOffset: " << sinfo.inputStartOffset << ", size: "
+        // << sinfo.size << std::endl;
     }
 
-    for(uint32_t runIdx = 0; runIdx <  numSliceRuns; ++runIdx )
+    for (uint32_t runIdx = 0; runIdx < numSliceRuns; ++runIdx)
     {
-        for(uint32_t sliceIdx =0; sliceIdx < sliceCnt; ++sliceIdx )
+        for (uint32_t sliceIdx = 0; sliceIdx < sliceCnt; ++sliceIdx)
         {
-            auto inPtr = input + sliceInfos[sliceIdx].inputStartOffset + runIdx*sliceRunStride;
-            std::copy(inPtr, inPtr+sliceInfos[sliceIdx].size, outputs[sliceIdx].data() + runIdx*sliceInfos[sliceIdx].size);
+            auto inPtr = input + sliceInfos[sliceIdx].inputStartOffset + runIdx * sliceRunStride;
+            std::copy(inPtr, inPtr + sliceInfos[sliceIdx].size,
+                      outputs[sliceIdx].data() + runIdx * sliceInfos[sliceIdx].size);
         }
     }
 }
 
-// Function to concatenate from slice along an axis. Output shape should be the same shape as the original input shape to slice.
+// Function to concatenate from slice along an axis. Output shape should be the same shape as the original input shape
+// to slice.
 template <typename DTYPE>
-void concat(const std::vector<std::vector<DTYPE>>& inputs,
-            const std::vector<uint32_t>& inputDim,
-            int32_t axis,
-            DTYPE* output,
-            std::vector<uint32_t>& outputDim) {
-
-    uint32_t realAxis = (axis >= 0) ? axis : inputDim.size() + axis;
-    outputDim = inputDim;
+void concat(const std::vector<std::vector<DTYPE>>& inputs, const std::vector<uint32_t>& inputDim, int32_t axis,
+            DTYPE* output, std::vector<uint32_t>& outputDim)
+{
+    uint32_t realAxis   = (axis >= 0) ? axis : inputDim.size() + axis;
+    outputDim           = inputDim;
     outputDim[realAxis] = inputs.size();
 
-    uint32_t a = 0;
+    uint32_t a        = 0;
     uint32_t numUnits = 1;
-    for(; a < realAxis; ++a)
+    for (; a < realAxis; ++a)
     {
-        numUnits = numUnits*inputDim[a];
+        numUnits = numUnits * inputDim[a];
     }
 
     uint32_t unitSize = 1;
-    for(; a < inputDim.size(); ++a)
+    for (; a < inputDim.size(); ++a)
     {
         unitSize = unitSize * inputDim[a];
     }
-    for( uint32_t i = 0; i < numUnits; ++i )
+    for (uint32_t i = 0; i < numUnits; ++i)
     {
-        for( uint32_t u = 0; u < (uint32_t)inputs.size(); ++u )
+        for (uint32_t u = 0; u < (uint32_t) inputs.size(); ++u)
         {
-            const DTYPE* src = inputs[u].data() + unitSize*i;
-            std::copy(src, src+unitSize, output);
+            const DTYPE* src = inputs[u].data() + unitSize * i;
+            std::copy(src, src + unitSize, output);
             output += unitSize;
         }
     }
 }
 
-template void slice(const float* input,
-                    const std::vector<uint32_t>& inputDim,
-                    int32_t axis,
-                    std::vector<std::vector<float>>& outputs,
-                    std::vector<uint32_t>& outputDim);
-template void slice(const double* input,
-                    const std::vector<uint32_t>& inputDim,
-                    int32_t axis,
-                    std::vector<std::vector<double>>& outputs,
-                    std::vector<uint32_t>& outputDim);
-template void slice(const uint8_t* input,
-                    const std::vector<uint32_t>& inputDim,
-                    int32_t axis,
-                    std::vector<std::vector<uint8_t>>& outputs,
-                    std::vector<uint32_t>& outputDim);
+template void slice(const float* input, const std::vector<uint32_t>& inputDim, int32_t axis,
+                    std::vector<std::vector<float>>& outputs, std::vector<uint32_t>& outputDim);
+template void slice(const double* input, const std::vector<uint32_t>& inputDim, int32_t axis,
+                    std::vector<std::vector<double>>& outputs, std::vector<uint32_t>& outputDim);
+template void slice(const uint8_t* input, const std::vector<uint32_t>& inputDim, int32_t axis,
+                    std::vector<std::vector<uint8_t>>& outputs, std::vector<uint32_t>& outputDim);
 
-template void concat(const std::vector<std::vector<float>>& inputs,
-                     const std::vector<uint32_t>& inputDim,
-                     int32_t axis,
-                     float* output,
-                     std::vector<uint32_t>& outputDim);
-template void concat(const std::vector<std::vector<double>>& inputs,
-                     const std::vector<uint32_t>& inputDim,
-                     int32_t axis,
-                     double* output,
-                     std::vector<uint32_t>& outputDim);
-template void concat(const std::vector<std::vector<unsigned char>>& inputs,
-                     const std::vector<uint32_t>& inputDim,
-                     int32_t axis,
-                     unsigned char* output,
-                     std::vector<uint32_t>& outputDim);
+template void concat(const std::vector<std::vector<float>>& inputs, const std::vector<uint32_t>& inputDim, int32_t axis,
+                     float* output, std::vector<uint32_t>& outputDim);
+template void concat(const std::vector<std::vector<double>>& inputs, const std::vector<uint32_t>& inputDim,
+                     int32_t axis, double* output, std::vector<uint32_t>& outputDim);
+template void concat(const std::vector<std::vector<unsigned char>>& inputs, const std::vector<uint32_t>& inputDim,
+                     int32_t axis, unsigned char* output, std::vector<uint32_t>& outputDim);
+
 }   // End of namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
+++ b/ModelOptimizations/DlQuantization/src/quantization_utils.hpp
@@ -47,9 +47,20 @@
 
 namespace DlQuantization
 {
+
+static constexpr double EPSILON = 1e-5;
+
 TfEncoding getComputedEncodings(uint8_t bw, double min, double max, bool useSymmetricEncodings, bool useStrictSymmetric,
                                 bool useUnsignedSymmetric);
 
+// ensures min - max is not too close, by checking that max - min > epsilon
+void gateMinMax(double& encodingMin, double& encodingMax);
+
+void computeMinMaxRangeFromDeltaOffset(uint8_t bw, TfEncoding& encoding, bool useSymmetricEncodings, bool useUnsignedSymmetric,
+                                       bool useStrictSymmetric);
+
+void computeDeltaAndOffsetFromMinMax(uint8_t bw, TfEncoding& encoding, bool useSymmetricEncodings, bool useUnsignedSymmetric,
+                                     bool useStrictSymmetric);
 
 // Function to slice a tensor along an axis, allocate and populate output buffers. Output shape will be the same for each slice.
 template <typename DTYPE>

--- a/ModelOptimizations/DlQuantization/test/test_quantization_lib.hpp
+++ b/ModelOptimizations/DlQuantization/test/test_quantization_lib.hpp
@@ -188,20 +188,22 @@ using namespace DlQuantization;
 
 // Assume a non-skewed distribution.
 // Round offset to fixed point, and adjust min and max accordingly.
-static TfEncoding getTfEncoding(double min, double max, int bw) {
+static TfEncoding getTfEncoding(double min, double max, int bw)
+{
     TfEncoding encoding;
-    int steps = pow(2, bw) - 1;
-    encoding.delta = (max - min) / (double)steps;
+    int steps       = pow(2, bw) - 1;
+    encoding.delta  = (max - min) / (double) steps;
     encoding.offset = round(min / encoding.delta);
-    encoding.min = encoding.delta * encoding.offset;
-    encoding.max = encoding.delta * steps + encoding.min;
-    encoding.bw = bw;
+    encoding.min    = encoding.delta * encoding.offset;
+    encoding.max    = encoding.delta * steps + encoding.min;
+    encoding.bw     = bw;
     return encoding;
 }
 
-static TfEncoding getTfSymmetricEncoding(double max, int bw) {
+static TfEncoding getTfSymmetricEncoding(double max, int bw)
+{
     TfEncoding encoding;
-    int halfSteps = pow(2, bw) - 2; // To make it symmetric
+    int halfSteps                 = pow(2, bw) - 2;   // To make it symmetric
     unsigned int numPositiveSteps = std::floor(halfSteps / 2);
     encoding.delta                = max / numPositiveSteps;
     encoding.offset               = -std::ceil(halfSteps / 2);
@@ -211,18 +213,18 @@ static TfEncoding getTfSymmetricEncoding(double max, int bw) {
     return encoding;
 }
 
-static void printEncoding(TfEncoding encoding) {
-    std::cout << "Encoding: min: " << encoding.min << ", max: " << encoding.max <<
-        ", delta: " << encoding.delta << ", offset: " << encoding.offset <<
-        ", bw: " << encoding.bw << std::endl;
+static void printEncoding(TfEncoding encoding)
+{
+    std::cout << "Encoding: min: " << encoding.min << ", max: " << encoding.max << ", delta: " << encoding.delta
+              << ", offset: " << encoding.offset << ", bw: " << encoding.bw << std::endl;
 }
 
-static bool compareEncodings(TfEncoding e0, TfEncoding e1) {
+static bool compareEncodings(TfEncoding e0, TfEncoding e1)
+{
     bool result = true;
 
     // Hacky to use the gtest internal function of testing double value equaity
-#define TEST_DOUBLE_EQ(v0, v1)                                          \
-    bool(::testing::internal::CmpHelperFloatingPointEQ<double>(#v0, #v1, v0, v1))
+#define TEST_DOUBLE_EQ(v0, v1) bool(::testing::internal::CmpHelperFloatingPointEQ<double>(#v0, #v1, v0, v1))
 
     result = result && TEST_DOUBLE_EQ(e0.min, e1.min);
     result = result && TEST_DOUBLE_EQ(e0.max, e1.max);
@@ -234,8 +236,8 @@ static bool compareEncodings(TfEncoding e0, TfEncoding e1) {
     return result;
 }
 
-static void compareEncodings(TfEncoding e0, TfEncoding e1, double err) {
-
+static void compareEncodings(TfEncoding e0, TfEncoding e1, double err)
+{
     EXPECT_NEAR(e0.min, e1.min, err);
     EXPECT_NEAR(e0.max, e1.max, err);
     EXPECT_NEAR(e0.delta, e1.delta, err);
@@ -243,23 +245,30 @@ static void compareEncodings(TfEncoding e0, TfEncoding e1, double err) {
 }
 
 template <typename T>
-void printTensors(const T* v1, const T* v2, uint32_t size) {
-    std::cout << "Got tensor: ";;
-    for(uint32_t i = 0; i < size; ++i) {
-        std::cout << (float)v1[i] << ", ";
+void printTensors(const T* v1, const T* v2, uint32_t size)
+{
+    std::cout << "Got tensor: ";
+    ;
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        std::cout << (float) v1[i] << ", ";
     }
     std::cout << std::endl << "Expected:   ";
-    for(uint32_t i = 0; i < size; ++i) {
-        std::cout << (float)v2[i] << ", ";
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        std::cout << (float) v2[i] << ", ";
     }
     std::cout << std::endl;
 }
 
 template <typename T>
-bool compareTensors(const T* v1, const T* v2, uint32_t size) {
-    for(uint32_t i = 0; i < size; ++i) {
-        if(v1[i] != v2[i]) {
-            printTensors(v1,v2,size);
+bool compareTensors(const T* v1, const T* v2, uint32_t size)
+{
+    for (uint32_t i = 0; i < size; ++i)
+    {
+        if (v1[i] != v2[i])
+        {
+            printTensors(v1, v2, size);
             return false;
         }
     }


### PR DESCRIPTION
- Adds an API to compute partial encodings without needing user data
- compute min/max given delta and offset
- compute delta and offset given min/max
- distinct from computeEncodings as that API requires update stats with data
- distinct from computeEncodingFromData in the same vein

Signed-off-by: Akin Solomon <quic_akinlawo@quicinc.com>