### PR TITLE
 Decomopse freezing into requires_grad and allow_overwrite

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -499,7 +499,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import parameter encodings represented in below format:
         {
@@ -566,7 +566,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                 strict: bool,
                                 partial: bool,
                                 requires_grad: Optional[bool],
-                                allow_overwrite: Optional[bool]):
+                                allow_overwrite: bool):
         """
         Import output encodings represented in below format:
         {
@@ -583,7 +583,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import input encodings represented in below format:
         {
@@ -596,7 +596,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                               strict, partial, requires_grad, allow_overwrite)
 
     def _import_encoding(self, encodings, quantizers, strict: bool, partial: bool,
-                         requires_grad: Optional[bool], allow_overwrite: Optional[bool]):
+                         requires_grad: Optional[bool], allow_overwrite: bool):
         # pylint: disable=too-many-branches
         assert quantizers is self.input_quantizers or quantizers is self.output_quantizers
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -540,7 +540,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
 
                 if requires_grad is not None:
                     if isinstance(quantizer, LearnedGridTensorQuantizer) and quantizer.wrapper_ref:
-                        quantizer.wrapper_ref.requires_grad_(requires_grad)
+                        q_min = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_min')
+                        q_min.requires_grad_(requires_grad)
+                        q_max = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_max')
+                        q_max.requires_grad_(requires_grad)
 
                 if allow_recompute is not None:
                     if not allow_recompute:
@@ -634,7 +637,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
 
             if requires_grad is not None:
                 if isinstance(quantizer, LearnedGridTensorQuantizer) and quantizer.wrapper_ref:
-                    quantizer.wrapper_ref.requires_grad_(requires_grad)
+                    q_min = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_min')
+                    q_min.requires_grad_(requires_grad)
+                    q_max = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_max')
+                    q_max.requires_grad_(requires_grad)
 
             if allow_recompute is not None:
                 if not allow_recompute:

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -40,7 +40,7 @@
 # pylint: disable=too-many-lines
 import abc
 from enum import Enum
-from typing import Dict, Tuple, Union, List, Callable, Type, Any, Optional
+from typing import Dict, Tuple, Union, List, Callable, Type, Any, Optional, Mapping
 import os
 import torch
 from torch import nn
@@ -380,9 +380,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             input_encoding = {}
 
         self.import_input_encodings(input_encoding,
-                                    ignore_when_quantizer_disabled,
-                                    disable_quantizer_without_encoding,
-                                    freeze=False)
+                                    strict=not ignore_when_quantizer_disabled,
+                                    partial=not disable_quantizer_without_encoding,
+                                    requires_grad=None,
+                                    allow_recompute=None)
 
         try:
             output_encoding = activation_encodings[module_name]['output']
@@ -390,9 +391,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             output_encoding = {}
 
         self.import_output_encodings(output_encoding,
-                                     ignore_when_quantizer_disabled,
-                                     disable_quantizer_without_encoding,
-                                     freeze=False)
+                                     strict=not ignore_when_quantizer_disabled,
+                                     partial=not disable_quantizer_without_encoding,
+                                     requires_grad=None,
+                                     allow_recompute=None)
 
     def set_param_encoding(self, module_name: str, param_encodings: Dict,
                            ignore_when_quantizer_disabled: bool = False, disable_quantizer_without_encoding: bool = True):
@@ -412,9 +414,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             if f'{module_name}.{param_name}' in param_encodings
         }
         self.import_param_encodings(param_encoding,
-                                    ignore_when_quantizer_disabled,
-                                    disable_quantizer_without_encoding,
-                                    freeze=False)
+                                    strict=not ignore_when_quantizer_disabled,
+                                    partial=not disable_quantizer_without_encoding,
+                                    requires_grad=None,
+                                    allow_recompute=None)
 
     def freeze_param_encoding(self, module_name: str, param_encodings: Dict):
         """
