### PR TITLE
Add torch.mean's redefining model example and support it in "model_prepare"API

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
@@ -162,3 +162,14 @@ class AdaptiveAvgPool2d(torch.nn.Module):
         Forward-pass routine for adaptive_avg_pool2d op
         """
         return torch.nn.functional.adaptive_avg_pool2d(*args, **kwargs)
+
+
+class Mean(torch.nn.Module):
+    """ReduceMean module for a functional mean"""
+    # pylint:disable=arguments-differ
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for Mean op
+        """
+        return torch.mean(*args, **kwargs)

--- a/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
@@ -112,6 +112,7 @@ functional_with_args_kwargs = {
     'max_pool2d'                : elementwise_ops.MaxPool2d,
     'max_pool2d_with_indices'   : elementwise_ops.MaxPool2d,
     'adaptive_avg_pool2d'       : elementwise_ops.AdaptiveAvgPool2d,
+    'mean'                      : elementwise_ops.Mean,
 }
 
 


### PR DESCRIPTION
Signed-off-by: Shuxiang Han <quic_shuxiang@quicinc.com>
At present, ’model_prepare’ does not support the model using 'torch.mean', and the model needs to be redefined and do special handling in ’model_prepare’