### PR TITLE
Enhance model preparer support

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
@@ -43,7 +43,8 @@ import torch
 import torch.nn
 
 
-def forward_function_wrapper(functional):
+def forward_function_wrapper(functional: str) -> Callable:
+    """ Wrapper function returning forward pass function"""
     @staticmethod
     def forward(*args, **kwargs) -> torch.Tensor:
         """
@@ -52,11 +53,12 @@ def forward_function_wrapper(functional):
         return functional(*args, **kwargs)
     return forward
 
-def create_wrapper_module(class_name, functional):
-    WrappedModule = type(class_name, (torch.nn.Module,), dict(forward=forward_function_wrapper(functional)))
-    return WrappedModule
+def create_wrapper_module(class_name: str, functional: str) -> type:
+    """ Wrapper function returning module class for a functional op"""
+    wrapped_module = type(class_name, (torch.nn.Module,), dict(forward=forward_function_wrapper(functional)))
+    return wrapped_module
 
-# Modules with args and kwargs
+
 Interpolate = create_wrapper_module('Interpolate', torch.nn.functional.interpolate)
 MaxPool2d = create_wrapper_module('MaxPool2d', torch.nn.functional.max_pool2d)
 AdaptiveAvgPool2d = create_wrapper_module('AdaptiveAvgPool2d', torch.nn.functional.adaptive_avg_pool2d)

--- a/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
@@ -38,6 +38,7 @@
 
 """ Modules for functional elementwise ops """
 
+from typing import Callable
 import torch
 import torch.nn
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
@@ -86,6 +86,17 @@ class Divide(torch.nn.Module):
         return torch.div(x, y)
 
 
+class FloorDivide(torch.nn.Module):
+    """ Floor Divide module for a functional floor divide"""
+    # pylint:disable=arguments-differ
+    @staticmethod
+    def forward(x: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
+        """
+        Forward-pass routine for floor divide op
+        """
+        return torch.floor_divide(x, y)
+
+
 class Concat(torch.nn.Module):
     """ Concat module for a functional concat"""
     def __init__(self, axis: int = 0):
@@ -162,3 +173,53 @@ class AdaptiveAvgPool2d(torch.nn.Module):
         Forward-pass routine for adaptive_avg_pool2d op
         """
         return torch.nn.functional.adaptive_avg_pool2d(*args, **kwargs)
+
+
+class AvgPool2d(torch.nn.Module):
+    """ AvgPool2d module for a functional avg_pool2d"""
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for avg_pool2d op
+        """
+        return torch.nn.functional.avg_pool2d(*args, **kwargs)
+
+
+class Norm(torch.nn.Module):
+    """ AvgPool2d module for a functional norm"""
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for norm op
+        """
+        return torch.norm(*args, **kwargs)
+
+
+class Chunk(torch.nn.Module):
+    """ Chunk module for a functional chunk"""
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for chunk op
+        """
+        return torch.chunk(*args, **kwargs)
+
+
+class BatchNorm(torch.nn.Module):
+    """ BatchNorm module for a functional batchnorm"""
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for batchnorm op
+        """
+        return torch.nn.functional.batch_norm(*args, **kwargs)
+
+
+class GroupNorm(torch.nn.Module):
+    """ GroupNorm module for a functional groupnorm"""
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for groupnorm op
+        """
+        return torch.nn.functional.group_norm(*args, **kwargs)

--- a/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/elementwise_ops.py
@@ -42,6 +42,30 @@ import torch
 import torch.nn
 
 
+def forward_function_wrapper(functional):
+    @staticmethod
+    def forward(*args, **kwargs) -> torch.Tensor:
+        """
+        Forward-pass routine for the functional op
+        """
+        return functional(*args, **kwargs)
+    return forward
+
+def create_wrapper_module(class_name, functional):
+    WrappedModule = type(class_name, (torch.nn.Module,), dict(forward=forward_function_wrapper(functional)))
+    return WrappedModule
+
+# Modules with args and kwargs
+Interpolate = create_wrapper_module('Interpolate', torch.nn.functional.interpolate)
+MaxPool2d = create_wrapper_module('MaxPool2d', torch.nn.functional.max_pool2d)
+AdaptiveAvgPool2d = create_wrapper_module('AdaptiveAvgPool2d', torch.nn.functional.adaptive_avg_pool2d)
+AvgPool2d = create_wrapper_module('AvgPool2d', torch.nn.functional.avg_pool2d)
+Norm = create_wrapper_module('Norm', torch.norm)
+Chunk = create_wrapper_module('Chunk', torch.chunk)
+BatchNorm = create_wrapper_module('BatchNorm', torch.nn.functional.batch_norm)
+GroupNorm = create_wrapper_module('GroupNorm', torch.nn.functional.group_norm)
+
+
 class Add(torch.nn.Module):
     """ Add module for a functional add"""
     # pylint:disable=arguments-differ
@@ -122,16 +146,6 @@ class MatMul(torch.nn.Module):
         return torch.matmul(x, y)
 
 
-class Interpolate(torch.nn.Module):
-    """ Interpolate module for a functional interpolate"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for interpolate op
-        """
-        return torch.nn.functional.interpolate(*args, **kwargs)
-
-
 class DynamicConv2d(torch.nn.Module):
     """ Conv2d module for a functional conv2d"""
     def __init__(self, stride=1, padding=0, dilation=1, groups=1):
@@ -153,73 +167,3 @@ class Exponential(torch.nn.Module):
         Forward-pass routine for exponential op
         """
         return torch.exp(x)