@@ -491,8 +494,12 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
         """
         return [export_quantizer_encoding(quantizer) for quantizer in self.input_quantizers]
 
-    def import_param_encodings(self, encodings: Dict[str, List[Dict]], ignore_when_quantizer_disabled: bool,
-                               disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_param_encodings(self,
+                               encodings: Mapping[str, Mapping],
+                               strict: bool,
+                               partial: bool,
+                               requires_grad: Optional[bool],
+                               allow_recompute: Optional[bool]):
         """
         Import parameter encodings represented in below format:
         {
@@ -501,10 +508,12 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             ...
         }
         """
+        # pylint: disable=too-many-branches
         for param_name, quantizer in self.param_quantizers.items():
             encoding = encodings.get(param_name, None)
             if not encoding:
-                if disable_quantizer_without_encoding:
+                if not partial:
+                    # Dnagling quantizers have to be removed when importing non-partial encodings
                     quantizer.enabled = False
                 continue
 
@@ -528,12 +537,20 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                     quantizer.data_type = QuantizationDataType.float
                 else:
                     raise RuntimeError("Data type does not match int or float in encodings file")
-                if freeze:
-                    quantizer.freeze_encoding()
+
+                if requires_grad is not None:
+                    if isinstance(quantizer, LearnedGridTensorQuantizer) and quantizer.wrapper_ref:
+                        quantizer.wrapper_ref.requires_grad_(requires_grad)
+
+                if allow_recompute is not None:
+                    if not allow_recompute:
+                        quantizer.freeze_encoding()
+                    else:
+                        raise NotImplementedError("Unfreezing is not supported")
 
                 _logger.info("Setting quantization encodings for parameter: %s", param_name)
             else:
-                if ignore_when_quantizer_disabled:
+                if not strict:
                     _logger.warning("Param Quantizer disabled, Couldn't set quantization encodings provided "
                                     "for parameter %s", param_name)
                 else:
@@ -541,8 +558,12 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                        "configuration as the quantsim which was used to export the encodings")
 
 
-    def import_output_encodings(self, encodings: Dict[str, Dict], ignore_when_quantizer_disabled: bool,
-                                disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_output_encodings(self,
+                                encodings: Mapping[str, Mapping],
+                                strict: bool,
+                                partial: bool,
+                                requires_grad: Optional[bool],
+                                allow_recompute: Optional[bool]):
         """
         Import output encodings represented in below format:
         {
@@ -551,11 +572,15 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             ...
         }
         """
-        self._import_encoding(encodings, self.output_quantizers, ignore_when_quantizer_disabled, disable_quantizer_without_encoding,
-                              freeze=freeze)
+        self._import_encoding(encodings, self.output_quantizers,
+                              strict, partial, requires_grad, allow_recompute)
 
-    def import_input_encodings(self, encodings: Dict[str, Dict], ignore_when_quantizer_disabled: bool,
-                               disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_input_encodings(self,
+                               encodings: Mapping[str, Mapping],
+                               strict: bool,
+                               partial: bool,
+                               requires_grad: Optional[bool],
+                               allow_recompute: Optional[bool]):
         """
         Import input encodings represented in below format:
         {
@@ -564,21 +589,23 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
             ...
         }
         """
-        self._import_encoding(encodings, self.input_quantizers, ignore_when_quantizer_disabled, disable_quantizer_without_encoding,
-                              freeze=freeze)
+        self._import_encoding(encodings, self.input_quantizers,
+                              strict, partial, requires_grad, allow_recompute)
 
-    def _import_encoding(self, encodings, quantizers, ignore_when_quantizer_disabled: bool,
-                         disable_quantizer_without_encoding: bool, freeze: bool):
+    def _import_encoding(self, encodings, quantizers, strict: bool, partial: bool,
+                         requires_grad: Optional[bool], allow_recompute: Optional[bool]):
+        # pylint: disable=too-many-branches
         assert quantizers is self.input_quantizers or quantizers is self.output_quantizers
 
         for i, quantizer in enumerate(quantizers):
             encoding = encodings.get(str(i), None)
             if not encoding:
-                if disable_quantizer_without_encoding:
+                if not partial:
+                    # Dnagling quantizers have to be removed when importing non-partial encodings
                     quantizer.enabled = False
                 continue
             if not quantizer.enabled:
-                if ignore_when_quantizer_disabled:
+                if not strict:
                     type_of_quantizer = 'input' if quantizers is self.input_quantizers else 'output'
                     _logger.info("%s quantizer %s is disabled, and the provided encoding can't be set",
                                  type_of_quantizer, str(i))
@@ -604,8 +631,16 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                 quantizer.data_type = QuantizationDataType.float
             else:
                 raise RuntimeError("Unrecognized encodings datatype")
-            if freeze:
-                quantizer.freeze_encoding()
+
+            if requires_grad is not None:
+                if isinstance(quantizer, LearnedGridTensorQuantizer) and quantizer.wrapper_ref:
+                    quantizer.wrapper_ref.requires_grad_(requires_grad)
+
+            if allow_recompute is not None:
+                if not allow_recompute:
+                    quantizer.freeze_encoding()
+                else:
+                    raise NotImplementedError("Unfreezing is not supported")
 
 
 class StaticGridQuantWrapper(QcQuantizeWrapper):

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -383,7 +383,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                     strict=not ignore_when_quantizer_disabled,
                                     partial=not disable_quantizer_without_encoding,
                                     requires_grad=None,
-                                    allow_recompute=None)
+                                    allow_overwrite=None)
 
         try:
             output_encoding = activation_encodings[module_name]['output']
@@ -394,7 +394,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                      strict=not ignore_when_quantizer_disabled,
                                      partial=not disable_quantizer_without_encoding,
                                      requires_grad=None,
-                                     allow_recompute=None)
+                                     allow_overwrite=None)
 
     def set_param_encoding(self, module_name: str, param_encodings: Dict,
                            ignore_when_quantizer_disabled: bool = False, disable_quantizer_without_encoding: bool = True):
@@ -417,7 +417,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                     strict=not ignore_when_quantizer_disabled,
                                     partial=not disable_quantizer_without_encoding,
                                     requires_grad=None,
-                                    allow_recompute=None)
+                                    allow_overwrite=None)
 
     def freeze_param_encoding(self, module_name: str, param_encodings: Dict):
         """
