### PR TITLE
Fix same layer-outputs of two consecutive layers due to inplace nature of latter layer

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
@@ -221,7 +221,7 @@ class LayerOutput:
         :return: None
         """
         layer_name = self.module_to_name_dict[module]
-        self.layer_name_to_layer_output_dict[layer_name] = output
+        self.layer_name_to_layer_output_dict[layer_name] = output.clone()
 
     @staticmethod
     def rename_layer_outputs(layer_name_to_layer_output_dict: Dict[str, torch.Tensor],


### PR DESCRIPTION
Fix #2393 
The Layer Output Generation (LOG) API for pytorch, wasn't handling in-place operation of layers. Because of this, the output of the layer previous to any in-place operating layer was being overridden with the output of in-place operating layer.