### PR TITLE
Fixed: When new PerChannelQuantizer or AdaRoundQuantizer objects were…

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
@@ -246,8 +246,11 @@ class Adaround:
         if isinstance(quantizer, StaticGridPerChannelQuantizer):
             # pylint: disable=protected-access
             ch_axis = quantizer._ch_axis
+
         adaround_quantizer = AdaroundTensorQuantizer(quantizer.bitwidth, 'Adaptive', quantizer.quant_scheme,
                                                      quantizer.use_symmetric_encodings, quantizer.enabled, ch_axis)
+        adaround_quantizer.use_strict_symmetric = quantizer.use_strict_symmetric
+        adaround_quantizer.use_unsigned_symmetric = quantizer.use_unsigned_symmetric
 
         # Set the encodings and replace by Adaround tensor quantizer
         adaround_quantizer.encoding = quantizer.encoding

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -691,6 +691,8 @@ class StaticGridQuantWrapper(QcQuantizeWrapper):
                                                                   enabled_by_default=param_quantizer.enabled,
                                                                   ch_axis=channel_axis,
                                                                   data_type=param_quantizer.data_type)
+            per_channel_quantizer.use_strict_symmetric = param_quantizer.use_strict_symmetric
+            per_channel_quantizer.use_unsigned_symmetric = param_quantizer.use_unsigned_symmetric
 
             new_param_quant_dict[param_name] = per_channel_quantizer
         self.param_quantizers = new_param_quant_dict

--- a/TrainingExtensions/torch/test/python/test_quantsim_config.py
+++ b/TrainingExtensions/torch/test/python/test_quantsim_config.py
@@ -902,9 +902,14 @@ class TestQuantsimConfig:
         model.eval()
 
         quantsim_config = {
-            "defaults": {
+            "defaults":
+            {
                 "ops": {},
-                "params": {},
+                "params":
+                {
+                    "is_symmetric": "True"
+                },
+                "per_channel_quantization": "True",
                 "strict_symmetric": "True",
                 "unsigned_symmetric": "False"
             },


### PR DESCRIPTION
… created from existing other quantizers, unsigned symmetric and strict symmetric flags were not propagated.

Signed-off-by: Abhi Khobare <quic_akhobare@quicinc.com>

Fixes #1642 