@@ -499,7 +499,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_recompute: Optional[bool]):
+                               allow_overwrite: Optional[bool]):
         """
         Import parameter encodings represented in below format:
         {
@@ -545,8 +545,8 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                         q_max = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_max')
                         q_max.requires_grad_(requires_grad)
 
-                if allow_recompute is not None:
-                    if not allow_recompute:
+                if allow_overwrite is not None:
+                    if not allow_overwrite:
                         quantizer.freeze_encoding()
                     else:
                         raise NotImplementedError("Unfreezing is not supported")
@@ -566,7 +566,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                                 strict: bool,
                                 partial: bool,
                                 requires_grad: Optional[bool],
-                                allow_recompute: Optional[bool]):
+                                allow_overwrite: Optional[bool]):
         """
         Import output encodings represented in below format:
         {
@@ -576,14 +576,14 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
         }
         """
         self._import_encoding(encodings, self.output_quantizers,
-                              strict, partial, requires_grad, allow_recompute)
+                              strict, partial, requires_grad, allow_overwrite)
 
     def import_input_encodings(self,
                                encodings: Mapping[str, Mapping],
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_recompute: Optional[bool]):
+                               allow_overwrite: Optional[bool]):
         """
         Import input encodings represented in below format:
         {
@@ -593,10 +593,10 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
         }
         """
         self._import_encoding(encodings, self.input_quantizers,
-                              strict, partial, requires_grad, allow_recompute)
+                              strict, partial, requires_grad, allow_overwrite)
 
     def _import_encoding(self, encodings, quantizers, strict: bool, partial: bool,
-                         requires_grad: Optional[bool], allow_recompute: Optional[bool]):
+                         requires_grad: Optional[bool], allow_overwrite: Optional[bool]):
         # pylint: disable=too-many-branches
         assert quantizers is self.input_quantizers or quantizers is self.output_quantizers
 
@@ -642,8 +642,8 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                     q_max = getattr(quantizer.wrapper_ref, quantizer.name + '_encoding_max')
                     q_max.requires_grad_(requires_grad)
 
-            if allow_recompute is not None:
-                if not allow_recompute:
+            if allow_overwrite is not None:
+                if not allow_overwrite:
                     quantizer.freeze_encoding()
                 else:
                     raise NotImplementedError("Unfreezing is not supported")

--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -549,7 +549,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                         q_max.requires_grad_(requires_grad)
 
                 assert not quantizer.is_encoding_frozen
-                if not allow_overwrite:
+                if not allow_overwrite and quantizer.encoding is not None:
                     quantizer.freeze_encoding()
 
                 _logger.info("Setting quantization encodings for parameter: %s", param_name)
@@ -644,7 +644,7 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                     q_max.requires_grad_(requires_grad)
 
             assert not quantizer.is_encoding_frozen
-            if not allow_overwrite:
+            if not allow_overwrite and quantizer.encoding is not None:
                 quantizer.freeze_encoding()
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -1630,8 +1630,8 @@ class QuantizationSimModel:
         :param bool strict: If True, an error will be thrown if the model doesn't
             have a quantizer corresponding to the specified encodings.
         :param bool partial: If True, the encoding will be interpreted as a partial encoding,
-            and the dangling quantizers that has no corresponding encoding will be kept intact.
-            Otherwise, the dangling quantizers will removed.
+            and the dangling quantizers with no corresponding encoding will be kept untouched.
+            Otherwise, the dangling quantizers will be removed from the model.
         :param bool requires_grad: Whether or not the quantization parameters loaded from the
             encodings require gradient computation during training.
             If None, ``requires_grad`` flag of the quantization parameters will be kept unchanged.

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -158,7 +158,7 @@ class ExportableQuantModule(Protocol):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import input encodings represented in below format:
         {
@@ -173,7 +173,7 @@ class ExportableQuantModule(Protocol):
                                 strict: bool,
                                 partial: bool,
                                 requires_grad: Optional[bool],
-                                allow_overwrite: Optional[bool]):
+                                allow_overwrite: bool):
         """
         Import output encodings represented in below format:
         {
@@ -188,7 +188,7 @@ class ExportableQuantModule(Protocol):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import parameter encodings represented in below format:
         {
@@ -1624,7 +1624,7 @@ class QuantizationSimModel:
                        strict: bool = True,
                        partial: bool = True,
                        requires_grad: Optional[bool] = None,
-                       allow_overwrite: Optional[bool] = None):
+                       allow_overwrite: bool = True):
         """
         :param encodings: Encoding dictionary or path to the encoding dictionary json file.
         :param bool strict: If True, an error will be thrown if the model doesn't
@@ -1649,7 +1649,7 @@ class QuantizationSimModel:
                              strict: bool,
                              partial: bool,
                              requires_grad: Optional[bool],
-                             allow_overwrite: Optional[bool]):
+                             allow_overwrite: bool):
         if 'param_encodings' not in encodings:
             param_encodings = encodings
             activation_encodings = {}
@@ -1704,7 +1704,7 @@ class QuantizationSimModel:
                              strict: bool,
                              partial: bool,
                              requires_grad: Optional[bool],
-                             allow_overwrite: Optional[bool]):
+                             allow_overwrite: bool):
         for name, quant_module in self.model.named_modules():
             if isinstance(quant_module, ExportableQuantModule):
                 param_encoding = {
@@ -1723,7 +1723,7 @@ class QuantizationSimModel:
                                   strict: bool,
                                   partial: bool,
                                   requires_grad: Optional[bool],
-                                  allow_overwrite: Optional[bool]):
+                                  allow_overwrite: bool):
         for module_name, module in self.model.named_modules():
             if not isinstance(module, ExportableQuantModule):
                 continue

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -153,8 +153,12 @@ class ExportableQuantModule(Protocol):
         Returns a dict of {param name: param encodings}, with each encoding represented as a List of Dicts
         """
 
