### PR TITLE
Keras and TF API to load encodings to sim.

### DIFF
--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
@@ -101,7 +101,7 @@ def _handle_conv2d_transpose(callback):
 class TensorQuantizer(tf.keras.layers.Layer, abc.ABC):
     """Tensor quantizer class containing the bare bones of a given Quantizer"""
 
-    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-arguments, too-many-instance-attributes
     # pylint: disable=unused-argument
     def __init__(self, layer: tf.keras.layers.Layer, name: str, op_mode: libpymo.TensorQuantizerOpMode,
                  quant_scheme: QuantScheme,
@@ -273,6 +273,21 @@ class TensorQuantizer(tf.keras.layers.Layer, abc.ABC):
         if self.quant_mode == libpymo.TensorQuantizerOpMode.passThrough.value:
             return tensor
         return self._call_handler(tensor)
+
+    def set_quantizer_encodings(self, bitwidth: int, is_symmetric: bool, encoding: libpymo.TfEncoding,
+                                opmode: libpymo.TensorQuantizerOpMode):
+        """
+        Helper Function to set encodings, bitwidth, opmode, symmetric flag and opmode to tensor quantizer
+        :param bitwidth: Bitwidth for the tensor quantizer
+        :param is_symmetric: True if symmetric encoding is used. False otherwise.
+        :param encoding: encodings which needs to be applied to the quantizer
+        :param opmode: operation mode for the quantizer
+        """
+        # pylint: disable  = attribute-defined-outside-init
+        self.use_symmetric_encodings = is_symmetric
+        self.bitwidth = bitwidth
+        self.encoding = encoding
+        self.quant_mode = opmode
 
 
 # pylint: disable=too-many-ancestors

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
@@ -523,10 +523,8 @@ class QuantizationSimModel(tf.keras.Model):
                 if tensor_name in activation_encodings:
                     encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(activation_encodings[tensor_name][0])
                     input_quantizer.tensor_quantizer.isEncodingValid = True
-                    input_quantizer.bitwidth = encoding.bw
-                    input_quantizer.use_symmetric_encodings = is_symmetric
-                    input_quantizer.encoding = encoding
-                    input_quantizer.quant_mode = libpymo.TensorQuantizerOpMode.quantizeDequantize
+                    input_quantizer.set_quantizer_encodings(encoding.bw, is_symmetric, encoding,
+                                                            libpymo.TensorQuantizerOpMode.quantizeDequantize)
                     _logger.info("Setting encodings for : %s", tensor_name)
 
             for idx, param_quantizer in enumerate(wrapper.param_quantizers):
@@ -537,15 +535,13 @@ class QuantizationSimModel(tf.keras.Model):
                         encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(param_encodings[param_name])
                         for tensor_quantizer in param_quantizer.tensor_quantizer:
                             tensor_quantizer.isEncodingValid = True
-                        param_quantizer.bitwidth = encoding[0].bw
+                        bw = encoding[0].bw
                     else:
                         encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(param_encodings[param_name][0])
                         param_quantizer.tensor_quantizer.isEncodingValid = True
-                        param_quantizer.bitwidth = encoding.bw
-
-                    param_quantizer.use_symmetric_encodings = is_symmetric
-                    param_quantizer.encoding = encoding
-                    param_quantizer.quant_mode = libpymo.TensorQuantizerOpMode.quantizeDequantize
+                        bw = encoding.bw
+                    param_quantizer.set_quantizer_encodings(bw, is_symmetric, encoding,
+                                                            libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize)
                     _logger.info("Setting encodings for : %s", param_name)
 
             for idx, output_quantizer in enumerate(wrapper.output_quantizers):
@@ -559,10 +555,8 @@ class QuantizationSimModel(tf.keras.Model):
                 if tensor_name in activation_encodings:
                     encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(activation_encodings[tensor_name][0])
                     output_quantizer.tensor_quantizer.isEncodingValid = True
-                    output_quantizer.use_symmetric_encodings = is_symmetric
-                    output_quantizer.bitwidth = encoding.bw
-                    output_quantizer.encoding = encoding
-                    output_quantizer.quant_mode = libpymo.TensorQuantizerOpMode.quantizeDequantize
+                    output_quantizer.set_quantizer_encodings(encoding.bw, is_symmetric, encoding,
+                                                             libpymo.TensorQuantizerOpMode.quantizeDequantize)
                     _logger.info("Setting encodings for : %s", tensor_name)
 
     def _param_op_mode_after_analysis(self, quant_scheme) -> libpymo.TensorQuantizerOpMode:

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
@@ -502,8 +502,7 @@ class QuantizationSimModel(tf.keras.Model):
         :param encoding_file_path: path from where to load encodings file
         :return:
         """
-        # pylint: disable=protected-access, too-many-branches, too-many-locals
-
+        # pylint: disable=protected-access, too-many-branches, too-many-locals, too-many-statements
         # Load encodings file
         with open(encoding_file_path) as json_file:
             encodings = json.load(json_file)
@@ -521,16 +520,26 @@ class QuantizationSimModel(tf.keras.Model):
                     tensor_name = wrapper._layer_to_wrap.inbound_nodes[0].keras_inputs[idx].name
 
                 if tensor_name in activation_encodings:
+                    if not input_quantizer.is_enabled():
+                        _logger.info("Not loading encodings for quantizer: %s as it is disabled", tensor_name)
+                        continue
                     encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(activation_encodings[tensor_name][0])
                     input_quantizer.tensor_quantizer.isEncodingValid = True
                     input_quantizer.set_quantizer_encodings(encoding.bw, is_symmetric, encoding,
                                                             libpymo.TensorQuantizerOpMode.quantizeDequantize)
                     _logger.info("Setting encodings for : %s", tensor_name)
+                else:
+                    if input_quantizer.is_enabled():
+                        input_quantizer.disable()
+                        _logger.info("Encoding for quantizer: %s is not present thus disabling it.", tensor_name)
 
             for idx, param_quantizer in enumerate(wrapper.param_quantizers):
                 param_name = wrapper._layer_to_wrap.weights[idx].name
 
                 if param_name in param_encodings:
+                    if not param_quantizer.is_enabled():
+                        _logger.info("Not loading encodings for parameter: %s as quantizer is disabled", param_name)
+                        continue
                     if isinstance(param_quantizer, StaticGridPerChannelQuantizer):
                         encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(param_encodings[param_name])
                         for tensor_quantizer in param_quantizer.tensor_quantizer:
@@ -543,6 +552,10 @@ class QuantizationSimModel(tf.keras.Model):
                     param_quantizer.set_quantizer_encodings(bw, is_symmetric, encoding,
                                                             libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize)
                     _logger.info("Setting encodings for : %s", param_name)
+                else:
+                    if param_quantizer.is_enabled():
+                        param_quantizer.disable()
+                        _logger.info("Encoding for parameter: %s not present thus disabling this quantizer.", param_name)
 
             for idx, output_quantizer in enumerate(wrapper.output_quantizers):
                 # because dense layers in quantizable MHA are not explicitly sublayers, they don't have their
@@ -553,11 +566,18 @@ class QuantizationSimModel(tf.keras.Model):
                     tensor_name = wrapper._layer_to_wrap.output.name
 
                 if tensor_name in activation_encodings:
+                    if not output_quantizer.is_enabled():
+                        _logger.info("Not loading encodings for quantizer: %s as it is disabled", tensor_name)
+                        continue
                     encoding, is_symmetric = quantsim_utils.create_encoding_from_dict(activation_encodings[tensor_name][0])
                     output_quantizer.tensor_quantizer.isEncodingValid = True
                     output_quantizer.set_quantizer_encodings(encoding.bw, is_symmetric, encoding,
                                                              libpymo.TensorQuantizerOpMode.quantizeDequantize)
                     _logger.info("Setting encodings for : %s", tensor_name)
+                else:
+                    if output_quantizer.is_enabled():
+                        output_quantizer.disable()
+                        _logger.info("Encoding for quantizer: %s is not present thus disabling it.", tensor_name)
 
     def _param_op_mode_after_analysis(self, quant_scheme) -> libpymo.TensorQuantizerOpMode:
         """

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
@@ -96,6 +96,8 @@ class PickleableTensorQuantizerState:
 
 
 class QuantizerInfo:
+    # pylint: disable=too-many-public-methods
+
     """
     Holds information about a given MO Quantizer object and active session
     """
@@ -597,3 +599,18 @@ class QuantizerInfo:
         assert len(readvariable_op.outputs) == 1
 
         return readvariable_op.outputs[0]
+
+    def set_encodings_to_quantizer(self, bitwidth: int, is_symmetric: bool, encoding: libpymo.TfEncoding,
+                                   opmode: libpymo.TensorQuantizerOpMode):
+        """
+        Helper Function to set encodings, bitwidth, opmode, symmetric flag and opmode to tensor quantizer
+        :param bitwidth: Bitwidth for the tensor quantizer
+        :param is_symmetric: True if symmetric encoding is used. False otherwise.
+        :param encoding: encodings which needs to be applied to the quantizer
+        :param opmode: operation mode for the quantizer
+        """
+
+        self.bitwidth = bitwidth
+        self.use_symmetric_encoding = is_symmetric
+        self.set_encoding(encoding)
+        self.set_op_mode(opmode)

--- a/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
@@ -646,7 +646,6 @@ def test_quantizable_mha_export_encodings():
                 assert param_name in encodings['param_encodings']
                 assert encodings['param_encodings'][param_name] == encoding_dict
 
-
 def test_clone_model():
     model = dense_functional()
     rand_inp = np.random.randn(100, 5)
@@ -807,7 +806,7 @@ def test_model_stays_valid_after_export_per_channel():
 
 
 def test_load_encodings():
-    """ Test set and freeze parameter encodings functionality """
+    """ Test load encodings functionality """
     tf.compat.v1.reset_default_graph()
 
     model = keras_model()
@@ -859,4 +858,92 @@ def test_load_encodings():
         os.remove("./dummy.encodings")
 
 
+def test_load_encodings_pcq():
+    """ Test load encodings functionality with PCQ """
+
+    quantsim_config = {
+        "defaults": {
+            "ops": {
+                "is_output_quantized": "True",
+                "is_symmetric": "True"
+            },
+            "params": {
+                "is_quantized": "False",
+                "is_symmetric": "True"
+            },
+            "per_channel_quantization": "True",
+        },
+        "params": {},
+        "op_type": {},
+        "supergroups": [],
+        "model_input": {},
+        "model_output": {}
+    }
+    with open('./quantsim_config.json', 'w') as f:
+        json.dump(quantsim_config, f)
+    tf.compat.v1.reset_default_graph()
+
+    model = keras_model()
+
+    sim = QuantizationSimModel(model,config_file='./quantsim_config.json')
+    param_encodings = {'conv2d_1/kernel:0': [{'bitwidth': 4, 'is_symmetric': False,
+                                              'max': 0.14584073424339294,
+                                              'min': -0.12761062383651733,
+                                              'offset': -7.0, 'scale': 0.01823008991777897},
+                                             {'bitwidth': 4, 'is_symmetric': False,
+                                              'max': 0.14584073424339294,
+                                              'min': -0.12761062383651733,
+                                              'offset': -7.0, 'scale': 0.01823008991777897},
+                                             {'bitwidth': 4, 'is_symmetric': False,
+                                              'max': 0.14584073424339294,
+                                              'min': -0.12761062383651733,
+                                              'offset': -7.0, 'scale': 0.01823008991777897},
+                                             {'bitwidth': 4, 'is_symmetric': False,
+                                              'max': 0.14584073424339294,
+                                              'min': -0.12761062383651733,
+                                              'offset': -7.0, 'scale': 0.01823008991777897}]}
+    activation_encodings = {"conv2d_1/Tanh:0": [
+        {
+            "bitwidth": 8,
+            "dtype": "int",
+            "is_symmetric": "False",
+            "max": 5.98828125,
+            "min": -7.78128125,
+            "offset": -144,
+            "scale": 0.05399828431372549
+        }
+    ]}
+
+    dummy_encodings = {"activation_encodings": activation_encodings,
+                       "param_encodings": param_encodings}
+
+    # export encodings to JSON file
+    encoding_file_path = os.path.join('./', 'dummy.encodings')
+    with open(encoding_file_path, 'w') as encoding_fp:
+        json.dump(dummy_encodings, encoding_fp, sort_keys=True, indent=4)
+
+    sim.load_encodings_to_sim(encoding_file_path='./dummy.encodings')
+
+    extracted_encoding = sim.get_encodings_dict()
+
+    # For param
+    expected_encoding = param_encodings['conv2d_1/kernel:0']
+    actual_encoding   = extracted_encoding["param_encodings"]['conv2d_1/kernel:0']
+    for i in range(4):
+        assert actual_encoding[i].get('min') == expected_encoding[i].get('min')
+        assert actual_encoding[i].get('max') == expected_encoding[i].get('max')
+
+    # For activation
+    expected_encoding = activation_encodings["conv2d_1/Tanh:0"][0]
+    actual_encoding   = extracted_encoding["activation_encodings"]["conv2d_1/Tanh:0"][0]
+    assert actual_encoding.get('min') == expected_encoding.get('min')
+    assert actual_encoding.get('max') == expected_encoding.get('max')
+
+
+    # Delete encodings JSON file
+    if os.path.exists("./dummy.encodings"):
+        os.remove("./dummy.encodings")
+        
+        
 test_model_stays_valid_after_export_per_tensor()
+

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
@@ -1237,7 +1237,6 @@ class TestQuantSim(unittest.TestCase):
         if os.path.exists("./dummy.encodings"):
             os.remove("./dummy.encodings")
 
-
     def test_load_encodings_pcq(self):
         """ Test load encodings functionality with PCQ """
 
@@ -1248,7 +1247,7 @@ class TestQuantSim(unittest.TestCase):
                     "is_symmetric": "True"
                 },
                 "params": {
-                    "is_quantized": "False",
+                    "is_quantized": "True",
                     "is_symmetric": "True"
                 },
                 "per_channel_quantization": "True",
