### PR TITLE
Fix the problem of out-of-memory and the number of workers used by image_net_trainer

### DIFF
--- a/Examples/torch/utils/image_net_trainer.py
+++ b/Examples/torch/utils/image_net_trainer.py
@@ -71,7 +71,7 @@ class ImageNetTrainer:
                                                 is_training=True, num_workers=num_workers,
                                                 num_samples_per_class=num_train_samples_per_class).data_loader
 
-        self._evaluator = ImageNetEvaluator(images_dir=images_dir, image_size=image_size, batch_size=batch_size, 
+        self._evaluator = ImageNetEvaluator(images_dir=images_dir, image_size=image_size, batch_size=batch_size,
                                             num_workers=num_workers)
 
     def _train_loop(self, model: nn.Module, criterion: torch.nn.modules.loss, optimizer: torch.optim,

--- a/Examples/torch/utils/image_net_trainer.py
+++ b/Examples/torch/utils/image_net_trainer.py
@@ -71,7 +71,8 @@ class ImageNetTrainer:
                                                 is_training=True, num_workers=num_workers,
                                                 num_samples_per_class=num_train_samples_per_class).data_loader
 
-        self._evaluator = ImageNetEvaluator(images_dir=images_dir, image_size=image_size, batch_size=batch_size)
+        self._evaluator = ImageNetEvaluator(images_dir=images_dir, image_size=image_size, batch_size=batch_size, 
+                                            num_workers=num_workers)
 
     def _train_loop(self, model: nn.Module, criterion: torch.nn.modules.loss, optimizer: torch.optim,
                     max_iterations: int, current_epoch: int, max_epochs: int,
@@ -113,7 +114,7 @@ class ImageNetTrainer:
                 # compute model output
                 output = model(images)
                 loss = criterion(output, target)
-                avg_loss += loss
+                avg_loss += loss.item()
 
                 # compute gradient and do SGD step
                 optimizer.zero_grad()


### PR DESCRIPTION
Add .item() to avoid out-of-memory problem on cpu/gpu due to accumulating gradients of loss
Add num_workers parameter to ImageNetEvaluator to enable modifying the number of processes used