-    def import_input_encodings(self, encodings: Dict[str, Dict], ignore_when_quantizer_disabled: bool,
-                               disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_input_encodings(self,
+                               encodings: Mapping[str, Mapping],
+                               strict: bool,
+                               partial: bool,
+                               requires_grad: Optional[bool],
+                               allow_recompute: Optional[bool]):
         """
         Import input encodings represented in below format:
         {
@@ -164,8 +168,12 @@ class ExportableQuantModule(Protocol):
         }
         """
 
-    def import_output_encodings(self, encodings: Dict[str, Dict], ignore_when_quantizer_disabled: bool,
-                                disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_output_encodings(self,
+                                encodings: Mapping[str, Mapping],
+                                strict: bool,
+                                partial: bool,
+                                requires_grad: Optional[bool],
+                                allow_recompute: Optional[bool]):
         """
         Import output encodings represented in below format:
         {
@@ -175,8 +183,12 @@ class ExportableQuantModule(Protocol):
         }
         """
 
-    def import_param_encodings(self, encodings: Dict[str, List[Dict]], ignore_when_quantizer_disabled: bool,
-                               disable_quantizer_without_encoding: bool, freeze: bool):
+    def import_param_encodings(self,
+                               encodings: Mapping[str, Mapping],
+                               strict: bool,
+                               partial: bool,
+                               requires_grad: Optional[bool],
+                               allow_recompute: Optional[bool]):
         """
         Import parameter encodings represented in below format:
         {
@@ -1610,27 +1622,34 @@ class QuantizationSimModel:
 
     def load_encodings(self, encodings: Union[Mapping, str, os.PathLike],
                        strict: bool = True,
-                       partial: bool = True):
+                       partial: bool = True,
+                       requires_grad: Optional[bool] = None,
+                       allow_recompute: Optional[bool] = False):
         """
         :param encodings: Encoding dictionary or path to the encoding dictionary json file.
         :param bool strict: If True, an error will be thrown if the model doesn't
             have a quantizer corresponding to the specified encodings.
-        :param bool partial: If True, the encoding will be interpreted as a partial encoding.
-            Otherwise, the dangling quantizers that has no corresponding encoding will be removed.
+        :param bool partial: If True, the encoding will be interpreted as a partial encoding,
+            and the dangling quantizers that has no corresponding encoding will be kept intact.
+            Otherwise, the dangling quantizers will removed.
+        :param bool requires_grad: Whether or not the quantization parameters loaded from the
+            encodings require gradient computation during training.
+            If None, ``requires_grad`` flag of the quantization parameters will be kept unchanged.
+        :param bool allow_recompute: Whether or not the quantization parameters loaded from the
+            encodings can be overwriiten when :ref:`compute_encodings` is called subsequently.
+            If None, whether the quantizer is allowed to overwrite encodings will be kept unchanged.
         """
-        self._load_encodings_impl(encodings,
-                                  ignore_when_quantizer_disabled=not strict,
-                                  disable_quantizer_without_encoding=not partial,
-                                  freeze=False)
-
-    def _load_encodings_impl(self, encodings: Union[Mapping, str, os.PathLike],
-                             freeze: bool,
-                             ignore_when_quantizer_disabled: bool,
-                             disable_quantizer_without_encoding: bool):
         if isinstance(encodings, (str, os.PathLike)):
             with open(encodings, mode='r') as f:
                 encodings = json.load(f)
 
+        self._load_encodings_impl(encodings, strict, partial, requires_grad, allow_recompute)
+
+    def _load_encodings_impl(self, encodings: Mapping,
+                             strict: bool,
+                             partial: bool,
+                             requires_grad: Optional[bool],
+                             allow_recompute: Optional[bool]):
         if 'param_encodings' not in encodings:
             param_encodings = encodings
             activation_encodings = {}
@@ -1656,15 +1675,11 @@ class QuantizationSimModel:
 
         if param_encodings is not None:
             self._set_param_encodings(param_encodings,
-                                      freeze=freeze,
-                                      ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                      disable_quantizer_without_encoding=disable_quantizer_without_encoding)
+                                      strict, partial, requires_grad, allow_recompute)
 
         if activation_encodings is not None:
             self._set_activation_encodings(activation_encodings,
-                                           freeze=freeze,
-                                           ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                           disable_quantizer_without_encoding=disable_quantizer_without_encoding)
+                                           strict, partial, requires_grad, allow_recompute)
 
     @deprecated(f"Use {load_encodings.__qualname__} instead.")
     def load_and_freeze_encodings(self, encoding_path: str, ignore_when_quantizer_disabled: bool = False):
@@ -1678,16 +1693,18 @@ class QuantizationSimModel:
         :param ignore_when_quantizer_disabled: ignore raising RuntimeError while setting encodings,
             when quantizers are disabled.
         """
-        self._load_encodings_impl(encoding_path,
-                                  ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                  disable_quantizer_without_encoding=False,
-                                  freeze=True)
+        self.load_encodings(encoding_path,
+                            strict=not ignore_when_quantizer_disabled,
+                            partial=True,
+                            requires_grad=False,
+                            allow_recompute=False)
 
     def _set_param_encodings(self,
-                             encoding_dict: Dict,
-                             freeze: bool,
-                             ignore_when_quantizer_disabled: bool,
-                             disable_quantizer_without_encoding: bool):
+                             encoding_dict: Mapping,
+                             strict: bool,
+                             partial: bool,
+                             requires_grad: Optional[bool],
+                             allow_recompute: Optional[bool]):
         for name, quant_module in self.model.named_modules():
             if isinstance(quant_module, ExportableQuantModule):
                 param_encoding = {
@@ -1696,15 +1713,17 @@ class QuantizationSimModel:
                     if f'{name}.{param_name}' in encoding_dict
                 }
                 quant_module.import_param_encodings(param_encoding,
-                                                    freeze=freeze,
-                                                    ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                                    disable_quantizer_without_encoding=disable_quantizer_without_encoding)
+                                                    strict,
+                                                    partial,
+                                                    requires_grad,
+                                                    allow_recompute)
 
     def _set_activation_encodings(self,
-                                  activation_encoding_dict: dict,
-                                  freeze: bool,
-                                  ignore_when_quantizer_disabled: bool,
-                                  disable_quantizer_without_encoding: bool):
+                                  activation_encoding_dict: Mapping,
+                                  strict: bool,
+                                  partial: bool,
+                                  requires_grad: Optional[bool],
+                                  allow_recompute: Optional[bool]):
         for module_name, module in self.model.named_modules():
             if not isinstance(module, ExportableQuantModule):
                 continue
