### PR TITLE
Fix limitation to tensors of size 4

### DIFF
--- a/ModelOptimizations/PyModelOptimizations/PyTensorQuantizer.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyTensorQuantizer.cpp
@@ -64,10 +64,11 @@ void PyTensorQuantizer::quantizeDequantize(py::array_t<float> inputTensor, py::a
 {
     auto inputArr     = inputTensor.mutable_unchecked();
     auto outputArr    = outputTensor.mutable_unchecked();
-    size_t tensorSize = inputArr.shape(0) * inputArr.shape(1) * inputArr.shape(2) * inputArr.shape(3);
 
-    auto inputTensorPtr  = static_cast<float*>(inputArr.mutable_data(0, 0, 0, 0));
-    auto outputTensorPtr = static_cast<float*>(outputArr.mutable_data(0, 0, 0, 0));
+    size_t tensorSize = inputArr.size();
+
+    auto inputTensorPtr  = static_cast<float*>(inputArr.mutable_data());
+    auto outputTensorPtr = static_cast<float*>(outputArr.mutable_data());
 
     // Delegate
    TensorQuantizer::quantizeDequantize(inputTensorPtr, tensorSize, outputTensorPtr,

--- a/ModelOptimizations/PyModelOptimizations/PyTensorQuantizer.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyTensorQuantizer.cpp
@@ -62,8 +62,8 @@ void PyTensorQuantizer::updateStats(py::array_t<float> tensor, bool useCuda)
 void PyTensorQuantizer::quantizeDequantize(py::array_t<float> inputTensor, py::array_t<float> outputTensor,
                                            double encodingMin, double encodingMax, unsigned int  bitwidth, bool useCuda)
 {
-    auto inputArr     = inputTensor.mutable_unchecked<4>();
-    auto outputArr    = outputTensor.mutable_unchecked<4>();
+    auto inputArr     = inputTensor.mutable_unchecked();
+    auto outputArr    = outputTensor.mutable_unchecked();
     size_t tensorSize = inputArr.shape(0) * inputArr.shape(1) * inputArr.shape(2) * inputArr.shape(3);
 
     auto inputTensorPtr  = static_cast<float*>(inputArr.mutable_data(0, 0, 0, 0));


### PR DESCRIPTION
Addresses issue #1488 

Fixed as per pybind11's documentation for tensors with unspecified dimensions at compile time - https://pybind11.readthedocs.io/en/stable/advanced/pycpp/numpy.html#direct-access