### PR TITLE
Skip constant scalars while capturing intermediate layer-outputs

### DIFF
--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/layer_output_utils.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/layer_output_utils.py
@@ -142,7 +142,17 @@ class LayerOutputUtil:
         :param input_batch: Batch of Inputs for which layer output need to be generated
         :return: None
         """
-        batch_layer_name_to_layer_output = self.get_outputs(input_batch)
-        self.save_inp_out_obj.save(np.array(input_batch), batch_layer_name_to_layer_output)
+        layer_output_batch_dict = self.get_outputs(input_batch)
+
+        # Skip constant scalar layer-outputs
+        const_scalar_layer_name = []
+        for layer_name, layer_output in layer_output_batch_dict.items():
+            if not isinstance(layer_output, np.ndarray):
+                const_scalar_layer_name.append(layer_name)
+        for layer_name in const_scalar_layer_name:
+            logger.info("Skipping constant scalar output of layer %s", layer_name)
+            _ = layer_output_batch_dict.pop(layer_name)
+
+        self.save_inp_out_obj.save(np.array(input_batch), layer_output_batch_dict)
 
         logger.info("Layer Outputs Saved")

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/layer_output_utils.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/layer_output_utils.py
@@ -93,6 +93,15 @@ class LayerOutputUtil:
         # Obtain layer-output name to output dictionary
         layer_output_batch_dict = self.layer_output.get_outputs(feed_dict)
 
+        # Skip constant scalar layer-outputs
+        const_scalar_layer_name = []
+        for layer_name, layer_output in layer_output_batch_dict.items():
+            if not isinstance(layer_output, np.ndarray):
+                const_scalar_layer_name.append(layer_name)
+        for layer_name in const_scalar_layer_name:
+            logger.info("Skipping constant scalar output of layer %s", layer_name)
+            _ = layer_output_batch_dict.pop(layer_name)
+
         # Save inputs and layer-outputs
         self.save_input_output.save(input_batch, layer_output_batch_dict)
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/layer_output_utils.py
@@ -229,7 +229,10 @@ class LayerOutput:
         :return: None
         """
         layer_name = self.module_to_name_dict[module]
-        self.layer_name_to_layer_output_dict[layer_name] = output.clone()
+        if isinstance(output, torch.Tensor):
+            self.layer_name_to_layer_output_dict[layer_name] = output.clone()
+        else:
+            logger.info("Skipping constant scalar output of layer %s", layer_name)
 
     @staticmethod
     def rename_layer_outputs(layer_name_to_layer_output_dict: Dict[str, torch.Tensor],


### PR DESCRIPTION
Fix #2874 

Constant scalars can be treated as model parameters. Hence, no need to capture them as intermediate layer activations. Currently we are capturing them, leading to errors, either while fetching (in pytorch) or saving (in tf and keras) intermediate layer activations.