-
-
-class MaxPool2d(torch.nn.Module):
-    """ MaxPool2d module for a functional MaxPool2d"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for MaxPool2d op
-        """
-        return torch.nn.functional.max_pool2d(*args, **kwargs)
-
-
-class AdaptiveAvgPool2d(torch.nn.Module):
-    """ AdaptiveAvgPool2d module for a functional adaptive_avg_pool2d"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for adaptive_avg_pool2d op
-        """
-        return torch.nn.functional.adaptive_avg_pool2d(*args, **kwargs)
-
-
-class AvgPool2d(torch.nn.Module):
-    """ AvgPool2d module for a functional avg_pool2d"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for avg_pool2d op
-        """
-        return torch.nn.functional.avg_pool2d(*args, **kwargs)
-
-
-class Norm(torch.nn.Module):
-    """ AvgPool2d module for a functional norm"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for norm op
-        """
-        return torch.norm(*args, **kwargs)
-
-
-class Chunk(torch.nn.Module):
-    """ Chunk module for a functional chunk"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for chunk op
-        """
-        return torch.chunk(*args, **kwargs)
-
-
-class BatchNorm(torch.nn.Module):
-    """ BatchNorm module for a functional batchnorm"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for batchnorm op
-        """
-        return torch.nn.functional.batch_norm(*args, **kwargs)
-
-
-class GroupNorm(torch.nn.Module):
-    """ GroupNorm module for a functional groupnorm"""
-    @staticmethod
-    def forward(*args, **kwargs) -> torch.Tensor:
-        """
-        Forward-pass routine for groupnorm op
-        """
-        return torch.nn.functional.group_norm(*args, **kwargs)

--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -139,6 +139,7 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         'view',
         'narrow',
         'reshape',
+        'reshape_as',
         'mean',
         'index_select',
         'slice',
@@ -152,7 +153,8 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         'copy',
         'clone',
         'index',
-        'ScalarImplicit'
+        'ScalarImplicit',
+        'transpose'
     }
 
     # Graph nodes for which which we will treat as passthrough and not represent with an Op

--- a/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
@@ -92,7 +92,9 @@ functional_with_kwargs = {
     'mul'           : elementwise_ops.Multiply,
     'div'           : elementwise_ops.Divide,
     'truediv'       : elementwise_ops.Divide,
+    'floordiv'      : elementwise_ops.FloorDivide,
     'matmul'        : elementwise_ops.MatMul,
+    'exp'           : elementwise_ops.Exponential,
 }
 
 
@@ -112,6 +114,11 @@ functional_with_args_kwargs = {
     'max_pool2d'                : elementwise_ops.MaxPool2d,
     'max_pool2d_with_indices'   : elementwise_ops.MaxPool2d,
     'adaptive_avg_pool2d'       : elementwise_ops.AdaptiveAvgPool2d,
+    'avg_pool2d'                : elementwise_ops.AvgPool2d,
+    'norm'                      : elementwise_ops.Norm,
+    'chunk'                     : elementwise_ops.Chunk,
+    'batch_norm'                : elementwise_ops.BatchNorm,
+    'group_norm'                : elementwise_ops.GroupNorm,
 }
 
 

--- a/TrainingExtensions/torch/test/python/test_model_preparer.py
+++ b/TrainingExtensions/torch/test/python/test_model_preparer.py
@@ -1447,7 +1447,7 @@ class TestFX:
         assert hasattr(prepared, "custom")
 
     def test_fx_with_max_pool2d_indices(self):
-        """ test torch fx with adaptive_avg_pool2d """
+        """ test torch fx with max_pool2d """
         class ModelWithMaxPool2d(torch.nn.Module):
             def __init__(self):
                 super().__init__()
@@ -1491,3 +1491,81 @@ class TestFX:
         assert _find_functional_name_for_node("cat_123_1") == "cat"
         assert _find_functional_name_for_node("relu6_123") == "relu6"
         assert _find_functional_name_for_node("123_relu6_123") is None # Not a valid name.
