### PR TITLE
Update cle_bc.ipynb

### DIFF
--- a/Examples/tensorflow/quantization/cle_bc.ipynb
+++ b/Examples/tensorflow/quantization/cle_bc.ipynb
@@ -521,7 +521,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sim = QuantizationSimModel(session=BN_folded_sess,\n",
+    "sim = QuantizationSimModel(session=cle_applied_sess,\n",
     "                           starting_op_names=starting_op_names,\n",
     "                           output_op_names=output_op_names,\n",
     "                           quant_scheme= QuantScheme.training_range_learning_with_tf_enhanced_init,\n",


### PR DESCRIPTION
In place of BN_folded_sess added cle_applied_sess, due to which segmentation fault error was resolved while doing compute encoding. By passing cle_applied_sess in Quantsim function we can run the code successfully.