@@ -1715,9 +1734,10 @@ class QuantizationSimModel:
                 input_encoding = {}
 
             module.import_input_encodings(input_encoding,
-                                          freeze=freeze,
-                                          ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                          disable_quantizer_without_encoding=disable_quantizer_without_encoding)
+                                          strict,
+                                          partial,
+                                          requires_grad,
+                                          allow_recompute)
 
             try:
                 output_encoding = activation_encoding_dict[module_name]['output']
@@ -1725,9 +1745,10 @@ class QuantizationSimModel:
                 output_encoding = {}
 
             module.import_output_encodings(output_encoding,
-                                           freeze=freeze,
-                                           ignore_when_quantizer_disabled=ignore_when_quantizer_disabled,
-                                           disable_quantizer_without_encoding=disable_quantizer_without_encoding)
+                                           strict,
+                                           partial,
+                                           requires_grad,
+                                           allow_recompute)
 
 
     @deprecated(f"Use {load_encodings.__qualname__} instead.")
@@ -1746,10 +1767,11 @@ class QuantizationSimModel:
         if 'activation_encodings' in encodings:
             del encodings['activation_encodings']
 
-        self._load_encodings_impl(encodings,
-                                  ignore_when_quantizer_disabled=False,
-                                  disable_quantizer_without_encoding=False,
-                                  freeze=True)
+        self.load_encodings(encodings,
+                            strict=True,
+                            partial=True,
+                            requires_grad=False,
+                            allow_recompute=False)
 
     def quant_wrappers(self):
         """
@@ -2129,10 +2151,11 @@ def load_encodings_to_sim(quant_sim_model: QuantizationSimModel, pytorch_encodin
         if isinstance(module, QcQuantizeWrapper):
             module.set_mode(QcQuantizeOpMode.ACTIVE)
 
-    quant_sim_model._load_encodings_impl(pytorch_encoding_path, # pylint: disable=protected-access
-                                         ignore_when_quantizer_disabled=False,
-                                         disable_quantizer_without_encoding=True,
-                                         freeze=False)
+    quant_sim_model.load_encodings(pytorch_encoding_path,
+                                   strict=True,
+                                   partial=False,
+                                   requires_grad=None,
+                                   allow_recompute=None)
 
     if isinstance(quant_sim_model, QuantizationSimModel):
         # Only for V1 quantsim

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -1624,7 +1624,7 @@ class QuantizationSimModel:
                        strict: bool = True,
                        partial: bool = True,
                        requires_grad: Optional[bool] = None,
-                       allow_recompute: Optional[bool] = False):
+                       allow_recompute: Optional[bool] = None):
         """
         :param encodings: Encoding dictionary or path to the encoding dictionary json file.
         :param bool strict: If True, an error will be thrown if the model doesn't

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/__init__.py
@@ -50,7 +50,7 @@ def compute_encodings(model: torch.nn.Module):
 
     .. warning::
         Encodings of the quantizers loaded with :ref:`QuantizationSimModel.load_encodings`
-        with ``allow_recompute=False`` will be kept unchanged.
+        with ``allow_overwrite=False`` will be kept unchanged.
     """
     with contextlib.ExitStack() as stack:
         for module in model.modules():
@@ -67,7 +67,7 @@ def compute_param_encodings(model: torch.nn.Module):
 
     .. warning::
         Encodings of the quantizers loaded with :ref:`QuantizationSimModel.load_encodings`
-        with ``allow_recompute=False`` will be kept unchanged.
+        with ``allow_overwrite=False`` will be kept unchanged.
     """
     for module in model.modules():
         if isinstance(module, BaseQuantizationMixin): # pylint: disable=undefined-variable

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -119,7 +119,7 @@ class BaseQuantizationMixin(abc.ABC):
             if not param_quantizer:
                 continue
 
