### PR TITLE
Update cle_bc.ipynb

### DIFF
--- a/Examples/tensorflow/quantization/cle_bc.ipynb
+++ b/Examples/tensorflow/quantization/cle_bc.ipynb
@@ -521,7 +521,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = QuantizationSimModel(session=BN_folded_sess,\n",
+    "sim = QuantizationSimModel(session=cle_applied_sess,\n",
     "                           starting_op_names=starting_op_names,\n",
     "                           output_op_names=output_op_names,\n",
     "                           quant_scheme= QuantScheme.training_range_learning_with_tf_enhanced_init,\n",


### PR DESCRIPTION
Changed parameter variable name from sim = QuantizationSimModel(session=BN_folded_sess,.....) to sim = QuantizationSimModel(session=cle_applied_sess,......). Because cle_applied_sess we have to pass in the Quantsim API and this parameter is working fine for other below steps, if we are passing BN_folded_sess variable segmentation fault error is coming while compute encoding.