### PR TITLE
Reparametrize from (bitwidth, signed) to (qmin, qmax)

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/__init__.py
@@ -39,3 +39,4 @@
 
 from .encoding import *
 from .quantizer import *
+from .backends import *

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/torch_builtins.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/torch_builtins.py
@@ -47,8 +47,9 @@ def _is_numerically_stable(dtype: torch.dtype, qmin: int, qmax: int):
     if finfo.min > qmin:
         return False
 
-    # NOTE: this is a heuristic criteria. It doesn't perfectly guarantee numerical stability
-    if finfo.tiny > 1e-3 / (qmax - qmin):
+    # NOTE: This is a heuristic criteria. It doesn't perfectly guarantee numerical stability
+    #       This criteria allows 8-bit quantization of float16, but it needs more discussion
+    if finfo.tiny > 1e-1 / (qmax - qmin):
         return False
 
     return True

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/utils.py
@@ -47,8 +47,8 @@ class _QuantizationBackendProtocol(Protocol):
                  input: torch.Tensor,
                  scale: torch.Tensor,
                  offset: torch.Tensor,
-                 bitwidth: int,
-                 signed: bool = False) -> torch.Tensor:
+                 qmin: int,
+                 qmax: int) -> torch.Tensor:
         ...
 
     def dequantize(self,
@@ -61,8 +61,8 @@ class _QuantizationBackendProtocol(Protocol):
                             input: torch.Tensor,
                             scale: torch.Tensor,
                             offset: torch.Tensor,
-                            bitwidth: int,
-                            signed: bool = False) -> torch.Tensor:
+                            qmin: int,
+                            qmax: int) -> torch.Tensor:
         ...
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -190,29 +190,10 @@ class AffineEncoding(EncodingBase):
         offset = self.offset
         bitwidth = self.bitwidth
         signed = self.signed
-
-        # Use dtype with more precision
-        if torch.finfo(input.dtype).bits >= torch.finfo(scale.dtype).bits:
-            dtype = input.dtype
-        else:
-            dtype = scale.dtype
-
-        return get_backend().quantize(input.to(dtype),
-                                      scale.to(dtype),
-                                      offset.to(dtype),
-                                      bitwidth,
-                                      signed).to(input.dtype)
+        return get_backend().quantize(input, scale.to(input.dtype), offset.to(input.dtype),
+                                      bitwidth, signed)
 
     def dequantize(self, input: torch.Tensor) -> torch.Tensor:
         scale = self.scale
         offset = self.offset
-
-        # Use dtype with more precision
-        if torch.finfo(input.dtype).bits >= torch.finfo(scale.dtype).bits:
-            dtype = input.dtype
-        else:
-            dtype = scale.dtype
-
-        return get_backend().dequantize(input.to(dtype),
-                                        scale.to(dtype),
-                                        offset.to(dtype)).to(input.dtype)
+        return get_backend().dequantize(input, scale.to(input.dtype), offset.to(input.dtype))

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -41,7 +41,7 @@ import torch
 from torch._C._nn import _parse_to as parse_to_args
 
 from aimet_torch.v2.quantization.base import EncodingBase
-from aimet_torch.v2.quantization.affine.backends import get_backend
+from aimet_torch.v2.quantization.affine.backends import quantize, dequantize
 
 
 __all__ = ["AffineEncoding"]
@@ -190,10 +190,9 @@ class AffineEncoding(EncodingBase):
         offset = self.offset
         bitwidth = self.bitwidth
         signed = self.signed
-        return get_backend().quantize(input, scale.to(input.dtype), offset.to(input.dtype),
-                                      bitwidth, signed)
+        return quantize(input, scale.to(input.dtype), offset.to(input.dtype), bitwidth, signed)
 
     def dequantize(self, input: torch.Tensor) -> torch.Tensor:
         scale = self.scale
         offset = self.offset
-        return get_backend().dequantize(input, scale.to(input.dtype), offset.to(input.dtype))
+        return dequantize(input, scale.to(input.dtype), offset.to(input.dtype))

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -51,7 +51,7 @@ from aimet_torch.v2.quantization.encoding_analyzer import EncodingAnalyzer, MinM
 from aimet_torch.v2.quantization.affine import AffineEncoding
 from aimet_torch.v2.quantization.tensor import QuantizedTensor, DequantizedTensor
 from aimet_torch.v2.quantization.base import QuantizerBase
-from aimet_torch.v2.quantization.affine.backends import get_backend
+from aimet_torch.v2.quantization.affine.backends import quantize, quantize_dequantize
 from aimet_torch.v2.utils import ste_round
 
 
@@ -395,11 +395,11 @@ class Quantize(MinMaxQuantizer):
             raise RuntimeError(msg)
 
         encoding = self.get_encoding()
-        output = get_backend().quantize(input.to(dtype),
-                                        encoding.scale.to(dtype),
-                                        encoding.offset.to(dtype),
-                                        encoding.bitwidth,
-                                        encoding.signed)
+        output = quantize(input.to(dtype),
+                          encoding.scale.to(dtype),
+                          encoding.offset.to(dtype),
+                          encoding.bitwidth,
+                          encoding.signed)
         output = output.as_subclass(QuantizedTensor)
         output.encoding = encoding
         return output.to(dtype)
@@ -431,11 +431,11 @@ class QuantizeDequantize(MinMaxQuantizer):
                 raise RuntimeError(msg)
 
         encoding = self.get_encoding()
-        output = get_backend().quantize_dequantize(input.to(internal_dtype),
-                                                   encoding.scale.to(internal_dtype),
-                                                   encoding.offset.to(internal_dtype),
-                                                   encoding.bitwidth,
-                                                   encoding.signed)
+        output = quantize_dequantize(input.to(internal_dtype),
+                                     encoding.scale.to(internal_dtype),
+                                     encoding.offset.to(internal_dtype),
+                                     encoding.bitwidth,
+                                     encoding.signed)
         output = output.as_subclass(DequantizedTensor)
         output.encoding = encoding
         return output.to(output_dtype)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -52,7 +52,7 @@ from aimet_torch.v2.quantization.affine import AffineEncoding
 from aimet_torch.v2.quantization.tensor import QuantizedTensor, DequantizedTensor
 from aimet_torch.v2.quantization.base import QuantizerBase
 from aimet_torch.v2.quantization.affine.backends import quantize, quantize_dequantize
