### PR TITLE
use the system's patchelf executable if it is installed already

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -270,16 +270,21 @@ else()
   message(STATUS "Set ${AIMET_PYTHONPATH} in ${CMAKE_CURRENT_SOURCE_DIR}")
 endif()
 
-# FIXME
-# Better to include patchefl into docker image, although seems it is not trivial
-include(FetchContent)
-FetchContent_Declare(patchelf
-    URL "https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-x86_64.tar.gz"
-)
-if(NOT patchelf_POPULATED)
-    FetchContent_Populate(patchelf)
-    set(PATCHELF_EXE ${patchelf_SOURCE_DIR}/bin/patchelf)
-    message(STATUS "patchelf: ${PATCHELF_EXE}")
+find_program(PATCHELF_EXE patchelf)
+if (PATCHELF_EXE)
+    message(STATUS "Found patchelf in '${PATCHELF_EXE}'")
+else()
+    # FIXME
+    # Better to include patchefl into docker image, although seems it is not trivial
+    include(FetchContent)
+    FetchContent_Declare(patchelf
+        URL "https://github.com/NixOS/patchelf/releases/download/0.15.0/patchelf-0.15.0-x86_64.tar.gz"
+    )
+    if(NOT patchelf_POPULATED)
+        FetchContent_Populate(patchelf)
+        set(PATCHELF_EXE ${patchelf_SOURCE_DIR}/bin/patchelf)
+        message(STATUS "patchelf: ${PATCHELF_EXE}")
+    endif()
 endif()
 
 # -------------------------------


### PR DESCRIPTION
We would like to reduce the number of dependencies that are downloaded from third-party sources during the build process.