### PR TITLE
add "package" parameter in aimet's setup.py

### DIFF
--- a/packaging/setup_aimet.py
+++ b/packaging/setup_aimet.py
@@ -74,6 +74,7 @@ setup(
     license='NOTICE.txt',
     description='AIMET',
     long_description=open('README.txt').read(),
+    packages=['aimet'],
     install_requires=[],
     dependency_links=dependency_list,
     zip_safe=True,


### PR DESCRIPTION
The created wheels seems completely useless but this reduces the number of warnings/errors seen when rebuilding AIMET wheels.