-from aimet_torch.v2.utils import ste_round
+from aimet_torch.v2.utils import ste_round, PrecisionError
 
 
 __all__ = ['AffineQuantizerBase', 'MinMaxQuantizer', 'Quantize', 'QuantizeDequantize', 'Dequantize']
@@ -388,12 +388,6 @@ class Quantize(MinMaxQuantizer):
 
         dtype = input.dtype
 
-        if torch.finfo(dtype).max < 2 ** self.bitwidth - 1:
-            msg = f"{dtype} is unable to represent quantized output "\
-                  f"of range [0, 2**(bitwidth={self.bitwidth})-1]. "\
-                  "Please consider lowering the quantization bitwidth."
-            raise RuntimeError(msg)
-
         encoding = self.get_encoding()
         output = quantize(input.to(dtype),
                           encoding.scale.to(dtype),
@@ -420,22 +414,22 @@ class QuantizeDequantize(MinMaxQuantizer):
                 ' Please initialize the quantization parameters using `compute_encodings()`.'
             )
 
-        output_dtype = internal_dtype = input.dtype
-
-        if torch.finfo(internal_dtype).max < 2 ** self.bitwidth - 1:
-            internal_dtype = torch.float32
-            if torch.finfo(internal_dtype).max < 2 ** self.bitwidth - 1:
-                msg = f"{internal_dtype} is unable to represent quantized output "\
-                      f"of range [0, 2**(bitwidth={self.bitwidth})-1]. "\
-                      "Please consider lowering the quantization bitwidth."
-                raise RuntimeError(msg)
-
+        output_dtype = input.dtype
         encoding = self.get_encoding()
-        output = quantize_dequantize(input.to(internal_dtype),
-                                     encoding.scale.to(internal_dtype),
-                                     encoding.offset.to(internal_dtype),
-                                     encoding.bitwidth,
-                                     encoding.signed)
+        try:
+            output = quantize_dequantize(input.to(output_dtype),
+                                         encoding.scale.to(output_dtype),
+                                         encoding.offset.to(output_dtype),
+                                         encoding.bitwidth,
+                                         encoding.signed)
+        except PrecisionError:
+            internal_dtype = torch.float32
+            output = quantize_dequantize(input.to(internal_dtype),
+                                         encoding.scale.to(internal_dtype),
+                                         encoding.offset.to(internal_dtype),
+                                         encoding.bitwidth,
+                                         encoding.signed)
+
         output = output.as_subclass(DequantizedTensor)
         output.encoding = encoding
         return output.to(output_dtype)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/utils.py
@@ -204,6 +204,12 @@ class StatisticsNotFoundError(RuntimeError):
     '''
 
 
+class PrecisionError(RuntimeError):
+    """
+    Error thrown when an operation is expected to produce nan values due to numerical instability.
+    """
+
+
 _ENABLE_RECOMPUTE = False
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/utils.py
@@ -204,12 +204,6 @@ class StatisticsNotFoundError(RuntimeError):
     '''
 
 
-class PrecisionError(RuntimeError):
-    """
-    Error thrown when an operation is expected to produce nan values due to numerical instability.
-    """
-
-
 _ENABLE_RECOMPUTE = False
 
 

--- a/TrainingExtensions/torch/test/python/experimental/v2/nn/test_activation.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/nn/test_activation.py
@@ -38,7 +38,7 @@
 import pytest
 import torch
 import torch.nn.functional as F
-from aimet_torch.v2.quantization.affine.backends import get_backend
+from aimet_torch.v2.quantization.affine.backends import quantize_dequantize
 from aimet_torch.v2.quantization.affine import QuantizeDequantize
 from aimet_torch.v2.nn import FakeQuantizedSoftmax
 from aimet_torch.v2.quantization.encoding_analyzer import MinMaxEncodingAnalyzer
@@ -107,7 +107,7 @@ class TestFakeQuantizedSoftmax:
         scale = quant_softmax.input_quantizers[0].get_scale()
         offset = quant_softmax.input_quantizers[0].get_offset()
         bitwidth = quant_softmax.input_quantizers[0].bitwidth
-        input_qdq = get_backend().quantize_dequantize(input, scale, offset, bitwidth)
+        input_qdq = quantize_dequantize(input, scale, offset, bitwidth)
 
         expected_output = F.softmax(input_qdq, quant_softmax.dim)
         assert torch.equal(quant_output, expected_output)
@@ -151,8 +151,5 @@ class TestFakeQuantizedSoftmax:
         bitwidth = quant_softmax.output_quantizers[0].bitwidth
 
         fp_output = F.softmax(input, quant_softmax.dim)
-        expected_output = get_backend().quantize_dequantize(fp_output,
-                                                            scale,
-                                                            offset,
-                                                            bitwidth)
+        expected_output = quantize_dequantize(fp_output, scale, offset, bitwidth)
         assert torch.equal(quant_output, expected_output)

--- a/TrainingExtensions/torch/test/python/experimental/v2/nn/test_linear.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/nn/test_linear.py
@@ -39,7 +39,7 @@ import pytest
 import torch
 from torch import nn
 import torch.nn.functional as F
-from aimet_torch.v2.quantization.affine.backends import get_backend
+from aimet_torch.v2.quantization.affine.backends import quantize_dequantize
 from aimet_torch.v2.quantization.affine import QuantizeDequantize
 from aimet_torch.v2.nn import FakeQuantizedLinear, FakeQuantizationMixin
 from aimet_torch.v2.quantization.encoding_analyzer import MinMaxEncodingAnalyzer
@@ -97,7 +97,7 @@ class TestFakeQuantizedLinear:
         scale = quant_linear.input_quantizers[0].get_scale()
         offset = quant_linear.input_quantizers[0].get_offset()
         bitwidth = quant_linear.input_quantizers[0].bitwidth