@@ -1272,21 +1271,21 @@ class TestQuantSim(unittest.TestCase):
         sim = QuantizationSimModel(session, ['conv2d_input'], ['keras_model/Softmax'],
                                    config_file='./quantsim_config.json')
         param_encodings = {'conv2d_1/Conv2D/ReadVariableOp:0': [{'bitwidth': 4, 'is_symmetric': False,
-                                                               'max': 0.14584073424339294,
-                                                               'min': -0.12761062383651733,
-                                                               'offset': -7.0, 'scale': 0.01823008991777897},
-                                                              {'bitwidth': 4, 'is_symmetric': False,
-                                                               'max': 0.14584073424339294,
-                                                               'min': -0.12761062383651733,
-                                                               'offset': -7.0, 'scale': 0.01823008991777897},
-                                                              {'bitwidth': 4, 'is_symmetric': False,
-                                                               'max': 0.14584073424339294,
-                                                               'min': -0.12761062383651733,
-                                                               'offset': -7.0, 'scale': 0.01823008991777897},
-                                                              {'bitwidth': 4, 'is_symmetric': False,
-                                                               'max': 0.14584073424339294,
-                                                               'min': -0.12761062383651733,
-                                                               'offset': -7.0, 'scale': 0.01823008991777897}]}
+                                                                 'max': 0.14584073424339294,
+                                                                 'min': -0.12761062383651733,
+                                                                 'offset': -7.0, 'scale': 0.01823008991777897},
+                                                                {'bitwidth': 4, 'is_symmetric': False,
+                                                                 'max': 0.14584073424339294,
+                                                                 'min': -0.12761062383651733,
+                                                                 'offset': -7.0, 'scale': 0.01823008991777897},
+                                                                {'bitwidth': 4, 'is_symmetric': False,
+                                                                 'max': 0.14584073424339294,
+                                                                 'min': -0.12761062383651733,
+                                                                 'offset': -7.0, 'scale': 0.01823008991777897},
+                                                                {'bitwidth': 4, 'is_symmetric': False,
+                                                                 'max': 0.14584073424339294,
+                                                                 'min': -0.12761062383651733,
+                                                                 'offset': -7.0, 'scale': 0.01823008991777897}]}
         activation_encodings = {"conv2d_1/Tanh:0": [
             {
                 "bitwidth": 8,
@@ -1322,6 +1321,87 @@ class TestQuantSim(unittest.TestCase):
         self.assertTrue(np.allclose(encoding_max, enc_max))
         self.assertEqual(int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize), quantizer.get_op_mode())
         self.assertEqual(quantizer.is_encoding_valid(), True)
+
+        # Check if activation quantizer encoding is set properly
+        quantizer = sim.quantizer_config('conv2d_1/Tanh_quantized')
+        encoding = activation_encodings['conv2d_1/Tanh:0'][0]
+
+        encoding_max = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_max)
+        encoding_min = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_min)
+
+        self.assertEqual(encoding_min, encoding.get('min'))
+        self.assertEqual(encoding_max, encoding.get('max'))
+        self.assertEqual(int(libpymo.TensorQuantizerOpMode.quantizeDequantize), quantizer.get_op_mode())
+        self.assertEqual(quantizer.is_encoding_valid(), True)
+
+        session.close()
+
+        # Delete encodings JSON file
+        if os.path.exists("./dummy.encodings"):
+            os.remove("./dummy.encodings")
+
+    def test_load_encodings_param_disabled(self):
+        """ Test load encodings functionality with PCQ """
+
+        quantsim_config = {
+            "defaults": {
+                "ops": {
+                    "is_output_quantized": "True",
+                    "is_symmetric": "True"
+                },
+                "params": {
+                    "is_quantized": "False",
+                    "is_symmetric": "True"
+                },
+            },
+            "params": {},
+            "op_type": {},
+            "supergroups": [],
+            "model_input": {},
+            "model_output": {}
+        }
+        with open('./quantsim_config.json', 'w') as f:
+            json.dump(quantsim_config, f)
+        tf.compat.v1.reset_default_graph()
+        with tf.device('/cpu:0'):
+            _ = keras_model()
+            init = tf.compat.v1.global_variables_initializer()
+
+        session = tf.compat.v1.Session()
+        session.run(init)
+
+        sim = QuantizationSimModel(session, ['conv2d_input'], ['keras_model/Softmax'],
+                                   config_file='./quantsim_config.json')
+        param_encodings = {'conv2d_1/Conv2D/ReadVariableOp:0': [{'bitwidth': 4, 'is_symmetric': False,
+                                                               'max': 0.14584073424339294,
+                                                               'min': -0.12761062383651733,
+                                                               'offset': -7.0, 'scale': 0.01823008991777897}]}
+        activation_encodings = {"conv2d_1/Tanh:0": [
+            {
+                "bitwidth": 8,
+                "dtype": "int",
+                "is_symmetric": "False",
+                "max": 5.98828125,
+                "min": -7.78128125,
+                "offset": -144,
+                "scale": 0.05399828431372549
+            }
+        ]}
+
+        dummy_encodings = {"activation_encodings": activation_encodings,
+                           "param_encodings": param_encodings}
+
+        # export encodings to JSON file
+        encoding_file_path = os.path.join('./', 'dummy.encodings')
+        with open(encoding_file_path, 'w') as encoding_fp:
+            json.dump(dummy_encodings, encoding_fp, sort_keys=True, indent=4)
+
+        sim.load_encodings_to_sim(encoding_path='./dummy.encodings')
+
+        # Check if parameter quantizer encoding not set
+        quantizer = sim.quantizer_config('conv2d_1/Conv2D/ReadVariableOp_quantized')
+        self.assertEqual(int(libpymo.TensorQuantizerOpMode.passThrough), quantizer.get_op_mode())
+        self.assertEqual(quantizer.is_encoding_valid(), False)
 
         # Check if activation quantizer encoding is set properly
         quantizer = sim.quantizer_config('conv2d_1/Tanh_quantized')

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
@@ -1171,7 +1171,7 @@ class TestQuantSim(unittest.TestCase):
             del sim
 
     def test_load_encodings(self):
