### PR TITLE
Add compute_param_encodings API

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -111,6 +111,10 @@ class BaseQuantizationMixin(abc.ABC):
             yield
 
     def _compute_param_encodings(self, overwrite: bool):
+        """
+        :param bool overwrite: If True, the quantizers that are already initialized will also recompute encodings.
+            Otherwise, only the uninitialized quantizers will compute encodings.
+        """
         for param_name, param_quantizer in self.param_quantizers.items():
             if not param_quantizer:
                 continue
@@ -120,6 +124,10 @@ class BaseQuantizationMixin(abc.ABC):
                 if param is not None:
                     with param_quantizer.compute_encodings():
                         _ = param_quantizer(param)
+
+    def compute_param_encodings(self):
+        """ Compute encodings of parameter quantizers """
+        self._compute_param_encodings(overwrite=True)
 
     @contextlib.contextmanager
     def compute_encodings(self):


### PR DESCRIPTION
Added `compute_param_encodings` function as a public API.
This function will be called by the user for realizing QAT 1.0 behavior with more visibility and flexibility.
For example, users will now be able to control how frequently the weight encodings should be recomputed.

```py
for i, (data, labels) in enumerate(data_loader):
    logits = model(data)
    loss = loss_fn(logits, labels)
    loss.backward()
    if i % GRADIENT_ACCUM_STEPS:
        optimizer.step()
        optimizer.zero_grad()
        aimet.nn.compute_param_encodings(model)
```

**IMPORTANT: In aimet v2, the users have to call `compute_param_encodings` explicitly in order to realize QAT 1.0 behavior. AIMET will NOT recompute param encodings silently/implicitly during forward/backward**