-        input_qdq = get_backend().quantize_dequantize(input, scale, offset, bitwidth)
+        input_qdq = quantize_dequantize(input, scale, offset, bitwidth)
 
         expected_output = F.linear(input_qdq, quant_linear.weight, quant_linear.bias)
         assert torch.equal(quant_output, expected_output)
@@ -142,10 +142,7 @@ class TestFakeQuantizedLinear:
         bitwidth = quant_linear.output_quantizers[0].bitwidth
 
         fp_output = F.linear(input, quant_linear.weight, quant_linear.bias)
-        expected_output = get_backend().quantize_dequantize(fp_output,
-                                                            scale,
-                                                            offset,
-                                                            bitwidth)
+        expected_output = quantize_dequantize(fp_output, scale, offset, bitwidth)
         assert torch.equal(quant_output, expected_output)
 
     @pytest.mark.parametrize('bias', [True, False])
@@ -181,7 +178,7 @@ class TestFakeQuantizedLinear:
         scale = quant_linear.param_quantizers['weight'].get_scale()
         offset = quant_linear.param_quantizers['weight'].get_offset()
         bitwidth = quant_linear.param_quantizers['weight'].bitwidth
-        weight_qdq = get_backend().quantize_dequantize(weight, scale, offset, bitwidth, signed=True)
+        weight_qdq = quantize_dequantize(weight, scale, offset, bitwidth, signed=True)
 
         expected_output = F.linear(input, weight_qdq, quant_linear.bias)
         assert torch.equal(quant_output, expected_output)
@@ -218,22 +215,19 @@ class TestFakeQuantizedLinear:
         scale = quant_linear.input_quantizers[0].get_scale()
         offset = quant_linear.input_quantizers[0].get_offset()
         bitwidth = quant_linear.input_quantizers[0].bitwidth
-        input_qdq = get_backend().quantize_dequantize(input, scale, offset, bitwidth)
+        input_qdq = quantize_dequantize(input, scale, offset, bitwidth)
 
         weight = quant_linear.weight
         scale = quant_linear.param_quantizers['weight'].get_scale()
         offset = quant_linear.param_quantizers['weight'].get_offset()
         bitwidth = quant_linear.param_quantizers['weight'].bitwidth
-        weight_qdq = get_backend().quantize_dequantize(weight, scale, offset, bitwidth, signed=True)
+        weight_qdq = quantize_dequantize(weight, scale, offset, bitwidth, signed=True)
 
         scale = quant_linear.output_quantizers[0].get_scale()
         offset = quant_linear.output_quantizers[0].get_offset()
         bitwidth = quant_linear.output_quantizers[0].bitwidth
         expected_output = F.linear(input_qdq, weight_qdq, quant_linear.bias)
-        expected_output = get_backend().quantize_dequantize(expected_output,
-                                                            scale,
-                                                            offset,
-                                                            bitwidth)
+        expected_output = quantize_dequantize(expected_output, scale, offset, bitwidth)
         assert torch.equal(quant_output, expected_output)
 
         """

--- a/TrainingExtensions/torch/test/python/experimental/v2/quantizers/test_affine_quantizer.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/quantizers/test_affine_quantizer.py
@@ -44,7 +44,7 @@ from torch.optim import SGD, RMSprop, Adagrad, Adam, AdamW
 from aimet_torch.v2.quantization.encoding_analyzer import MinMaxEncodingAnalyzer
 from aimet_torch.v2.quantization.affine import AffineQuantizerBase, Quantize, \
     QuantizeDequantize, Dequantize
-from aimet_torch.v2.quantization.affine.backends import get_backend
+import aimet_torch.v2.quantization as Q
 
 
 _PARAMETER_SHAPE = (100,)
@@ -141,11 +141,11 @@ def test_quantize_compute_encodings(quantize: Quantize, x: torch.Tensor):
                                                           dynamic_max,
                                                           quantize.symmetric,
                                                           bitwidth=8)
-    expected_x_int = get_backend().quantize(x,
-                                            dynamic_scale,
-                                            dynamic_offset,
-                                            quantize.bitwidth,
-                                            quantize._signed)
+    expected_x_int = Q.affine.quantize(x,
+                                       dynamic_scale,
+                                       dynamic_offset,
+                                       quantize.bitwidth,
+                                       quantize._signed)
 
     with quantize.compute_encodings():
         x_int = quantize(x)
@@ -187,11 +187,11 @@ def test_qdq_compute_encodings(quantize_dequantize: QuantizeDequantize, x: torch
                                                           dynamic_max,
                                                           quantize_dequantize.symmetric,
                                                           bitwidth=8)
-    expected_output = get_backend().quantize_dequantize(x,
-                                                        dynamic_scale,
-                                                        dynamic_offset,
-                                                        quantize_dequantize.bitwidth,
-                                                        quantize_dequantize._signed)
+    expected_output = Q.affine.quantize_dequantize(x,
+                                                   dynamic_scale,
+                                                   dynamic_offset,
+                                                   quantize_dequantize.bitwidth,
+                                                   quantize_dequantize._signed)
 
     with quantize_dequantize.compute_encodings():
         output = quantize_dequantize(x)
@@ -329,11 +329,11 @@ def test_quantize_forward(quantize: Quantize, x: torch.Tensor):
     Then: forward() returns parametric quantization output.
     """
     output = quantize(x)
-    expected_output = get_backend().quantize(x,
-                                             quantize.get_scale(),
-                                             quantize.get_offset(),
-                                             quantize.bitwidth,
-                                             quantize._signed)
+    expected_output = Q.affine.quantize(x,
+                                        quantize.get_scale(),
+                                        quantize.get_offset(),
+                                        quantize.bitwidth,
+                                        quantize._signed)
     assert torch.allclose(output.quantized_repr(), expected_output.to(output.encoding.dtype))
 
 
