### PR TITLE
Aligning the export format of adaround with the quantsim

### DIFF
--- a/NightlyTests/torch/test_adaround.py
+++ b/NightlyTests/torch/test_adaround.py
@@ -99,7 +99,7 @@ class AdaroundAcceptanceTests(unittest.TestCase):
 
         # Test exported encodings JSON file
         with open('./resnet18.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         self.assertTrue(isinstance(encoding_data["conv1.weight"], list))
@@ -136,7 +136,7 @@ class AdaroundAcceptanceTests(unittest.TestCase):
 
         # Read exported param encodings JSON file
         with open('./resnet18.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         encoding = encoding_data["conv1.weight"][0]
         before_min, before_max, before_delta, before_offset = encoding.get('min'), encoding.get('max'),\

--- a/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/adaround/adaround_weight.py
@@ -502,11 +502,13 @@ class Adaround:
                 if 'weight' in quant_module.param_quantizers:
                     cls._update_param_encodings_dict(quant_module, name, param_encodings)
 
+        # Unify the encoding format to be same as that of full encoding export file
+        encoding = {'param_encodings': param_encodings}
         # export encodings to JSON file
         os.makedirs(os.path.abspath(path), exist_ok=True)
         encoding_file_path = os.path.join(path, filename_prefix + '.encodings')
         with open(encoding_file_path, 'w') as encoding_fp:
-            json.dump(param_encodings, encoding_fp, sort_keys=True, indent=4)
+            json.dump(encoding, encoding_fp, sort_keys=True, indent=4)
 
     @classmethod
     def _update_param_encodings_dict(cls, quant_module: ExportableQuantModule, name: str, param_encodings: Dict):

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -1685,6 +1685,13 @@ class QuantizationSimModel:
         # Load parameter encodings file
         with open(encoding_path) as json_file:
             param_encodings = json.load(json_file)
+            if 'param_encodings' in param_encodings:
+                param_encodings = param_encodings['param_encodings']
+            else:
+                logger.warning("An older AdaRound exported encoding file type has been detected! "
+                               "Please regenerate it using the AdaRound export function from the latest "
+                               "AIMET (version 1.32 or higher) if necessary. "
+                               "Support for this encoding file will be deprecated in AIMET version 1.33.0.")
 
         self._set_param_encodings(param_encodings,
                                   freeze=True,

--- a/TrainingExtensions/torch/test/python/experimental/v2/test_adaround.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/test_adaround.py
@@ -299,7 +299,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -356,11 +356,11 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         with open('./dummy_checkpoints.encodings') as json_file:
-            encoding_data_ckpts = json.load(json_file)
+            encoding_data_ckpts = json.load(json_file)['param_encodings']
             print(encoding_data_ckpts)
 
         assert list(encoding_data.keys()) == list(encoding_data_ckpts.keys())
@@ -420,11 +420,11 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         with open('./dummy_checkpoints.encodings') as json_file:
-            encoding_data_ckpts = json.load(json_file)
+            encoding_data_ckpts = json.load(json_file)['param_encodings']
             print(encoding_data_ckpts)
 
         assert list(encoding_data.keys()) == list(encoding_data_ckpts.keys())
@@ -495,7 +495,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -732,7 +732,7 @@ class TestAdaround:
         _ = ada_model(*inp_tensor_list)
 
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         assert len(encoding_data['trans_conv1.weight']) == 2
 
@@ -769,7 +769,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to 8
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -807,7 +807,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -878,7 +878,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -943,7 +943,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -980,7 +980,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -1019,7 +1019,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -1043,7 +1043,7 @@ class TestAdaround:
                                         ignore_quant_ops_list=[model.layer1, model.layer2, model.layer3,
                                                                model.layer4, model.fc])
             with open('./resnet18.encodings') as json_file:
-                encoding_data = json.load(json_file)
+                encoding_data = json.load(json_file)['param_encodings']
 
             assert len(encoding_data) == 1 # Only model.conv1 layer is adarounded.
         finally:

--- a/TrainingExtensions/torch/test/python/test_adaround_weight.py
+++ b/TrainingExtensions/torch/test/python/test_adaround_weight.py
@@ -297,6 +297,7 @@ class TestAdaround:
         # Test export functionality
         with open('./dummy.encodings') as json_file:
             encoding_data = json.load(json_file)
+            encoding_data = encoding_data['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -354,10 +355,12 @@ class TestAdaround:
         # Test export functionality
         with open('./dummy.encodings') as json_file:
             encoding_data = json.load(json_file)
+            encoding_data = encoding_data['param_encodings']
             print(encoding_data)
 
         with open('./dummy_checkpoints.encodings') as json_file:
             encoding_data_ckpts = json.load(json_file)
+            encoding_data_ckpts = encoding_data_ckpts['param_encodings']
             print(encoding_data_ckpts)
 
         assert list(encoding_data.keys()) == list(encoding_data_ckpts.keys())
@@ -417,11 +420,11 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         with open('./dummy_checkpoints.encodings') as json_file:
-            encoding_data_ckpts = json.load(json_file)
+            encoding_data_ckpts = json.load(json_file)['param_encodings']
             print(encoding_data_ckpts)
 
         assert list(encoding_data.keys()) == list(encoding_data_ckpts.keys())
@@ -493,6 +496,7 @@ class TestAdaround:
         # Test export functionality
         with open('./dummy.encodings') as json_file:
             encoding_data = json.load(json_file)
+            encoding_data = encoding_data['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -730,7 +734,7 @@ class TestAdaround:
         _ = ada_model(*inp_tensor_list)
 
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         assert len(encoding_data['trans_conv1.weight']) == 2
 
@@ -767,7 +771,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to 8
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -805,7 +809,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -876,7 +880,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -941,7 +945,7 @@ class TestAdaround:
 
         # Read exported param encodings JSON file
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
 
         # Verify Conv2 weight encoding bitwidth is set to the default value of 4
         conv2_encoding = encoding_data["conv2.weight"][0]
@@ -977,7 +981,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -1015,7 +1019,7 @@ class TestAdaround:
 
         # Test export functionality
         with open('./dummy.encodings') as json_file:
-            encoding_data = json.load(json_file)
+            encoding_data = json.load(json_file)['param_encodings']
             print(encoding_data)
 
         param_keys = list(encoding_data.keys())
@@ -1039,7 +1043,7 @@ class TestAdaround:
                                         ignore_quant_ops_list=[model.layer1, model.layer2, model.layer3,
                                                                model.layer4, model.fc])
             with open('./resnet18.encodings') as json_file:
-                encoding_data = json.load(json_file)
+                encoding_data = json.load(json_file)['param_encodings']
 
             assert len(encoding_data) == 1 # Only model.conv1 layer is adarounded.
         finally:


### PR DESCRIPTION
Fixes #2846 