-            if param_quantizer._skip_encoding_computation: # pylint: disable=protected-access
+            if not param_quantizer._allow_overwrite: # pylint: disable=protected-access
                 continue
 
             if not param_quantizer.is_initialized() or overwrite:
@@ -160,7 +160,7 @@ class BaseQuantizationMixin(abc.ABC):
                 if not isinstance(quantizer, QuantizerBase):
                     continue
 
-                if quantizer._skip_encoding_computation: # pylint: disable=protected-access
+                if not quantizer._allow_overwrite: # pylint: disable=protected-access
                     continue
 
                 ctx = quantizer.compute_encodings()

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -234,7 +234,7 @@ class BaseQuantizationMixin(abc.ABC):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_recompute: Optional[bool]):
+                               allow_overwrite: Optional[bool]):
         """
         Import input encodings represented in below format:
         {
@@ -252,7 +252,7 @@ class BaseQuantizationMixin(abc.ABC):
             encoding = encodings.get(str(i), None)
             if not encoding:
                 if not partial:
-                    # Dnagling quantizers have to be removed when importing non-partial encodings
+                    # Dangling quantizers have to be removed when importing non-partial encodings
                     self.input_quantizers[i] = None
                 continue
             if quantizer is None and strict:
@@ -264,8 +264,8 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_recompute is not None:
-                quantizer._skip_encoding_computation = not allow_recompute # pylint:disable = protected-access
+            if allow_overwrite is not None:
+                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def export_output_encodings(self) -> List[List[Dict]]:
         """
@@ -281,7 +281,7 @@ class BaseQuantizationMixin(abc.ABC):
                                 strict: bool,
                                 partial: bool,
                                 requires_grad: Optional[bool],
-                                allow_recompute: Optional[bool]):
+                                allow_overwrite: Optional[bool]):
         """
         Import output encodings represented in below format:
         {
@@ -299,7 +299,7 @@ class BaseQuantizationMixin(abc.ABC):
             encoding = encodings.get(str(i), None)
             if not encoding:
                 if not partial:
-                    # Dnagling quantizers have to be removed when importing non-partial encodings
+                    # Dangling quantizers have to be removed when importing non-partial encodings
                     self.output_quantizers[i] = None
                 continue
             if quantizer is None and strict:
@@ -311,8 +311,8 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_recompute is not None:
-                quantizer._skip_encoding_computation = not allow_recompute # pylint:disable = protected-access
+            if allow_overwrite is not None:
+                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def export_param_encodings(self) -> Dict[str, List[Dict]]:
         """
@@ -328,7 +328,7 @@ class BaseQuantizationMixin(abc.ABC):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_recompute: Optional[bool]):
+                               allow_overwrite: Optional[bool]):
         """
         Import parameter encodings represented in below format:
         {
@@ -346,7 +346,7 @@ class BaseQuantizationMixin(abc.ABC):
             encoding = encodings.get(param_name, None)
             if not encoding:
                 if not partial:
-                    # Dnagling quantizers have to be removed when importing non-partial encodings
+                    # Dangling quantizers have to be removed when importing non-partial encodings
                     self.param_quantizers[param_name] = None
                 continue
             if quantizer is None and strict:
@@ -358,8 +358,8 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_recompute is not None:
-                quantizer._skip_encoding_computation = not allow_recompute # pylint:disable = protected-access
+            if allow_overwrite is not None:
+                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def get_original_module(self) -> nn.Module:
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -249,6 +249,8 @@ class BaseQuantizationMixin(abc.ABC):
         :param freeze: If True, freezes the quantizer's encodings after loading
         """
         for i, quantizer in enumerate(list(self.input_quantizers)):
+            if quantizer and not quantizer._allow_overwrite: # pylint: disable=protected-access
+                continue
             encoding = encodings.get(str(i), None)
             if not encoding:
                 if not partial:
@@ -296,6 +298,8 @@ class BaseQuantizationMixin(abc.ABC):
         :param freeze: If True, freezes the quantizer's encodings after loading
         """
         for i, quantizer in enumerate(list(self.output_quantizers)):
+            if quantizer and not quantizer._allow_overwrite: # pylint: disable=protected-access
+                continue
             encoding = encodings.get(str(i), None)
             if not encoding:
                 if not partial:
@@ -343,6 +347,8 @@ class BaseQuantizationMixin(abc.ABC):
         :param freeze: If True, freezes the quantizer's encodings after loading
         """
         for param_name, quantizer in dict(self.param_quantizers).items():