-        """ Test set and freeze parameter encodings functionality """
+        """ Test load encodings functionality """
         tf.compat.v1.reset_default_graph()
         with tf.device('/cpu:0'):
             _ = keras_model()
@@ -1216,7 +1216,111 @@ class TestQuantSim(unittest.TestCase):
 
         self.assertEqual(encoding_min, encoding.get('min'))
         self.assertEqual(encoding_max, encoding.get('max'))
+        self.assertEqual(int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize), quantizer.get_op_mode())
+        self.assertEqual(quantizer.is_encoding_valid(), True)
+
+        # Check if activation quantizer encoding is set properly
+        quantizer = sim.quantizer_config('conv2d_1/Tanh_quantized')
+        encoding = activation_encodings['conv2d_1/Tanh:0'][0]
+
+        encoding_max = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_max)
+        encoding_min = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_min)
+
+        self.assertEqual(encoding_min, encoding.get('min'))
+        self.assertEqual(encoding_max, encoding.get('max'))
         self.assertEqual(int(libpymo.TensorQuantizerOpMode.quantizeDequantize), quantizer.get_op_mode())
+        self.assertEqual(quantizer.is_encoding_valid(), True)
+
+        session.close()
+
+        # Delete encodings JSON file
+        if os.path.exists("./dummy.encodings"):
+            os.remove("./dummy.encodings")
+
+
+    def test_load_encodings_pcq(self):
+        """ Test load encodings functionality with PCQ """
+
+        quantsim_config = {
+            "defaults": {
+                "ops": {
+                    "is_output_quantized": "True",
+                    "is_symmetric": "True"
+                },
+                "params": {
+                    "is_quantized": "False",
+                    "is_symmetric": "True"
+                },
+                "per_channel_quantization": "True",
+            },
+            "params": {},
+            "op_type": {},
+            "supergroups": [],
+            "model_input": {},
+            "model_output": {}
+        }
+        with open('./quantsim_config.json', 'w') as f:
+            json.dump(quantsim_config, f)
+        tf.compat.v1.reset_default_graph()
+        with tf.device('/cpu:0'):
+            _ = keras_model()
+            init = tf.compat.v1.global_variables_initializer()
+
+        session = tf.compat.v1.Session()
+        session.run(init)
+
+        sim = QuantizationSimModel(session, ['conv2d_input'], ['keras_model/Softmax'],
+                                   config_file='./quantsim_config.json')
+        param_encodings = {'conv2d_1/Conv2D/ReadVariableOp:0': [{'bitwidth': 4, 'is_symmetric': False,
+                                                               'max': 0.14584073424339294,
+                                                               'min': -0.12761062383651733,
+                                                               'offset': -7.0, 'scale': 0.01823008991777897},
+                                                              {'bitwidth': 4, 'is_symmetric': False,
+                                                               'max': 0.14584073424339294,
+                                                               'min': -0.12761062383651733,
+                                                               'offset': -7.0, 'scale': 0.01823008991777897},
+                                                              {'bitwidth': 4, 'is_symmetric': False,
+                                                               'max': 0.14584073424339294,
+                                                               'min': -0.12761062383651733,
+                                                               'offset': -7.0, 'scale': 0.01823008991777897},
+                                                              {'bitwidth': 4, 'is_symmetric': False,
+                                                               'max': 0.14584073424339294,
+                                                               'min': -0.12761062383651733,
+                                                               'offset': -7.0, 'scale': 0.01823008991777897}]}
+        activation_encodings = {"conv2d_1/Tanh:0": [
+            {
+                "bitwidth": 8,
+                "dtype": "int",
+                "is_symmetric": "False",
+                "max": 5.98828125,
+                "min": -7.78128125,
+                "offset": -144,
+                "scale": 0.05399828431372549
+            }
+        ]}
+
+        dummy_encodings = {"activation_encodings": activation_encodings,
+                           "param_encodings": param_encodings}
+
+        # export encodings to JSON file
+        encoding_file_path = os.path.join('./', 'dummy.encodings')
+        with open(encoding_file_path, 'w') as encoding_fp:
+            json.dump(dummy_encodings, encoding_fp, sort_keys=True, indent=4)
+
+        sim.load_encodings_to_sim(encoding_path='./dummy.encodings')
+
+        # Check if parameter quantizer encoding is set properly
+        quantizer = sim.quantizer_config('conv2d_1/Conv2D/ReadVariableOp_quantized')
+        encoding = param_encodings['conv2d_1/Conv2D/ReadVariableOp:0']
+
+        encoding_max = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_max)
+        encoding_min = quantizer.get_variable_from_op(QuantizeOpIndices.encoding_min)
+
+        enc_min = [e.get('min') for e in encoding]
+        enc_max = [e.get('max') for e in encoding]
+        self.assertTrue(np.allclose(encoding_min, enc_min))
+        self.assertTrue(np.allclose(encoding_max, enc_max))
+        self.assertEqual(int(libpymo.TensorQuantizerOpMode.oneShotQuantizeDequantize), quantizer.get_op_mode())
         self.assertEqual(quantizer.is_encoding_valid(), True)
 
         # Check if activation quantizer encoding is set properly


### PR DESCRIPTION
Fix for #1939 
API to load encodings from encoding file to the sim object for keras and TF.