### PR TITLE
Expose nn and quantization packages to root package

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/__init__.py
@@ -36,3 +36,5 @@
 # =============================================================================
 
 # pylint: disable=missing-docstring
+from . import nn
+from . import quantization


### PR DESCRIPTION
This PR enables import statements like below:
```py
import aimet_torch.v2 as aimet
qlinear = aimet.nn.QuantizedLinear(10, 10)
```
and like below:
```py
import aimet_torch.v2 as aimet
out = aimet.quantization.affine.quantize(x, scale, offset, bitwidth)
```