### PR TITLE
Replace / with _ in layer-output names

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
@@ -42,6 +42,7 @@ import os
 from typing import Union, Dict, List, Tuple
 from enum import Enum
 import shutil
+import re
 
 import numpy as np
 import onnx
@@ -174,16 +175,23 @@ class LayerOutput:
         self.is_quantsim_model = bool(quant_modules)
 
         # Obtain layer-name to layer-output name mapping
-        self.layer_name_to_layer_output_dict = None
+        self.layer_name_to_layer_output_dict = {}
+        self.layer_name_to_layer_output_name_dict = {}
         if naming_scheme == NamingScheme.PYTORCH:
-            self.layer_name_to_layer_output_name_dict = None
-            layer_output_names = [name.replace('._module_to_wrap', '') for name, module in model.named_modules() if utils.is_leaf_module(module)]
+            for name, module in model.named_modules():
+                if utils.is_leaf_module(module):
+                    name = name.replace('._module_to_wrap', '')
+                    self.layer_name_to_layer_output_name_dict[name] = name
         else:
             self.layer_name_to_layer_output_name_dict = LayerOutput.get_layer_name_to_layer_output_name_map(
                 self.model, naming_scheme, dummy_input, onnx_export_args, dir_path)
-            layer_output_names = list(self.layer_name_to_layer_output_name_dict.values())
+
+        # Replace any delimiter in layer-output name string with underscore
+        for layer_name, output_name in self.layer_name_to_layer_output_name_dict.items():
+            self.layer_name_to_layer_output_name_dict[layer_name] = re.sub(r'\W+', "_", output_name)
 
         # Save layer-output names which are in topological order of model graph. This order can be used while comparing layer-outputs.
+        layer_output_names = list(self.layer_name_to_layer_output_name_dict.values())
         save_layer_output_names(layer_output_names, dir_path)
 
     def get_outputs(self, input_batch: Union[torch.Tensor, List[torch.Tensor], Tuple[torch.Tensor]]) -> Dict[str, torch.Tensor]:
@@ -226,18 +234,25 @@ class LayerOutput:
     @staticmethod
     def rename_layer_outputs(layer_name_to_layer_output_dict: Dict[str, torch.Tensor],
                              layer_name_to_layer_output_name_dict: Dict[str, str]) -> Dict[str, torch.Tensor]:
-        """ Rename layer-outputs based on the layer-name to layer-output name map """
+        """
+        Rename layer-outputs based on the layer-name to layer-output name map
 
-        layer_output_name_to_layer_output_dict = {}
+        :param layer_name_to_layer_output_dict: Dict containing layer-outputs
+        :param layer_name_to_layer_output_name_dict: Dict containing layer-output names
+        :return: layer_output_name_to_layer_output_dict
+        """
+        layer_names = list(layer_name_to_layer_output_dict.keys())
 
-        if layer_name_to_layer_output_name_dict:
-            for layer_name in layer_name_to_layer_output_name_dict:
-                output_name = layer_name_to_layer_output_name_dict[layer_name]
-                layer_output_name_to_layer_output_dict[output_name] = layer_name_to_layer_output_dict[layer_name]
-        else:
-            layer_output_name_to_layer_output_dict = layer_name_to_layer_output_dict
+        for layer_name in layer_names:
+            if layer_name in layer_name_to_layer_output_name_dict:
+                # Rename the layer-output by using layer-output name, instead of layer-name
+                layer_output_name = layer_name_to_layer_output_name_dict[layer_name]
+                layer_name_to_layer_output_dict[layer_output_name] = layer_name_to_layer_output_dict.pop(layer_name)
+            else:
+                # Delete the layer-output as it doesn't have a name
+                layer_name_to_layer_output_dict.pop(layer_name)
 
-        return layer_output_name_to_layer_output_dict
+        return layer_name_to_layer_output_dict
 
     @staticmethod
     def get_layer_name_to_layer_output_name_map(model, naming_scheme: NamingScheme, dummy_input: Union[torch.Tensor, Tuple, List],


### PR DESCRIPTION
Fix #2395 
The layer-output names are sanitized by replacing all word delimiters within them with "_". Delimiters like "/" cause errors while saving the outputs.