+
+    def test_fx_with_chunk(self):
+        """ test torch fx with chunk """
+        class ModelWithChunk(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 4, kernel_size=2, stride=2, padding=2)
+                self.conv2 = torch.nn.Conv2d(2, 4, kernel_size=2, stride=2, padding=2)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x1, x2 = x.chunk(2, dim=1)
+                x2 = self.conv2(x2)
+                return x1, x2
+
+        input_shape = (1, 3, 64, 64)
+        dummy_input = torch.randn(input_shape)
+        model = ModelWithChunk().eval()
+        model_transformed = prepare_model(model)
+
+        # Compare both outputs.
+        assert torch.equal(model_transformed(dummy_input)[0], model(dummy_input)[0])
+        assert torch.equal(model_transformed(dummy_input)[1], model(dummy_input)[1])
+
+        # Verify that the modules are added correctly
+        assert isinstance(model_transformed.module_chunk, elementwise_ops.Chunk)
+
+        # Verify Quantization workflow.
+        sim = QuantizationSimModel(model_transformed, dummy_input=dummy_input)
+        sim.compute_encodings(evaluate, forward_pass_callback_args=dummy_input)
+
+        # Quantizer enabled for both outputs of Chunk
+        assert sim.model.module_chunk.output_quantizers[0].enabled
+        assert sim.model.module_chunk.output_quantizers[1].enabled
+
+    def test_fx_with_functional_batchnorm(self):
+        """ test torch fx with function batchnorm """
+        class ModelWithFunctionalBN(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.conv1 = torch.nn.Conv2d(3, 4, kernel_size=2, stride=2, padding=2)
+                self.conv2 = torch.nn.Conv2d(4, 4, kernel_size=2, stride=2, padding=2)
+                self.rm = torch.tensor([1.0,1.0,1.0,1.0], requires_grad=False)
+                self.rv = torch.tensor([0.0,0.0,0.0,0.0], requires_grad=False)
+
+            def forward(self, x):
+                x = self.conv1(x)
+                x = torch.nn.functional.batch_norm(x, running_mean=self.rm, running_var=self.rv)
+                x = self.conv2(x)
+                x = torch.nn.functional.batch_norm(x, running_mean=self.rm, running_var=self.rv, momentum=0.2, eps=1e-4)
+                return x
+
+        input_shape = (1, 3, 64, 64)
+        dummy_input = torch.randn(input_shape)
+        model = ModelWithFunctionalBN().eval()
+        model_transformed = prepare_model(model)
+        model(dummy_input)
+
+        # Compare output.
+        assert torch.equal(model_transformed(dummy_input), model(dummy_input))
+
+        # Verify that the modules are added correctly
+        assert isinstance(model_transformed.module_batch_norm, elementwise_ops.BatchNorm)
+        assert isinstance(model_transformed.module_batch_norm_1, elementwise_ops.BatchNorm)
+
+        # Verify Quantization workflow.
+        sim = QuantizationSimModel(model_transformed, dummy_input=dummy_input)
+        sim.compute_encodings(evaluate, forward_pass_callback_args=dummy_input)
+
+        # Quantizer enabled for output
+        assert sim.model.module_batch_norm.output_quantizers[0].enabled
+        assert sim.model.module_batch_norm_1.output_quantizers[0].enabled
+
+        # Apply Batchnorm folding
+        fold_all_batch_norms(model_transformed, input_shape)
+
+        # Compare output after bnf
+        assert torch.equal(model_transformed(dummy_input)[0], model(dummy_input)[0])

--- a/TrainingExtensions/torch/test/python/test_model_preparer.py
+++ b/TrainingExtensions/torch/test/python/test_model_preparer.py
@@ -1533,8 +1533,8 @@ class TestFX:
                 super().__init__()
                 self.conv1 = torch.nn.Conv2d(3, 4, kernel_size=2, stride=2, padding=2)
                 self.conv2 = torch.nn.Conv2d(4, 4, kernel_size=2, stride=2, padding=2)
-                self.rm = torch.tensor([1.0,1.0,1.0,1.0], requires_grad=False)
-                self.rv = torch.tensor([0.0,0.0,0.0,0.0], requires_grad=False)
+                self.rm = torch.tensor([1.0, 1.0, 1.0, 1.0], requires_grad=False)
+                self.rv = torch.tensor([0.0, 0.0, 0.0, 0.0], requires_grad=False)
 
             def forward(self, x):
                 x = self.conv1(x)


### PR DESCRIPTION
This change adds the following:

1. Support for following ops: floordivide, chunk, norm, avgpool2d, batchnorm, and groupnorm in model preparer.
2. Add transpose and reshape_as as math invariant ops
3. Modules with args and kwargs are now initialized in elementwise_ops using a common custom metaclass.
4. Added test cases for chunk and batch_norm in test_model_preparer.