### PR TITLE
Support for Percentile QuantScheme in TF and Keras

### DIFF
--- a/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
@@ -111,6 +111,18 @@ public:
         // This method is applicable only for TfPercentileEncodingAnalyzer.
         assert(0);
     }
+
+    /**
+     * @brief Fecth the percentile value
+     *
+     * @return percentile value of the encoding analyzer.
+     */
+    virtual float getPercentileValue()
+    {
+        // TODO - check if there is a better way to do this.
+        // This method is applicable only for TfPercentileEncodingAnalyzer.
+        assert(0);
+    }
 };
 
 

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/IQuantizationEncodingAnalyzer.hpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2019-2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2019-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
@@ -218,6 +218,13 @@ public:
      * @param splits    Slices of the input tensor along the axis
      * @param splitShape The shape of each input slice
      */
+
+    /**
+     * @brief Sets the specified percentile value for the encoding analyzer
+     * @param percentile Percentile value to set.
+     */
+    void setPercentileValue(float percentile);
+
     void generatePerChannelEncodings(const float* input, const std::vector<uint32_t> &inputShape, uint32_t axis,
                                      std::vector<TfEncoding> &encodings, uint32_t bw, std::vector<std::vector<float>> &splits,
                                      std::vector<uint32_t> &splitShape, bool useCuda);

--- a/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/TensorQuantizer.h
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2020 - 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2020 - 2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -221,9 +221,17 @@ public:
 
     /**
      * @brief Sets the specified percentile value for the encoding analyzer
+     *
      * @param percentile Percentile value to set.
      */
     void setPercentileValue(float percentile);
+
+    /**
+     * @brief Fetches the percentile value for the encoding analyzer
+     *
+     * @return Percentile value of the encoding analyzer.
+     */
+    float getPercentileValue();
 
     void generatePerChannelEncodings(const float* input, const std::vector<uint32_t> &inputShape, uint32_t axis,
                                      std::vector<TfEncoding> &encodings, uint32_t bw, std::vector<std::vector<float>> &splits,

--- a/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -205,6 +205,12 @@ template <typename DTYPE>
 void PercentileEncodingAnalyzer<DTYPE>::setPercentileValue(float percentile)
 {
     this->_percentile = percentile;
+}
+
+template <typename DTYPE>
+float PercentileEncodingAnalyzer<DTYPE>::getPercentileValue()
+{
+    return this->_percentile;
 }
 
 // Explicit instantiations

--- a/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.h
+++ b/ModelOptimizations/DlQuantization/src/PercentileEncodingAnalyzer.h
@@ -1,7 +1,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -87,6 +87,13 @@ public:
      * @param percentile Percentile value to be used while adjusting min and max
      */
     void setPercentileValue(float percentile);
+
+    /**
+     * @brief Fetch the Percentile Value of the encoding analyzer
+     *
+     * @return percentile value
+     */
+    float getPercentileValue();
 
 private:
     PDF _stats;

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizer.cpp
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizer.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2020 - 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2020 - 2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -236,6 +236,15 @@ void TensorQuantizer::setPercentileValue(float percentile)
     if (_quantScheme == DlQuantization::QuantizationMode::QUANTIZATION_PERCENTILE) {
         _encodingAnalyzer->setPercentileValue(percentile);
     }
+}
+
+float TensorQuantizer::getPercentileValue()
+{
+    if (_quantScheme == DlQuantization::QuantizationMode::QUANTIZATION_PERCENTILE) {
+        return _encodingAnalyzer->getPercentileValue();
+    }
+    else
+        throw std::runtime_error("Percentile Value only exists in case of percentile quant scheme.");
 }
 
 void TensorQuantizer::generatePerChannelEncodings(const float* input, const std::vector<uint32_t>& inputShape,

--- a/ModelOptimizations/DlQuantization/src/TensorQuantizer.cpp
+++ b/ModelOptimizations/DlQuantization/src/TensorQuantizer.cpp
@@ -229,6 +229,15 @@ std::vector<std::tuple<double, double>> TensorQuantizer::getStatsHistogram()
     auto histogram = _encodingAnalyzer->getStatsHistogram();
     return histogram;
 }
