### PR TITLE
Updated CUDAExecutionProvider in ONNX AdaRound

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/activation_sampler.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/activation_sampler.py
@@ -81,7 +81,7 @@ class ActivationSampler:
         if 'CUDAExecutionProvider' not in ort.get_available_providers():
             self._use_cuda = False
         if self._use_cuda:
-            self.providers = [('CUDAExecutionProvider', {'device_id': device}), 'CPUExecutionProvider']
+            self.providers = [('CUDAExecutionProvider', {'device_id': device, 'cudnn_conv_algo_search': 'DEFAULT'}), 'CPUExecutionProvider']
         else:
             self.providers = ['CPUExecutionProvider']
 


### PR DESCRIPTION
 Fixes #2798 

Added a new parameter `cudnn_conv_algo_search` to CUDAExecutionProvider to have deterministic model inferencing across different runs.