### PR TITLE
Fixed assert in the forward callback function of the pytorch AutoQuan…

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/auto_quant_v2.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/auto_quant_v2.py
@@ -254,7 +254,7 @@ class AutoQuant: # pylint: disable=too-many-instance-attributes
                     if isinstance(input_data, torch.Tensor):
                         model(input_data)
                     else:
-                        assert isinstance(input_data, (tuple, list))
+                        assert isinstance(input_data, tuple) or isinstance(input_data, list)
                         model(*input_data)
 
         self.forward_pass_callback = forward_pass_callback


### PR DESCRIPTION
Fixed assert in the forward callback function of the pytorch AutoQuant v2 where input_data was being checked if it was a (tuple, list) instead of if it was a tuple OR a list. 

Fix for issue: https://github.com/quic/aimet/issues/2124