+
+void TensorQuantizer::setPercentileValue(float percentile)
+{
+    // Set percentile value only when quant scheme is percentile.
+    if (_quantScheme == DlQuantization::QuantizationMode::QUANTIZATION_PERCENTILE) {
+        _encodingAnalyzer->setPercentileValue(percentile);
+    }
+}
+
 void TensorQuantizer::generatePerChannelEncodings(const float* input, const std::vector<uint32_t>& inputShape,
                                                   uint32_t axis, std::vector<TfEncoding>& encodings, uint32_t bw,
                                                   std::vector<std::vector<float>>& splits,

--- a/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
@@ -168,6 +168,7 @@ PYBIND11_MODULE(libpymo, m)
         .def("setUnsignedSymmetric", &DlQuantization::PyTensorQuantizer::setUnsignedSymmetric)
         .def("getUnsignedSymmetric", &DlQuantization::PyTensorQuantizer::getUnsignedSymmetric)
         .def("getStatsHistogram", &DlQuantization::PyTensorQuantizer::getStatsHistogram)
+        .def("setPercentileValue", &DlQuantization::PyTensorQuantizer::setPercentileValue)
         .def("computePartialEncoding", &DlQuantization::PyTensorQuantizer::computePartialEncoding)
         .def_readwrite("roundingMode", &DlQuantization::PyTensorQuantizer::roundingMode)
         .def_readwrite("isEncodingValid", &DlQuantization::PyTensorQuantizer::isEncodingValid);

--- a/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
+++ b/ModelOptimizations/PyModelOptimizations/PyModelOptimizations.cpp
@@ -2,7 +2,7 @@
 //
 //  @@-COPYRIGHT-START-@@
 //
-//  Copyright (c) 2020 - 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+//  Copyright (c) 2020 - 2023, Qualcomm Innovation Center, Inc. All rights reserved.
 //
 //  Redistribution and use in source and binary forms, with or without
 //  modification, are permitted provided that the following conditions are met:
@@ -169,6 +169,7 @@ PYBIND11_MODULE(libpymo, m)
         .def("getUnsignedSymmetric", &DlQuantization::PyTensorQuantizer::getUnsignedSymmetric)
         .def("getStatsHistogram", &DlQuantization::PyTensorQuantizer::getStatsHistogram)
         .def("setPercentileValue", &DlQuantization::PyTensorQuantizer::setPercentileValue)
+        .def("getPercentileValue", &DlQuantization::PyTensorQuantizer::getPercentileValue)
         .def("computePartialEncoding", &DlQuantization::PyTensorQuantizer::computePartialEncoding)
         .def_readwrite("roundingMode", &DlQuantization::PyTensorQuantizer::roundingMode)
         .def_readwrite("isEncodingValid", &DlQuantization::PyTensorQuantizer::isEncodingValid);

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/qc_quantize_wrapper.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/qc_quantize_wrapper.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -68,6 +68,8 @@ class QuantizerSettings:
                 quant_scheme = QuantScheme.post_training_tf
             elif quant_scheme == 'tf_enhanced':
                 quant_scheme = QuantScheme.post_training_tf_enhanced
+            elif quant_scheme == "percentile":
+                quant_scheme = QuantScheme.post_training_percentile
             else:
                 error_msg = f'Unsupported quant scheme: {quant_scheme}'
                 _logger.error(error_msg)

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -506,13 +506,25 @@ class StaticGridPerTensorQuantizer(TensorQuantizer):
     def set_percentile_value(self, percentile: float):
         """
         Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+
         :param percentile: Percentile value to set
-        :return:
         """
         if self._quant_scheme != QuantScheme.post_training_percentile:
             raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
 
         self.tensor_quantizer.setPercentileValue(percentile)
+
+    def get_percentile_value(self) -> float:
+        """
+        Fetches the percentile value to the tensor quantizer only in case of percentile quant scheme.
+
+        :return Percentile value of the quantizer
+        """
+        if self._quant_scheme != QuantScheme.post_training_percentile:
+            raise RuntimeError("get_percentile_value() can be invoked only when quantization scheme is Percentile.")
+
+        return self.tensor_quantizer.getPercentileValue()
+
 
 
 # pylint: disable=too-many-ancestors
@@ -878,13 +890,25 @@ class StaticGridPerChannelQuantizer(TensorQuantizer):
     def set_percentile_value(self, percentile: float):
         """
         Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+
         :param percentile: Percentile value to set
-        :return:
         """
         if self._quant_scheme != QuantScheme.post_training_percentile:
             raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
         for quantizer in self.tensor_quantizer:
             quantizer.setPercentileValue(percentile)
+
+    def get_percentile_value(self) -> List[float]:
+        """
+        Fetches the percentile value to the tensor quantizer only in case of percentile quant scheme.
+
+        :return Percentile value of the quantizer
+        """
+
+        if self._quant_scheme != QuantScheme.post_training_percentile:
+            raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
+
+        return [quantizer.getPercentileValue() for quantizer in self.tensor_quantizer]
 
 # pylint: disable=too-many-ancestors
 class ParamPerChannelQuantizer(StaticGridPerChannelQuantizer):

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quant_sim/tensor_quantizer.py
@@ -503,6 +503,17 @@ class StaticGridPerTensorQuantizer(TensorQuantizer):
         histograms = [self.tensor_quantizer.getStatsHistogram()]
         return histograms
 
+    def set_percentile_value(self, percentile: float):
+        """
+        Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+        :param percentile: Percentile value to set
+        :return:
+        """
+        if self._quant_scheme != QuantScheme.post_training_percentile:
+            raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
+
+        self.tensor_quantizer.setPercentileValue(percentile)
+
 
 # pylint: disable=too-many-ancestors
 class ParamPerTensorQuantizer(StaticGridPerTensorQuantizer):
@@ -864,6 +875,16 @@ class StaticGridPerChannelQuantizer(TensorQuantizer):
         histograms = [quantizer.getStatsHistogram() for quantizer in self.tensor_quantizer]
         return histograms
 
+    def set_percentile_value(self, percentile: float):
+        """
+        Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+        :param percentile: Percentile value to set
+        :return:
+        """
+        if self._quant_scheme != QuantScheme.post_training_percentile:
+            raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
+        for quantizer in self.tensor_quantizer:
+            quantizer.setPercentileValue(percentile)
 
 # pylint: disable=too-many-ancestors
 class ParamPerChannelQuantizer(StaticGridPerChannelQuantizer):

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
@@ -123,6 +123,7 @@ class QuantizationSimModel(tf.keras.Model):
                                                                              default_output_bw, default_param_bw,
                                                                              default_data_type, config_file)
         self.quant_scheme = quant_scheme
