### PR TITLE
Fix typos in the quantization user guide

### DIFF
--- a/Docs/user_guide/bn_reestimation.rst
+++ b/Docs/user_guide/bn_reestimation.rst
@@ -9,10 +9,10 @@ Overview
 ========
 
 The BN Re-estimation feature utilizes a small subset of training data to individually re-estimate the statistics of the
-Batch Normalization (BN) layers in a model. These BN statistics are then used to adjust the quantization scale parameter
-of the preceeding Convolution or Linear laye. Effectively, the BN layers are folded.
+Batch Normalization (BN) layers in a model. These BN statistics are then used to adjust the quantization scale parameters
+of the preceeding Convolution or Linear layers. Effectively, the BN layers are folded.
 
-The BN Re-estimation feature is applied after performaing Quantization Aware Training (QAT) with Range Learning, with
+The BN Re-estimation feature is applied after performing Quantization Aware Training (QAT) with Range Learning, with
 Per Channel Quantization (PCQ) enabled. It is very important NOT to fold the BN layers before performing QAT. The BN layers are
 folded ONLY after QAT and the re-estimation of the BN statistics are completed. The Workflow section below, covers
 the exact sequence of steps.

--- a/Docs/user_guide/model_quantization.rst
+++ b/Docs/user_guide/model_quantization.rst
@@ -106,7 +106,7 @@ depend on the ML framework the model is written in.
 Pytorch:
     :doc:`PyTorch Model Guidelines<../api_docs/torch_model_guidelines>`
 
-    In the case of PyTorch, there exist the Model Validator utility, to automate the checking of certain PyTorch model
+    In the case of PyTorch, there exists the Model Validator utility, to automate the checking of certain PyTorch model
     requirements, as well as the Model Preparer utility, to automate the updating of the model definition to align with
     certain requirements.
 

--- a/Docs/user_guide/post_training_quant_techniques.rst
+++ b/Docs/user_guide/post_training_quant_techniques.rst
@@ -9,7 +9,7 @@ AIMET Post-Training Quantization Techniques
 Overview
 ========
 
-It is observed that some ML models show reduced inference accuracy when run on quantized hardware due to approximation noises. AIMET provides quantization post-training techniques that help adjust the parameters in the model such that the model becomes more quantization-friendly. AIMET post-quantization techniques are designed to be applied on pre-trained ML models. These techniques are explained as part of the "Data-Free Quantization Through Weight Equalization and Bias Correction” paper at ICCV 2019 - https://arxiv.org/abs/1906.04721
+It is observed that some ML models show reduced inference accuracy when run on quantized hardware due to approximation noises. AIMET provides post-training quantization techniques that help adjust the parameters in the model such that the model becomes more quantization-friendly. AIMET post-training quantizations are designed to be applied on pre-trained ML models. These techniques are explained as part of the "Data-Free Quantization Through Weight Equalization and Bias Correction” paper at ICCV 2019 - https://arxiv.org/abs/1906.04721
 
 
 User Flow

--- a/Docs/user_guide/quantization_sim.rst
+++ b/Docs/user_guide/quantization_sim.rst
@@ -83,8 +83,8 @@ computed using the specified quantization calibration technique. An encoding for
 - Delta:   Granularity of the fixed point numbers (is a function of the bit-width selected)
 - Offset:  Offset from zero
 
-The delta and offset can be calculated using min and max and vice versa using the equations:
-    :math:`delta = \frac{min - max}{{2}^{bitwidth} - 1}` and :math:`offset = \frac{-min}{delta}`
+The Delta and Offset can be calculated using Min and Max and vice versa using the equations:
+    :math:`\textrm{Delta} = \dfrac{\textrm{Max} - \textrm{Min}}{{2}^{\textrm{bitwidth}} - 1} \quad \textrm{Offset} = \dfrac{-\textrm{Min}}{\textrm{Delta}}`
 
 Quantization Schemes
 ====================

--- a/Docs/user_guide/visualization_quant.rst
+++ b/Docs/user_guide/visualization_quant.rst
@@ -9,11 +9,11 @@ AIMET Visualization for Quantization
 
 Overview
 ========
-AIMET Visualization adds analytical capability to the AIMET tool (which helps quantize and compress ML models) through visualization. It provide more detailed insights in to AIMET features as users are able to analyze a model's layers in terms of compressibility and also highlight potential issues when applying quantization. The tool also assists in displaying progress for computationally heavy tasks. The visualizations get saved as an HTML file under the specified directory.
+AIMET Visualization adds analytical capability to the AIMET tool (which helps quantize and compress ML models) through visualization. It provides more detailed insights into AIMET features as users are able to analyze a model's layers in terms of compressibility and also highlight potential issues when applying quantization. The tool also assists in displaying progress for computationally heavy tasks. The visualizations get saved as an HTML file under the specified directory.
 
 Quantization
 ============
-During quantization, common parameters are used throughout a layer for converting the floating point weight values to INT8. If the dynamic range in weights is very high the quantization will not be very granular. To equalize the weight range we apply Cross Layer Equalization.
+During quantization, common parameters are used throughout a layer for converting the floating point weight values to INT8. If the dynamic range in weights is very high, the quantization will not be very granular. To equalize the weight range we apply Cross Layer Equalization.
 In order to understand if we need to apply Cross Layer Equalization, we can visualize the weight range for every channel in a layer. If the weight range varies a lot over the various channels, applying cross layer equalization helps in improving the Quantization accuracy.
 
 .. image:: ../images/vis_3.png


### PR DESCRIPTION
Just fix some typos in the user guide of quantization.
The most important one should be the formula of $\textrm{Delta}$.
I think it should be $\textrm{Delta} = \dfrac{\textrm{Max} - \textrm{Min}}{{2}^{\textrm{bitwidth}} - 1}$ instead of $\textrm{Delta} = \dfrac{\textrm{Min} - \textrm{Max}}{{2}^{\textrm{bitwidth}} - 1}$.

Please correct me if I am wrong! : )