### PR TITLE
Implement Op instance specific config support

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
@@ -78,6 +78,7 @@ class ConfigDictKeys:
     ACTIVATION = "activation"
     PARAM = "param"
     BITWIDTH = "bitwidth"
+    HW_VERSION = "hw_version"
 
 
 class JsonConfigImporter:

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config_schema.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config_schema.py
@@ -35,7 +35,7 @@
 #
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
-""" Schema used to validate json configuration file """
+""" Schema used to validate json configuration file. Docs: https://json-schema.org/learn/ """
 
 
 QUANTSIM_CONFIG_SCHEMA = {
@@ -129,6 +129,9 @@ QUANTSIM_CONFIG_SCHEMA = {
                     },
                     "minItems": 1,
                     "additionalItems": False
+                },
+                "hw_version": {
+                    "type": "string"
                 }
             },
             "required": ["ops", "params"],

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim_config/quantsim_config.py
@@ -513,3 +513,10 @@ class QuantSimConfigurator(AimetCommonQuantSimConfigurator):
         :param data_type: data type as QuantizationDataType
         :return:
         """
+
+    def _generate_and_apply_op_instance_specific_config(self):
+        """
+        Generate op instance specific configurations - currently supported_kernels and per_channel_quantization fields
+        This function uses op specific supported_kernels (if absent use defaults), op specific per_channel_quantization
+        fields (if absent use default per_channel_quantization) and generate op instance specific config
+        """

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim_config/quantsim_config.py
@@ -511,6 +511,14 @@ class QuantSimConfigurator(AimetCommonQuantSimConfigurator):
 
     # -----------------------------------[ override support end] --------------------------------------------- #
 
+    def _generate_and_apply_op_instance_specific_config(self):
+        """
+        Generate op instance specific configurations - currently supported_kernels and per_channel_quantization fields
+        This function uses op specific supported_kernels (if absent use defaults), op specific per_channel_quantization
+        fields (if absent use default per_channel_quantization) and generate op instance specific config
+        """
+
+
 def _get_quantize_ops_to_modify(input_output_quantize_ops: QuantizerListType, setting_name: str) -> List[tf.Operation]:
     """
     Given the tuple containing lists of quantize ops to modify under different situations, identify a list of quantize

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -105,6 +105,7 @@ def tensor_quantizer_factory(bitwidth: int, round_mode: str, quant_scheme: Quant
     :param quant_scheme: Quantization scheme (e.g. Range Learning)
     :param use_symmetric_encodings: True if symmetric encoding is used.  False otherwise.
     :param enabled_by_default: True if quantization of tensor is enabled.  False otherwise.
+    :param data_type: Quantization data_type to be used
     :return: An instance of StaticGridPerTensorQuantizer
     """
 
@@ -269,6 +270,7 @@ class QcQuantizeWrapper(nn.Module):
                                  for _ in range(num_inputs)]
 
         self._quant_scheme = quant_scheme
+        self._supported_kernels = {}
 
     def get_named_parameters(self):
         """


### PR DESCRIPTION
- Add hw_version field in config file
- reorganize per-channel-quantization logic to work with op instance specific config

Signed-off-by: yathindra kota <quic_ykota@quicinc.com>