+        self._percentile_value = 100  # default percentile value
         self.per_channel_quantization_enabled = self._quantsim_configurator.per_channel_quantization_flag
         self.model = self._add_quantization_wrappers(quant_scheme, rounding_mode,
                                                      default_output_bw, default_param_bw, default_data_type)
@@ -148,6 +149,41 @@ class QuantizationSimModel(tf.keras.Model):
                          f'Layers with multiple inbound nodes: {multiple_inbound_node_layers}')
             _logger.error(error_msg)
             raise NotImplementedError(error_msg)
+
+    def _get_quantizer_list(self) -> Tuple[List, List, List]:
+        """
+        Method to provide a list of input, output and parameter quantizers
+        :return: Three lists containing input, paramater and output quantizers respectively
+        """
+        input_quantizers = []
+        parameter_quantizers = []
+        output_quantizers = []
+
+        for wrapper in self.quant_wrappers():
+            for quantizer in wrapper.input_quantizers:
+                input_quantizers.append(quantizer)
+
+            for quantizer in wrapper.param_quantizers:
+                parameter_quantizers.append(quantizer)
+
+            for quantizer in wrapper.output_quantizers:
+                output_quantizers.append(quantizer)
+
+        return input_quantizers, parameter_quantizers, output_quantizers
+
+    def set_percentile_value(self, percentile_value: float):
+        """
+        Set the percentile value to be used while computing encodings
+        """
+        if percentile_value < 90 or percentile_value > 100:
+            raise ValueError("Percentile value must be in range [90, 100]")
+        self._percentile_value = percentile_value
+
+        if self.quant_scheme == QuantScheme.post_training_percentile:
+            # Set the percentile value to the activation quantizers:
+            input_quantizers, _, output_quantizers = self._get_quantizer_list()
+            for quantizer in input_quantizers  + output_quantizers:
+                quantizer.set_percentile_value(self._percentile_value)
 
     def _initialize_quantsim_configurator(self, quant_scheme: Union[QuantScheme, str], rounding_mode: str,
                                           default_output_bw: int, default_param_bw: int,

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
@@ -82,6 +82,7 @@ class QuantizationSimModelParams:
     default_data_type: QuantizationDataType = QuantizationDataType.int
 
 # pylint: disable=too-many-ancestors
+# pylint: disable=too-many-instance-attributes
 class QuantizationSimModel(tf.keras.Model):
     """
     Implements mechanism to add quantization simulations ops to a model. This allows for off-target simulation of

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/quantsim.py
@@ -3,7 +3,7 @@
 # =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2022, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -173,16 +173,18 @@ class QuantizationSimModel(tf.keras.Model):
 
     def set_percentile_value(self, percentile_value: float):
         """
-        Set the percentile value to be used while computing encodings
+        Set the percentile value to be used while computing encodings for quantizers having percentile quant scheme.
+
+        :param percentile_value: Percentile value to be set to
         """
         if percentile_value < 90 or percentile_value > 100:
             raise ValueError("Percentile value must be in range [90, 100]")
         self._percentile_value = percentile_value
 
-        if self.quant_scheme == QuantScheme.post_training_percentile:
-            # Set the percentile value to the activation quantizers:
-            input_quantizers, _, output_quantizers = self._get_quantizer_list()
-            for quantizer in input_quantizers  + output_quantizers:
+        # Set the percentile value to the activation quantizers
+        input_quantizers, _, output_quantizers = self._get_quantizer_list()
+        for quantizer in input_quantizers + output_quantizers:
+            if quantizer.quant_scheme == QuantScheme.post_training_percentile:
                 quantizer.set_percentile_value(self._percentile_value)
 
     def _initialize_quantsim_configurator(self, quant_scheme: Union[QuantScheme, str], rounding_mode: str,

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
@@ -334,13 +334,34 @@ class QuantizerInfo:
 
     def set_percentile_value(self, percentile: float):
         """
-        Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+        Sets the percentile value to the tensor quantizer only in case of percentile quant scheme.
+
         :param percentile: Percentile value to set
-        :return:
         """
         if self.quant_scheme != libpymo.QuantizationMode.QUANTIZATION_PERCENTILE:
             raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
-        self.tensor_quantizer.setPercentileValue(percentile)
+
+        if isinstance(self.tensor_quantizer, list):
+            for tensor_quantizer in self.tensor_quantizer:
+                tensor_quantizer.setPercentileValue(percentile)
+        else:
+            self.tensor_quantizer.setPercentileValue(percentile)
+
+    def get_percentile_value(self):
+        """
+        Fetches the percentile value to the tensor quantizer only in case of percentile quant scheme.
+
+        :return Percentile value of the quantizer
+        """
+        if self.quant_scheme != libpymo.QuantizationMode.QUANTIZATION_PERCENTILE:
+            raise RuntimeError("get_percentile_value() can be invoked only when quantization scheme is Percentile.")
+
+        if isinstance(self.tensor_quantizer, list):
+            percentile_values = [tensor_quantizer.getPercentileValue() for tensor_quantizer in self.tensor_quantizer]
+        else:
+            percentile_values = self.tensor_quantizer.getPercentileValue()
+
+        return percentile_values
 
     @property
     def enabled(self) -> bool:

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantizer_info.py
@@ -56,7 +56,9 @@ quant_scheme_to_libpymo = {QuantScheme.post_training_tf: libpymo.QuantizationMod
                            QuantScheme.training_range_learning_with_tf_init:
                                libpymo.QuantizationMode.QUANTIZATION_TF,
                            QuantScheme.training_range_learning_with_tf_enhanced_init:
-                               libpymo.QuantizationMode.QUANTIZATION_TF_ENHANCED}
+                               libpymo.QuantizationMode.QUANTIZATION_TF_ENHANCED,
+                           QuantScheme.post_training_percentile:
+                               libpymo.QuantizationMode.QUANTIZATION_PERCENTILE}
 
 
 class QuantizerType(Enum):
@@ -329,6 +331,16 @@ class QuantizerInfo:
         if not self._is_encoding_frozen:
             var_name = self.quant_op_name + '_op_mode'
             self.set_variable(var_name, int(op_mode))
+
+    def set_percentile_value(self, percentile: float):
+        """
+        Sets the percentile value to the tensor quantizer only in case of percentile quant scheme
+        :param percentile: Percentile value to set
+        :return:
+        """
+        if self.quant_scheme != libpymo.QuantizationMode.QUANTIZATION_PERCENTILE:
+            raise RuntimeError("set_percentile_value() can be invoked only when quantization scheme is Percentile.")
+        self.tensor_quantizer.setPercentileValue(percentile)
 
     @property
     def enabled(self) -> bool:

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
@@ -161,7 +161,8 @@ class QuantizationSimModel:
 
         if isinstance(quant_scheme, str):
             quant_scheme_lookup = {'tf': QuantScheme.post_training_tf,
-                                   'tf_enhanced': QuantScheme.post_training_tf_enhanced}
+                                   'tf_enhanced': QuantScheme.post_training_tf_enhanced,
+                                   'percentile': QuantScheme.post_training_percentile}
             quant_scheme = quant_scheme_lookup[quant_scheme]
         self._quant_scheme = quant_scheme
         self._rounding_mode = rounding_mode
@@ -170,6 +171,7 @@ class QuantizationSimModel:
         self._activation_quantizers = {}
         self._default_output_bw = default_output_bw
         self._default_param_bw = default_param_bw
+        self._percentile_value = 100  # default percentile value
         self._op_to_quant_ops_dict = {}
         self.connected_graph = ConnectedGraph(self.session.graph, starting_op_names, output_op_names)
 
@@ -223,6 +225,19 @@ class QuantizationSimModel:
 
         _logger.error('Could not find  Quantizer for given op {%s} ', quant_op_name)
         return None
+
+    def set_percentile_value(self, percentile_value: float):
+        """
+        Set the percentile value to be used while computing encodings
+        """
+        if percentile_value < 90 or percentile_value > 100:
+            raise ValueError("Percentile value must be in range [90, 100]")
+        self._percentile_value = percentile_value
+
+        if self._quant_scheme == QuantScheme.post_training_percentile:
+            # Set the percentile value to the activation quantizers:
+            for quant_info in self._activation_quantizers.values():
+                quant_info.set_percentile_value(self._percentile_value)
 
     def get_supported_kernels(self) -> Dict:
         """

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/quantsim.py
@@ -228,7 +228,9 @@ class QuantizationSimModel:
 
     def set_percentile_value(self, percentile_value: float):
         """
-        Set the percentile value to be used while computing encodings
+        Set the percentile value to be used while computing encodings for quantizers having percentile quant scheme.
+
+        :param percentile_value: Percentile value to set
         """
         if percentile_value < 90 or percentile_value > 100:
             raise ValueError("Percentile value must be in range [90, 100]")

--- a/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
@@ -1193,3 +1193,25 @@ def test_initialization_and_export_non_strict_symmetric_per_channel(quant_scheme
                 assert offset == -128
                 assert np.isclose(encoding_min, scale * offset, atol=1e-6)
                 assert np.isclose(encoding_max, encoding_min + scale * 255, atol=1e-6)
+
+def test_quant_scheme_percentile():
+    """
+    This test case ensures that the quantization is working fine with percentile scheme
+    :return:
+    """
+    if version.parse(tf.version.VERSION) >= version.parse("2.00"):
+        model = dense_functional()
+
+        qsim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf, default_param_bw=16, default_output_bw=16 )
+        _, _, output_quantizers = qsim._get_quantizer_list()
+        with pytest.raises(RuntimeError):
+            for quantizer in output_quantizers:
+                quantizer.set_percentile_value(99.99)
+
+        for quantizer in output_quantizers:
+            quantizer.quant_scheme = QuantScheme.post_training_percentile
+            quantizer.set_percentile_value(99.99)
+
+        assert 0 == 0
+
+

--- a/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/eager/test_quantsim_keras.py
@@ -1211,7 +1211,22 @@ def test_quant_scheme_percentile():
         for quantizer in output_quantizers:
             quantizer.quant_scheme = QuantScheme.post_training_percentile
             quantizer.set_percentile_value(99.99)
+            assert np.allclose(quantizer.get_percentile_value(), 99.99)
 
-        assert 0 == 0
+
+
+def test_quant_scheme_percentile_setting_using_str():
+    """
+    This test case ensures that the quantization is working fine with percentile scheme
+    :return:
+    """
+    if version.parse(tf.version.VERSION) >= version.parse("2.00"):
+        model = dense_functional()
+
+        qsim = QuantizationSimModel(model, quant_scheme="percentile", default_param_bw=16, default_output_bw=16 )
+        inp_quatizer, paramater_quantizer, output_quantizers = qsim._get_quantizer_list()
+
+        for quantizer in inp_quatizer + paramater_quantizer + output_quantizers:
+            assert quantizer.quant_scheme == QuantScheme.post_training_percentile
 
 

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
@@ -320,6 +320,32 @@ class TestQuantSim(unittest.TestCase):
         sim.session.close()
         del sim
 
+    def test_percentile_quant_scheme(self):
+        """
+        Create QuantSim for a CPU model and check that quantizers have been added to the graph
+        """
+        tf.compat.v1.reset_default_graph()
+        with tf.device('/cpu:0'):
+            model = tf.keras.Sequential()
+            model.add(tf.keras.layers.Conv2D(32, kernel_size=3, input_shape=(28, 28, 3), activation='relu'))
+            model.add(tf.keras.layers.MaxPooling2D((2, 2)))
+            model.add(tf.keras.layers.Conv2D(64, kernel_size=3, activation='relu'))
+            model.summary()
+
+        sess = tf.compat.v1.Session()
+        initialize_uninitialized_vars(sess)
+        sim = QuantizationSimModel(sess, ['conv2d_input'], ['conv2d_1/Relu'], quant_scheme=QuantScheme.post_training_tf ,use_cuda=False)
+        activation_quantizers = sim._activation_quantizers.values()
+        with pytest.raises(RuntimeError):
+            for quant_info in activation_quantizers:
+                quant_info.set_percentile_value(99.99)
+
+        for quant_info in activation_quantizers:
+            quant_info.quant_scheme = QuantScheme.post_training_percentile
+            quant_info.set_percentile_value(99.99)
+
+        assert 0 == 0
+
     def test_compute_encodings_cpu_model_fp16(self):
         """
         Create QuantSim for a CPU model and test that activation encodings are computed

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
@@ -343,8 +343,30 @@ class TestQuantSim(unittest.TestCase):
         for quant_info in activation_quantizers:
             quant_info.quant_scheme = QuantScheme.post_training_percentile
             quant_info.set_percentile_value(99.99)
+            assert np.allclose(quant_info.get_percentile_value(), 99.99)
 
-        assert 0 == 0
+
+    def test_percentile_quant_scheme_using_str(self):
+        """
+        Create QuantSim for a CPU model and check that quantizers have been added to the graph
+        """
+        tf.compat.v1.reset_default_graph()
+        with tf.device('/cpu:0'):
+            model = tf.keras.Sequential()
+            model.add(tf.keras.layers.Conv2D(32, kernel_size=3, input_shape=(28, 28, 3), activation='relu'))
+            model.add(tf.keras.layers.MaxPooling2D((2, 2)))
+            model.add(tf.keras.layers.Conv2D(64, kernel_size=3, activation='relu'))
+            model.summary()
+
+        sess = tf.compat.v1.Session()
+        initialize_uninitialized_vars(sess)
+        sim = QuantizationSimModel(sess, ['conv2d_input'], ['conv2d_1/Relu'], quant_scheme="percentile" ,use_cuda=False)
+        activation_quantizers = sim._activation_quantizers.values()
+        param_quantizers = sim._param_quantizers.values()
+
+        for quant_info in activation_quantizers or param_quantizers:
+            assert quant_info.quant_scheme == QuantScheme.post_training_percentile
+
 
     def test_compute_encodings_cpu_model_fp16(self):
         """

--- a/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
+++ b/TrainingExtensions/tensorflow/test/python/non_eager/test_quantsim.py
@@ -365,7 +365,7 @@ class TestQuantSim(unittest.TestCase):
         param_quantizers = sim._param_quantizers.values()
 
         for quant_info in activation_quantizers or param_quantizers:
-            assert quant_info.quant_scheme == QuantScheme.post_training_percentile
+            assert quant_info.quant_scheme == libpymo.QuantizationMode.QUANTIZATION_PERCENTILE
 
 
     def test_compute_encodings_cpu_model_fp16(self):


### PR DESCRIPTION
Fix for #2057 
Support to use percentile Quant Scheme for Quantization in TF and Keras added.