@@ -353,11 +353,11 @@ def test_qdq_forward(quantize_dequantize: QuantizeDequantize, x: torch.Tensor):
     Then: forward() returns parametric quantization output.
     """
     output = quantize_dequantize(x)
-    expected_output = get_backend().quantize_dequantize(x,
-                                                        quantize_dequantize.get_scale(),
-                                                        quantize_dequantize.get_offset(),
-                                                        quantize_dequantize.bitwidth,
-                                                        quantize_dequantize._signed)
+    expected_output = Q.affine.quantize_dequantize(x,
+                                                   quantize_dequantize.get_scale(),
+                                                   quantize_dequantize.get_offset(),
+                                                   quantize_dequantize.bitwidth,
+                                                   quantize_dequantize._signed)
     assert torch.allclose(output, expected_output)
 
 

--- a/TrainingExtensions/torch/test/python/experimental/v2/test_backend.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/test_backend.py
@@ -41,7 +41,7 @@ from collections import namedtuple
 from aimet_torch.v2.quantization.affine.backends import torch_builtins
 from aimet_torch.v2.utils import ste_round
 
-VectorSetForTest = namedtuple("VectorSetForTest", ["tensor", "tensor_q", "tensor_qdq", "mask", "delta", "offset", "bitwidth"])
+VectorSetForTest = namedtuple("VectorSetForTest", ["tensor", "tensor_q", "tensor_qdq", "mask", "delta", "offset", "qmin", "qmax"])
 
 bfloat16_compat_per_tensor_4b_test_set = VectorSetForTest(
     tensor=torch.tensor([
@@ -62,7 +62,8 @@ bfloat16_compat_per_tensor_4b_test_set = VectorSetForTest(
     ],  dtype=torch.bool),
     delta=torch.tensor([0.5]),
     offset=torch.tensor([-5]),
-    bitwidth=4
+    qmin=0,
+    qmax=15,
 )
 
 bfloat16_compat_per_tensor_8b_test_set = VectorSetForTest(
@@ -84,7 +85,8 @@ bfloat16_compat_per_tensor_8b_test_set = VectorSetForTest(
     ], dtype=torch.bool),
     delta=torch.tensor([0.5]),
     offset=torch.tensor([-133]),
-    bitwidth=8
+    qmin=0,
+    qmax=255,
 )
 
 per_tensor_4b_test_set = VectorSetForTest(
@@ -106,7 +108,8 @@ per_tensor_4b_test_set = VectorSetForTest(
     ],  dtype=torch.bool),
     delta=torch.tensor([0.5]),
     offset=torch.tensor([-5]),
-    bitwidth=4
+    qmin=0,
+    qmax=15,
 )
 
 per_tensor_8b_test_set = VectorSetForTest(
@@ -128,7 +131,8 @@ per_tensor_8b_test_set = VectorSetForTest(
     ], dtype=torch.bool),
     delta=torch.tensor([0.5]),
     offset=torch.tensor([-133]),
-    bitwidth=8
+    qmin=0,
+    qmax=255,
 )
 
 per_channel_4b_test_set = VectorSetForTest(
@@ -150,7 +154,8 @@ per_channel_4b_test_set = VectorSetForTest(
     ], dtype=torch.bool),
     delta=torch.tensor([[0.5], [0.0625]]),
     offset=torch.tensor([[-13], [-7]]),
-    bitwidth=4
+    qmin=0,
+    qmax=15,
 )
 
 per_channel_8b_test_set = VectorSetForTest(
@@ -172,26 +177,27 @@ per_channel_8b_test_set = VectorSetForTest(
     ], dtype=torch.bool),
     delta=torch.tensor([[0.5], [0.0625]]),
     offset=torch.tensor([[-133], [-127]]),
-    bitwidth=8
+    qmin=0,
+    qmax=255,
 )
 
 class AutogradQuantizationModule(torch.nn.Module):
-    def __init__(self, scale, offset, bitwidth):
+    def __init__(self, scale, offset, qmin, qmax):
         super().__init__()
-        self.bitwidth = bitwidth
+        self.qmin = qmin
+        self.qmax = qmax
         self.scale = torch.nn.Parameter(scale.clone())
         self.offset = torch.nn.Parameter(offset.clone())
 
     def forward(self, x):
         return torch.clamp(
             ste_round(x / self.scale) - ste_round(self.offset),
-            0, 2 ** self.bitwidth - 1
+            self.qmin, self.qmax
         )
 
 class AutogradDequantizationModule(torch.nn.Module):
-    def __init__(self, scale, offset, bitwidth):
+    def __init__(self, scale, offset):
         super().__init__()
-        self.bitwidth = bitwidth
         self.scale = torch.nn.Parameter(scale.clone())
         self.offset = torch.nn.Parameter(offset.clone())
 
@@ -199,16 +205,17 @@ class AutogradDequantizationModule(torch.nn.Module):
         return (x + ste_round(self.offset)) * self.scale
 
 class AutogradQuantDequantModule(torch.nn.Module):
-    def __init__(self, scale, offset, bitwidth):
+    def __init__(self, scale, offset, qmin, qmax):
         super().__init__()
-        self.bitwidth = bitwidth
+        self.qmin = qmin
+        self.qmax = qmax
         self.scale = torch.nn.Parameter(scale.clone())
         self.offset = torch.nn.Parameter(offset.clone())
 
     def forward(self, x):
         x_q = torch.clamp(
             ste_round(x / self.scale) - ste_round(self.offset),
-            0, 2 ** self.bitwidth - 1
+            self.qmin, self.qmax
         )
         x_dq = (x_q + ste_round(self.offset)) * self.scale
         return x_dq
@@ -222,20 +229,21 @@ def copy_test_set(test_set: namedtuple, device: torch.device = torch.device("cpu
         mask=test_set.mask.clone().to(device),
         delta=test_set.delta.clone().detach().to(device, dtype),
         offset=test_set.offset.clone().detach().to(device, dtype),
-        bitwidth=test_set.bitwidth
+        qmin=test_set.qmin,
+        qmax=test_set.qmax,
     )
     return new_test_set
 
-def get_round_safe_quantizable_tensor(size: tuple, scale: torch.Tensor, bitwidth: int):
+def get_round_safe_quantizable_tensor(size: tuple, scale: torch.Tensor, qmin: int, qmax: int):
     """
     Returns round-safe quantizable random tensor by forcing
     fractional part of tensor divided by scale not to be near 0.5
     """
-    return scale.cpu() * (torch.randint(0, 2 ** bitwidth - 1, size).to(torch.float32) \
+    return scale.cpu() * (torch.randint(qmin, qmax+1, size).to(torch.float32) \
         + torch.rand(size) * 0.8 - 0.4)
 
-def get_random_quantized_tensor(size: tuple, bitwidth: int):
-    return torch.randint(0, 2 ** bitwidth, size).to(torch.float32)
+def get_random_quantized_tensor(size: tuple, qmin: int, qmax: int):
+    return torch.randint(qmin, qmax+1, size).to(torch.float32)
 
 @pytest.fixture(autouse=True)
 def set_seed():
@@ -246,102 +254,109 @@ def set_seed():
 def offset():
     return torch.randint(-5, 5, []).to(torch.float32)
 
+
 @pytest.mark.parametrize('backend_module', [torch_builtins])
 class TestQuantizationBackends:
-    def _test_quantization_backend(self, backend_module, random_tensor, scale, offset, bitwidth):
-        expected_quantized_tensor = torch.clamp(torch.round(random_tensor / scale) - torch.round(offset), 0, 2 ** bitwidth - 1)
-        quantized_tensor = backend_module.quantize(random_tensor, scale, offset, bitwidth)
+    def _test_quantization_backend(self, backend_module, random_tensor, scale, offset, qmin, qmax):
+        expected_quantized_tensor = torch.clamp(torch.round(random_tensor / scale) - torch.round(offset), qmin, qmax)
+        quantized_tensor = backend_module.quantize(random_tensor, scale, offset, qmin, qmax)
         assert torch.allclose(quantized_tensor, expected_quantized_tensor)
 
         dequantized_tensor = backend_module.dequantize(expected_quantized_tensor, scale, offset)
         expected_dequantized_tensor = (expected_quantized_tensor + torch.round(offset)) * scale
         assert torch.allclose(dequantized_tensor, expected_dequantized_tensor)
 
-        qdq_tensor = backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+        qdq_tensor = backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
         expected_qdq_tensor = (expected_quantized_tensor + torch.round(offset)) * scale
         assert torch.allclose(qdq_tensor, expected_qdq_tensor)
 
+    @pytest.mark.parametrize('qmin, qmax', [(0, 255), (-128, 127)])
     @pytest.mark.parametrize('scale_shape', [(4), (2,), (3, 1), (2, 1, 1)])
-    @pytest.mark.parametrize('bitwidth', [8])
-    def test_quantize_using_not_broadcastable_scale(self, backend_module, offset, scale_shape, bitwidth):
+    def test_quantize_using_not_broadcastable_scale(self, backend_module, offset, scale_shape, qmin, qmax):
         # Add small value to scale to make scale not equal to 0
         scale = torch.rand(scale_shape)
         scale[scale == 0.0] = 0.1
         random_tensor = torch.randn(2, 3, 4, 5)
-        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), bitwidth)
+        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), qmin, qmax)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize(random_tensor, scale, offset, qmin, qmax)
 
         with pytest.raises(RuntimeError):
             backend_module.dequantize(random_quantized_tensor, scale, offset)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
 
-    @pytest.mark.parametrize('bitwidth', [8])
+    @pytest.mark.parametrize('qmin, qmax', [(0, 255), (-128, 127)])
     @pytest.mark.parametrize('scale_dtype, input_dtype', [(torch.float32, torch.float16), (torch.float16, torch.float32)])
-    def test_quantize_using_invalid_dtype(self, backend_module, offset, bitwidth, scale_dtype, input_dtype):
+    def test_quantize_using_invalid_dtype(self, backend_module, offset, qmin, qmax, scale_dtype, input_dtype):
         scale = torch.tensor([0.2], dtype=scale_dtype)
         random_tensor = torch.randn(2, 3, 4, 5)
-        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), bitwidth)
+        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), qmin, qmax)
         random_tensor = random_tensor.to(input_dtype)
         random_quantized_tensor = random_quantized_tensor.to(input_dtype)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize(random_tensor, scale, offset, qmin, qmax)
 
         with pytest.raises(RuntimeError):
             backend_module.dequantize(random_quantized_tensor, scale, offset)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
 
-    @pytest.mark.parametrize('input_dtype, bitwidth', [(torch.bfloat16, 32), (torch.float16, 32), (torch.float32, 64)])
-    def test_quantize_using_wider_quantization_bitwidth(self, backend_module, offset, bitwidth, input_dtype):
-        scale = torch.tensor([0.2], dtype=torch.float32)
+    @pytest.mark.parametrize('input_dtype, qmin, qmax', [(torch.float16, 0, 2**32-1),
+                                                         (torch.float32, 0, 2**64-1)])
+    def test_quantize_using_wider_quantization_bitwidth(self, backend_module, offset, input_dtype, qmin, qmax):
+        scale = torch.tensor([0.2])
         random_tensor = torch.randn(2, 3, 4, 5)
         random_tensor = random_tensor.to(input_dtype)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize(random_tensor.to(input_dtype),
+                                    scale.to(input_dtype),
+                                    offset.to(input_dtype), qmin, qmax)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize_dequantize(random_tensor.to(input_dtype),
+                                               scale.to(input_dtype),
+                                               offset.to(input_dtype), qmin, qmax)
 
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
-    @pytest.mark.parametrize('bitwidth', [8])
-    @pytest.mark.parametrize(
-        'input_device, scale_device, offset_device',
-        [
-            (torch.device('cuda'), torch.device('cpu'), torch.device('cpu')),
-            (torch.device('cpu'), torch.device('cuda'), torch.device('cpu')),
-            (torch.device('cpu'), torch.device('cpu'), torch.device('cuda')),
-        ]
-    )
-    def test_quantize_using_parameters_on_different_device(self, backend_module, offset, bitwidth, input_device, scale_device, offset_device):
-        scale = torch.tensor([0.2], dtype=torch.float32, device=scale_device)
-        random_tensor = torch.randn(2, 3, 4, 5)
-        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), bitwidth)
-        random_tensor = random_tensor.to(input_device)
-        random_quantized_tensor = random_quantized_tensor.to(input_device)
-        offset = offset.to(offset_device)
-
-        with pytest.raises(RuntimeError):
-            backend_module.quantize(random_tensor, scale, offset, bitwidth)
-
-        with pytest.raises(RuntimeError):
-            backend_module.dequantize(random_quantized_tensor, scale, offset)
-
-        with pytest.raises(RuntimeError):
-            backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
-
-    @pytest.mark.parametrize('bitwidth', [8])
-    @pytest.mark.parametrize('memory_format', [torch.channels_last, torch.channels_last_3d])
-    def test_quantize_using_non_contiguous_tensor(self, backend_module, offset, bitwidth, memory_format):
+    @pytest.mark.cuda
+    def test_quantize_using_parameters_on_different_device(self, backend_module, offset):
+        qmin, qmax = 0, 255
         scale = torch.tensor([0.2], dtype=torch.float32)
-        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, bitwidth)
-        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), bitwidth)
+        random_tensor = torch.randn(2, 3, 4, 5)
+        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), qmin, qmax)
+
+        with pytest.raises(RuntimeError):
+            backend_module.quantize(random_tensor.cuda(), scale, offset, qmin, qmax)
+        with pytest.raises(RuntimeError):
+            backend_module.quantize(random_tensor, scale.cuda(), offset, qmin, qmax)
+        with pytest.raises(RuntimeError):
+            backend_module.quantize(random_tensor, scale, offset.cuda(), qmin, qmax)
+
+        with pytest.raises(RuntimeError):
+            backend_module.dequantize(random_quantized_tensor.cuda(), scale, offset)
+        with pytest.raises(RuntimeError):
+            backend_module.dequantize(random_quantized_tensor, scale.cuda(), offset)
+        with pytest.raises(RuntimeError):
+            backend_module.dequantize(random_quantized_tensor, scale, offset.cuda())
+
+        with pytest.raises(RuntimeError):
+            backend_module.quantize_dequantize(random_tensor.cuda(), scale, offset, qmin, qmax)
+        with pytest.raises(RuntimeError):
+            backend_module.quantize_dequantize(random_tensor, scale.cuda(), offset, qmin, qmax)
+        with pytest.raises(RuntimeError):
+            backend_module.quantize_dequantize(random_tensor, scale, offset.cuda(), qmin, qmax)
+
+    @pytest.mark.parametrize('memory_format', [torch.channels_last, torch.channels_last_3d])
+    def test_quantize_using_non_contiguous_tensor(self, backend_module, offset, memory_format):
+        qmin, qmax = 0, 255
+        scale = torch.tensor([0.2], dtype=torch.float32)
+        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, qmin, qmax)
+        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), qmin, qmax)
 
         # Rank 5 tensor is required to use channels_last_3d format
         if memory_format == torch.channels_last_3d:
@@ -351,16 +366,16 @@ class TestQuantizationBackends:
         channel_last_random_tensor = random_tensor.to(memory_format=memory_format)
         channel_last_random_quantized_tensor = random_quantized_tensor.to(memory_format=memory_format)
 
-        channel_last_quantized_tensor = backend_module.quantize(channel_last_random_tensor, scale, offset, bitwidth)
+        channel_last_quantized_tensor = backend_module.quantize(channel_last_random_tensor, scale, offset, qmin, qmax)
         assert channel_last_quantized_tensor.is_contiguous(memory_format=memory_format)
         
         channel_last_dequantized_tensor = backend_module.dequantize(channel_last_random_quantized_tensor, scale, offset)
         assert channel_last_dequantized_tensor.is_contiguous(memory_format=memory_format)
         
-        channel_last_qdq_tensor = backend_module.quantize_dequantize(channel_last_random_tensor, scale, offset, bitwidth)
+        channel_last_qdq_tensor = backend_module.quantize_dequantize(channel_last_random_tensor, scale, offset, qmin, qmax)
         assert channel_last_qdq_tensor.is_contiguous(memory_format=memory_format)
 
-        expected_quantized_tensor = torch.clamp(torch.round(random_tensor / scale) - torch.round(offset), 0, 2 ** bitwidth - 1)
+        expected_quantized_tensor = torch.clamp(torch.round(random_tensor / scale) - torch.round(offset), qmin, qmax)
         assert torch.allclose(channel_last_quantized_tensor, expected_quantized_tensor)
 
         expected_dequantized_tensor = (random_quantized_tensor + torch.round(offset)) * scale
@@ -369,38 +384,38 @@ class TestQuantizationBackends:
         expected_qdq_tensor = (expected_quantized_tensor + torch.round(offset)) * scale
         assert torch.allclose(channel_last_qdq_tensor, expected_qdq_tensor)
 
-    @pytest.mark.parametrize('bitwidth', [8])
     @pytest.mark.parametrize('scale_shape', [(5, 1, 1, 1, 1), (3, 1, 1)])
-    def test_quantize_using_inversely_broadcastable_scale(self, backend_module, offset, scale_shape, bitwidth):
+    def test_quantize_using_inversely_broadcastable_scale(self, backend_module, offset, scale_shape):
+        qmin, qmax = 0, 255
         # Add small value to scale to make scale not equal to 0
         scale = torch.rand(scale_shape)
         scale[scale == 0.0] = 0.1
         random_tensor = torch.randn(2, 1, 4, 5)
-        random_quantized_tensor = get_random_quantized_tensor((2, 1, 4, 5), bitwidth)
+        random_quantized_tensor = get_random_quantized_tensor((2, 1, 4, 5), qmin, qmax)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize(random_tensor, scale, offset, qmin, qmax)
 
         with pytest.raises(RuntimeError):
             backend_module.dequantize(random_quantized_tensor, scale, offset)
 
         with pytest.raises(RuntimeError):
-            backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+            backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
 
-    @pytest.mark.parametrize('bitwidth', [8])
     @pytest.mark.parametrize('scale_requires_grad', [True, False])
     @pytest.mark.parametrize('offset_requires_grad', [True, False])
     @pytest.mark.parametrize('input_requires_grad', [True, False])
-    def test_quantize_backward_pass(self, backend_module, offset, bitwidth, scale_requires_grad, offset_requires_grad, input_requires_grad):
+    def test_quantize_backward_pass(self, backend_module, offset, scale_requires_grad, offset_requires_grad, input_requires_grad):
+        qmin, qmax = 0, 255
         scale = torch.rand([])
         scale[scale == 0.0] = 0.1
         offset = offset.detach().clone()
-        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, bitwidth)
+        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, qmin, qmax)
         scale.requires_grad = scale_requires_grad
         offset.requires_grad = offset_requires_grad
         random_tensor.requires_grad = input_requires_grad
 
-        qdq_tensor = backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+        qdq_tensor = backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
         loss = torch.sum((random_tensor - qdq_tensor) ** 2)
         if loss.requires_grad:
             loss.backward()
@@ -420,19 +435,17 @@ class TestQuantizationBackends:
         else:
             assert random_tensor.grad is None
 
-    @pytest.mark.parametrize("signed", (False, True))
     @pytest.mark.parametrize("test_set", (per_tensor_4b_test_set,
                                           per_tensor_8b_test_set,
                                           per_channel_4b_test_set,
                                           per_channel_8b_test_set))
     @pytest.mark.parametrize("dtype", (torch.float16, torch.float32))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
-    def test_quantize_with_predefined_values(self, backend_module, test_set, dtype, signed):
+    @pytest.mark.cuda
+    def test_quantize_with_predefined_values(self, backend_module, test_set, dtype):
         test_set = copy_test_set(test_set, device="cuda:0", dtype=dtype)
         test_set.tensor.requires_grad = True
-        offset = test_set.offset if not signed else test_set.offset + 2 ** (test_set.bitwidth - 1)
-        tensor_q = backend_module.quantize(test_set.tensor, test_set.delta, offset, test_set.bitwidth, signed)
-        expected_tensor_q = test_set.tensor_q if not signed else test_set.tensor_q - 2 ** (test_set.bitwidth - 1)
+        tensor_q = backend_module.quantize(test_set.tensor, test_set.delta, test_set.offset, test_set.qmin, test_set.qmax)
+        expected_tensor_q = test_set.tensor_q
         assert torch.all(tensor_q == expected_tensor_q)
         grad_in = torch.randn_like(test_set.tensor)
         tensor_q.backward(grad_in)
@@ -444,25 +457,23 @@ class TestQuantizationBackends:
                                           per_channel_4b_test_set,
                                           per_channel_8b_test_set))
     @pytest.mark.parametrize("dtype", (torch.float16, torch.float32))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
+    @pytest.mark.cuda
     def test_dequantize_with_predefined_values(self, backend_module, test_set, dtype):
-        test_set = copy_test_set(per_tensor_8b_test_set, dtype=dtype, device="cuda")
+        test_set = copy_test_set(test_set, dtype=dtype, device="cuda")
         tensor_q = test_set.tensor_q
         tensor_qdq = backend_module.dequantize(tensor_q, test_set.delta, test_set.offset)
         assert torch.all(tensor_qdq == test_set.tensor_qdq)
 
-    @pytest.mark.parametrize("signed", (False, True))
     @pytest.mark.parametrize("test_set", (per_tensor_4b_test_set,
                                           per_tensor_8b_test_set,
                                           per_channel_4b_test_set,
                                           per_channel_8b_test_set))
     @pytest.mark.parametrize("dtype", (torch.float16, torch.float32))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
-    def test_qdq_with_predefined_values(self, backend_module, test_set, dtype, signed):
+    @pytest.mark.cuda
+    def test_qdq_with_predefined_values(self, backend_module, test_set, dtype):
         test_set = copy_test_set(test_set, dtype=dtype, device="cuda")
         test_set.tensor.requires_grad = True
-        offset = test_set.offset if not signed else test_set.offset + 2 ** (test_set.bitwidth - 1)
-        tensor_qdq = backend_module.quantize_dequantize(test_set.tensor, test_set.delta, offset, test_set.bitwidth, signed)
+        tensor_qdq = backend_module.quantize_dequantize(test_set.tensor, test_set.delta, test_set.offset, test_set.qmin, test_set.qmax)
         assert torch.allclose(tensor_qdq, test_set.tensor_qdq)
         grad_in = torch.randn_like(test_set.tensor)
         tensor_qdq.backward(grad_in)
@@ -471,11 +482,11 @@ class TestQuantizationBackends:
 
     @pytest.mark.parametrize("test_set", (bfloat16_compat_per_tensor_4b_test_set,
                                           bfloat16_compat_per_tensor_8b_test_set))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
+    @pytest.mark.cuda
     def test_quantize_with_predefined_bfloat_values(self, backend_module, test_set):
         test_set = copy_test_set(test_set, device="cuda:0", dtype=torch.bfloat16)
         test_set.tensor.requires_grad = True
-        tensor_q = backend_module.quantize(test_set.tensor, test_set.delta, test_set.offset, test_set.bitwidth)
+        tensor_q = backend_module.quantize(test_set.tensor, test_set.delta, test_set.offset, test_set.qmin, test_set.qmax)
         assert torch.all(tensor_q == test_set.tensor_q)
         grad_in = torch.randn_like(test_set.tensor)
         tensor_q.backward(grad_in)
@@ -484,7 +495,7 @@ class TestQuantizationBackends:
 
     @pytest.mark.parametrize("test_set", (bfloat16_compat_per_tensor_4b_test_set,
                                           bfloat16_compat_per_tensor_8b_test_set))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
+    @pytest.mark.cuda
     def test_dequantize_with_predefined_bfloat_values(self, backend_module, test_set):
         test_set = copy_test_set(per_tensor_8b_test_set, dtype=torch.bfloat16, device="cuda")
         tensor_q = test_set.tensor_q
@@ -493,23 +504,23 @@ class TestQuantizationBackends:
 
     @pytest.mark.parametrize("test_set", (bfloat16_compat_per_tensor_4b_test_set,
                                           bfloat16_compat_per_tensor_8b_test_set))
-    @pytest.mark.skipif(not torch.cuda.is_available(), reason='cannot test as there\'s only cpu on this machine')
+    @pytest.mark.cuda
     def test_qdq_with_predefined_bfloat_values(self, backend_module, test_set):
         test_set = copy_test_set(test_set, dtype=torch.bfloat16, device="cuda")
         test_set.tensor.requires_grad = True
-        tensor_qdq = backend_module.quantize_dequantize(test_set.tensor, test_set.delta, test_set.offset, test_set.bitwidth)
+        tensor_qdq = backend_module.quantize_dequantize(test_set.tensor, test_set.delta, test_set.offset, test_set.qmin, test_set.qmax)
         assert torch.allclose(tensor_qdq, test_set.tensor_qdq)
         grad_in = torch.randn_like(test_set.tensor)
         tensor_qdq.backward(grad_in)
         assert torch.all(test_set.tensor.grad[test_set.mask] == 0)
         assert torch.all(test_set.tensor.grad[~test_set.mask] == grad_in[~test_set.mask])
 
-    @pytest.mark.parametrize('bitwidth', [8])
-    def test_compare_quantize_gradients_with_autograd_results(self, backend_module, offset, bitwidth):
+    @pytest.mark.parametrize('qmin, qmax', [(0, 255), (-128, 127)])
+    def test_compare_quantize_gradients_with_autograd_results(self, backend_module, offset, qmin, qmax):
         scale = torch.rand([])
         scale[scale == 0.0] = 0.1
         offset = offset.detach().clone()
-        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, bitwidth)
+        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, qmin, qmax)
         random_tensor_for_autograd = random_tensor.detach().clone()
 
         scale.requires_grad = True
@@ -517,9 +528,9 @@ class TestQuantizationBackends:
         random_tensor.requires_grad = True
         random_tensor_for_autograd.requires_grad = True
         
-        autograd_based_module = AutogradQuantizationModule(scale, offset, bitwidth)
+        autograd_based_module = AutogradQuantizationModule(scale, offset, qmin, qmax)
         expected_tensor_q = autograd_based_module(random_tensor_for_autograd)
-        tensor_q = backend_module.quantize(random_tensor, scale, offset, bitwidth)
+        tensor_q = backend_module.quantize(random_tensor, scale, offset, qmin, qmax)
         assert torch.allclose(tensor_q, expected_tensor_q)
 
         grad_in = torch.randn_like(random_tensor)
@@ -534,12 +545,12 @@ class TestQuantizationBackends:
         assert torch.allclose(scale.grad, expected_scale_grad)
         assert torch.allclose(offset.grad, expected_offset_grad)
 
-    @pytest.mark.parametrize('bitwidth', [8])
-    def test_compare_dequantize_gradients_with_autograd_results(self, backend_module, offset, bitwidth):
+    @pytest.mark.parametrize('qmin, qmax', [(0, 255), (-128, 127)])
+    def test_compare_dequantize_gradients_with_autograd_results(self, backend_module, offset, qmin, qmax):
         scale = torch.rand([])
         scale[scale == 0.0] = 0.1
         offset = offset.detach().clone()
-        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), bitwidth)
+        random_quantized_tensor = get_random_quantized_tensor((2, 3, 4, 5), qmin, qmax)
         random_quantized_tensor_for_autograd = random_quantized_tensor.detach().clone()
 
         scale.requires_grad = True
@@ -547,7 +558,7 @@ class TestQuantizationBackends:
         random_quantized_tensor.requires_grad = True
         random_quantized_tensor_for_autograd.requires_grad = True
         
-        autograd_based_module = AutogradDequantizationModule(scale, offset, bitwidth)
+        autograd_based_module = AutogradDequantizationModule(scale, offset)
         expected_tensor_dq = autograd_based_module(random_quantized_tensor_for_autograd)
         tensor_dq = backend_module.dequantize(random_quantized_tensor, scale, offset)
         assert torch.allclose(tensor_dq, expected_tensor_dq)
@@ -564,12 +575,12 @@ class TestQuantizationBackends:
         assert torch.allclose(scale.grad, expected_scale_grad)
         assert torch.allclose(offset.grad, expected_offset_grad)
 
-    @pytest.mark.parametrize('bitwidth', [8])
-    def test_compare_qdq_gradients_with_autograd_results(self, backend_module, offset, bitwidth):
+    @pytest.mark.parametrize('qmin, qmax', [(0, 255), (-128, 127)])
+    def test_compare_qdq_gradients_with_autograd_results(self, backend_module, offset, qmin, qmax):
         scale = torch.rand([])
         scale[scale == 0.0] = 0.1
         offset = offset.detach().clone()
-        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, bitwidth)
+        random_tensor = get_round_safe_quantizable_tensor((2, 3, 4, 5), scale, qmin, qmax)
         random_tensor_for_autograd = random_tensor.detach().clone()
 
         scale.requires_grad = True
@@ -577,9 +588,9 @@ class TestQuantizationBackends:
         random_tensor.requires_grad = True
         random_tensor_for_autograd.requires_grad = True
         
-        autograd_based_module = AutogradQuantDequantModule(scale, offset, bitwidth)
+        autograd_based_module = AutogradQuantDequantModule(scale, offset, qmin, qmax)
         expected_tensor_qdq = autograd_based_module(random_tensor_for_autograd)
-        tensor_qdq = backend_module.quantize_dequantize(random_tensor, scale, offset, bitwidth)
+        tensor_qdq = backend_module.quantize_dequantize(random_tensor, scale, offset, qmin, qmax)
         assert torch.allclose(tensor_qdq, expected_tensor_qdq)
 
         grad_in = torch.randn_like(random_tensor)


### PR DESCRIPTION
## Main changes
1. Reparametrized `quantize(x, s, z, bw, signed)` to `quantize(x, s, z, qmin, qmax)`
2. As public APIs for the users, exposed multiple overloaded function signatures of `quantize`.
The users will now be able to import them as: `import aimet_torch.v2.quantization as Q; Q.affine.quantize(...)`.
    1. `quantize(x, s, z, bw, signed)`
    2. `quantize(x, s, z, num_bins, signed)`
    3. `quantize(x, s, z, qmin, qmax)`