+            if quantizer and not quantizer._allow_overwrite: # pylint: disable=protected-access
+                continue
             encoding = encodings.get(param_name, None)
             if not encoding:
                 if not partial:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -234,7 +234,7 @@ class BaseQuantizationMixin(abc.ABC):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import input encodings represented in below format:
         {
@@ -266,8 +266,7 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_overwrite is not None:
-                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
+            quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def export_output_encodings(self) -> List[List[Dict]]:
         """
@@ -283,7 +282,7 @@ class BaseQuantizationMixin(abc.ABC):
                                 strict: bool,
                                 partial: bool,
                                 requires_grad: Optional[bool],
-                                allow_overwrite: Optional[bool]):
+                                allow_overwrite: bool):
         """
         Import output encodings represented in below format:
         {
@@ -315,8 +314,7 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_overwrite is not None:
-                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
+            quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def export_param_encodings(self) -> Dict[str, List[Dict]]:
         """
@@ -332,7 +330,7 @@ class BaseQuantizationMixin(abc.ABC):
                                strict: bool,
                                partial: bool,
                                requires_grad: Optional[bool],
-                               allow_overwrite: Optional[bool]):
+                               allow_overwrite: bool):
         """
         Import parameter encodings represented in below format:
         {
@@ -364,8 +362,7 @@ class BaseQuantizationMixin(abc.ABC):
             if requires_grad is not None:
                 quantizer.requires_grad_(requires_grad)
 
-            if allow_overwrite is not None:
-                quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
+            quantizer._allow_overwrite = allow_overwrite # pylint:disable = protected-access
 
     def get_original_module(self) -> nn.Module:
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -276,7 +276,7 @@ class MinMaxQuantizer(AffineQuantizerBase): # pylint: disable=abstract-method
         During ``compute_encodings`` is enabled, the quantizer forward pass performs
         dynamic quantization using the batch statistics.
         """
-        if self._skip_encoding_computation:
+        if not self._allow_overwrite:
             yield
             return
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -276,7 +276,7 @@ class MinMaxQuantizer(AffineQuantizerBase): # pylint: disable=abstract-method
         During ``compute_encodings`` is enabled, the quantizer forward pass performs
         dynamic quantization using the batch statistics.
         """
-        if not self.encoding_analyzer:
+        if self._skip_encoding_computation:
             yield
             return
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
@@ -67,7 +67,7 @@ class QuantizerBase(abc.ABC, torch.nn.Module):
         # This info will be used for judging whether the current parameter has ever been
         # initialized after it was instantiated.
         self._initial_parameters = OrderedDict()
-        self._skip_encoding_computation = False
+        self._allow_overwrite = True
 
     @abc.abstractmethod
     @contextlib.contextmanager

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
@@ -67,6 +67,7 @@ class QuantizerBase(abc.ABC, torch.nn.Module):
         # This info will be used for judging whether the current parameter has ever been
         # initialized after it was instantiated.
         self._initial_parameters = OrderedDict()
+        self._skip_encoding_computation = False
 
     @abc.abstractmethod
     @contextlib.contextmanager
@@ -202,20 +203,3 @@ class QuantizerBase(abc.ABC, torch.nn.Module):
         is_initialized = state.pop('is_initialized')
         self.__dict__.update(state)
         self.set_extra_state(is_initialized)
-
-    def _freeze_encoding(self):
-        """
-        Freeze the encoding params so they won't be updated during training or compute_encodings
-        """
-        for param in self.parameters():
-            param.requires_grad = False
-        self.encoding_analyzer = None
-
-    def _is_encoding_frozen(self):
-        """
-        Returns true if the encodings are frozen
-        """
-        for param in self.parameters():
-            if param.requires_grad:
-                return False
-        return self.encoding_analyzer is None

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
@@ -172,7 +172,7 @@ class FloatQuantizeDequantize(QuantizerBase): # pylint: disable=abstract-method
         During ``compute_encodings`` is enabled, the quantizer forward pass performs
         dynamic quantization using the batch statistics.
         """
-        if not self.encoding_analyzer or self._skip_encoding_computation:
+        if not self.encoding_analyzer or not self._allow_overwrite:
             yield
             return
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
@@ -172,7 +172,7 @@ class FloatQuantizeDequantize(QuantizerBase): # pylint: disable=abstract-method
         During ``compute_encodings`` is enabled, the quantizer forward pass performs
         dynamic quantization using the batch statistics.
         """
-        if not self.encoding_analyzer:
+        if not self.encoding_analyzer or self._skip_encoding_computation:
             yield
             return
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -145,7 +145,8 @@ class SequentialMse(V1SequentialMse):
     @staticmethod
     def _freeze_quantizer_encoding(quantizer: QuantizerBase):
         # pylint: disable=protected-access
-        return quantizer._freeze_encoding()
+        quantizer.requires_grad_(False)
+        quantizer._allow_overwrite = False
 
     @staticmethod
     def _get_quantized_weight(quant_module: BaseQuantizationMixin):

--- a/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
@@ -953,17 +953,17 @@ def test_high_bitwidth(x, symmetric):
 
 @pytest.mark.parametrize("q", (Quantize(_PARAMETER_SHAPE, 8, False),
                                QuantizeDequantize(_PARAMETER_SHAPE, 8, True)))
-def test_skip_encoding_computation(x, q):
+def test_allow_overwrite(x, q):
     with q.compute_encodings():
         q(x)
 
     """
-    Given: _skip_encoding_computation set to True
+    Given: _allow_overwrite set to True
     When: Try to recompute encodings
     Then: Encoding does NOT get overwritten by compute_encodings
     """
     q_min, q_max = q.min.detach().clone(), q.max.detach().clone()
-    q._skip_encoding_computation = True
+    q._allow_overwrite = False
     with q.compute_encodings():
         q(x * 10)
 

--- a/TrainingExtensions/torch/test/python/v2/quantization/float/test_float_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/float/test_float_quantizer.py
@@ -127,27 +127,19 @@ def test_qdq_compute_encodings(x):
     assert torch.equal(float16_qdq(x), expected_output)
 
 
-def test_freeze_encodings(x):
+def test_skip_encoding_computation(x):
     exponent_bits, mantissa_bits = 3, 4
     q = FloatQuantizeDequantize(exponent_bits, mantissa_bits, encoding_analyzer=MinMaxEncodingAnalyzer((1, 100)))
     with q.compute_encodings():
         q(x)
 
-    q_max = q.maxval.detach().clone()
-
-    q._freeze_encoding()
-    assert q._is_encoding_frozen()
     """
-    Given: Called quantizer.freeze_encoding()
-    When: Inspect parameter requires_grad() attributes
-    Then: requires_grad = False for all parameters
-    """
-    assert not q.maxval.requires_grad
-
-    """
+    Given: _skip_encoding_computation set to True
     When: Try to recompute encodings
-    Then: Encodings do not change
+    Then: Encoding does NOT get overwritten by compute_encodings
     """
+    q_max = q.maxval.detach().clone()
+    q._skip_encoding_computation = True
     with q.compute_encodings():
         q(x * 10)
 

--- a/TrainingExtensions/torch/test/python/v2/quantization/float/test_float_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/float/test_float_quantizer.py
@@ -127,19 +127,19 @@ def test_qdq_compute_encodings(x):
     assert torch.equal(float16_qdq(x), expected_output)
 
 
-def test_skip_encoding_computation(x):
+def test_allow_overwrite(x):
     exponent_bits, mantissa_bits = 3, 4
     q = FloatQuantizeDequantize(exponent_bits, mantissa_bits, encoding_analyzer=MinMaxEncodingAnalyzer((1, 100)))
     with q.compute_encodings():
         q(x)
 
     """
-    Given: _skip_encoding_computation set to True
+    Given: _allow_overwrite set to False
     When: Try to recompute encodings
     Then: Encoding does NOT get overwritten by compute_encodings
     """
     q_max = q.maxval.detach().clone()
-    q._skip_encoding_computation = True
+    q._allow_overwrite = False
     with q.compute_encodings():
         q(x * 10)
 

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -331,11 +331,11 @@ class TestPercentileScheme:
                 assert q.max.requires_grad == max_copy.requires_grad
 
         """
-        When: Call load_encodings with allow_recompute=True
+        When: Call load_encodings with allow_overwrite=True
         Then: The loaded quantizers should be overwritten by a subsequent compute_encodings
         """
         sim = QuantizationSimModel(model, dummy_input)
-        sim.load_encodings(encodings, allow_recompute=True)
+        sim.load_encodings(encodings, allow_overwrite=True)
         weight_min = sim.model.conv1.param_quantizers['weight'].min.clone().detach()
         weight_max = sim.model.conv1.param_quantizers['weight'].max.clone().detach()
         input_min = sim.model.conv1.input_quantizers[0].min.clone().detach()
@@ -353,11 +353,11 @@ class TestPercentileScheme:
                                      sim.model.conv1.input_quantizers[0].max))
 
         """
-        When: Call load_encodings with allow_recompute=False
+        When: Call load_encodings with allow_overwrite=False
         Then: The loaded quantizers should NOT be overwritten by a subsequent compute_encodings
         """
         sim = QuantizationSimModel(model, dummy_input)
-        sim.load_encodings(encodings, allow_recompute=False)
+        sim.load_encodings(encodings, allow_overwrite=False)
         weight_min = sim.model.conv1.param_quantizers['weight'].min.clone().detach()
         weight_max = sim.model.conv1.param_quantizers['weight'].max.clone().detach()
         input_min = sim.model.conv1.input_quantizers[0].min.clone().detach()
@@ -371,10 +371,10 @@ class TestPercentileScheme:
         assert torch.equal(input_max, sim.model.conv1.input_quantizers[0].max)
 
         """
-        When: Call load_encodings with allow_recompute=None
+        When: Call load_encodings with allow_overwrite=None
         Then: Whether the loaded quantizers can be overwritten is kept unchanged
         """
-        sim.load_encodings(encodings, allow_recompute=None)
+        sim.load_encodings(encodings, allow_overwrite=None)
 
         assert torch.equal(weight_min, sim.model.conv1.param_quantizers['weight'].min)
         assert torch.equal(weight_max, sim.model.conv1.param_quantizers['weight'].max)


### PR DESCRIPTION
Removed the notion of "freezing", and decomposed it into "requires_grad" and "allow_overwrite"

So far, freezing has had two meanings
1. Do not update min/max during forward/backward
2. Do not overwrite min/max upon compute_encodings or load_encodings

From this PR on, we will let (1) solely controlled by `requires_grad`, and (2) solely controlled by `allow_overwrite`.

### Main changes
The concept of **frozen** is now decomposed it into **requires_grad** and **allow_overwrite**