### PR TITLE
Exclude a test that requires CUDA on CPU

### DIFF
--- a/NightlyTests/torch/test_compress_example_torch.py
+++ b/NightlyTests/torch/test_compress_example_torch.py
@@ -501,6 +501,7 @@ class SvdAcceptanceTests(unittest.TestCase):
         self.assertFalse(isinstance(compressed_model.conv1, torch.nn.Sequential))
         self.assertFalse(isinstance(compressed_model.fc, torch.nn.Sequential))
 
+    @pytest.mark.cuda
     def test_svd_manual_rank_sel_weight_svd_deprecated(self):
 
         torch.cuda.empty_cache()


### PR DESCRIPTION
A test which is test_svd_manual_rank_sel_weight_svd_deprecated requires CUDA so CUDA should be marked.

Resolves #2743 