### PR TITLE
Refactoring to restore super() in aimet.nn

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -38,7 +38,6 @@
 
 import abc
 import contextlib
-import functools
 import itertools
 from typing import Type, List, Dict, Union, Iterable
 
@@ -355,33 +354,6 @@ class BaseQuantizationMixin(abc.ABC):
         del orig_module._modules['param_quantizers']
 
         return orig_module
-
-    @property
-    def _super_forward(self):
-        # This is a manually/explicitly rewritten version of super().forward.
-        # NOTE: This is an ad-hoc solution and will be removed in the later versions
-        is_staticmethod = False
-        is_classmethod = False
-
-        for cls in type(self).__mro__:
-            if not 'forward' in cls.__dict__:
-                continue
-            super_forward = cls.__dict__['forward']
-
-            if isinstance(super_forward, staticmethod):
-                is_staticmethod = True
-            if isinstance(super_forward, classmethod):
-                is_classmethod = True
-            break
-        else:
-            raise RuntimeError
-
-        super_forward = self.qcls_to_cls[type(self)].forward
-
-        if is_staticmethod or is_classmethod:
-            return super_forward
-
-        return functools.partial(super_forward, self)
 
     def _remove_input_quantizers(self, indices: Union[int, Iterable[int]] = None):
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/fake_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/fake_quant.py
@@ -95,7 +95,7 @@ class _FakeQuantizedUnaryOpMixin(FakeQuantizationMixin):
             x = self.input_quantizers[0](x)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(x, *others, **kwargs)
+            output = super().forward(x, *others, **kwargs)
 
         if isinstance(output, Tensor) and output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -118,7 +118,7 @@ class _FakeQuantizedBinaryOpMixin(FakeQuantizationMixin):
             y = self.input_quantizers[1](y)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(x, y, *others, **kwargs)
+            output = super().forward(x, y, *others, **kwargs)
 
         if isinstance(output, Tensor) and output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -144,7 +144,7 @@ class _FakeQuantizedTernaryOpMixin(FakeQuantizationMixin):
             z = self.input_quantizers[2](z)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(x, y, z, *others, **kwargs)
+            output = super().forward(x, y, z, *others, **kwargs)
 
         if isinstance(output, Tensor) and output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -322,7 +322,7 @@ class FakeQuantizedEmbedding(FakeQuantizationMixin, nn.Embedding):
         # pylint: disable=redefined-builtin
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(input)
+            output = super().forward(input)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -354,7 +354,7 @@ class FakeQuantizedEmbeddingBag(FakeQuantizationMixin, nn.EmbeddingBag):
             per_sample_weights = self.input_quantizers[0](per_sample_weights)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(input, offsets, per_sample_weights)
+            output = super().forward(input, offsets, per_sample_weights)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -386,7 +386,7 @@ class _FakeQuantizedRNNBaseMixin(FakeQuantizationMixin):
             hx = self.input_quantizers[1](hx)
 
         with self._patch_quantized_parameters():
-            output, hidden = self._super_forward(input, hx)
+            output, hidden = super().forward(input, hx)
 
         if self.output_quantizers[0]:
             if isinstance(output, PackedSequence):
@@ -419,7 +419,7 @@ class _FakeQuantizedRNNCellBaseMixin(_FakeQuantizedBinaryOpMixin):
             hx = self.input_quantizers[1](hx)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(input, hx)
+            output = super().forward(input, hx)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -463,7 +463,7 @@ class FakeQuantizedLSTM(FakeQuantizationMixin, nn.LSTM):
             hx = (h, c)
 
         with self._patch_quantized_parameters():
-            output, hidden = self._super_forward(input, hx)
+            output, hidden = super().forward(input, hx)
 
         if self.output_quantizers[0]:
             if isinstance(output, PackedSequence):
@@ -515,7 +515,7 @@ class FakeQuantizedLSTMCell(FakeQuantizationMixin, nn.LSTMCell):
             hx = (h, c)
 
         with self._patch_quantized_parameters():
-            output = self._super_forward(input, hx)
+            output = super().forward(input, hx)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -545,7 +545,7 @@ class FakeQuantizedAdaptiveLogSoftmaxWithLoss(FakeQuantizationMixin, nn.Adaptive
             target_ = self.input_quantizers[1](target_)
 
         with self._patch_quantized_parameters():
-            outputs = self._super_forward(input_, target_)
+            outputs = super().forward(input_, target_)
 
         output, loss = outputs
 
@@ -718,7 +718,7 @@ class FakeQuantizedBatchNorm(FakeQuantizationMixin, aimet_ops.BatchNorm): # pyli
         if bias is not None and self.input_quantizers[4]:
             bias = self.input_quantizers[4](bias)
 
-        output = self._super_forward(input, running_mean, running_var,
+        output = super().forward(input, running_mean, running_var,
                                      weight, bias, training, momentum, eps)
 
         if self.output_quantizers[0]:
@@ -757,7 +757,7 @@ class FakeQuantizedAimetGroupNorm(FakeQuantizationMixin, aimet_ops.GroupNorm): #
         if bias is not None and self.input_quantizers[3]:
             bias = self.input_quantizers[3](bias)
 
-        output = self._super_forward(input, num_groups, weight, bias, eps)
+        output = super().forward(input, num_groups, weight, bias, eps)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -786,7 +786,7 @@ class FakeQuantizedNonMaxSuppression(FakeQuantizationMixin, aimet_ops.NonMaxSupp
             # Use same input quantizer for all the score tensors
             scores = tree_map(self.input_quantizers[0], scores)
 
-        self._super_forward(boxes, scores)
+        super().forward(boxes, scores)
 
         if self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -808,7 +808,7 @@ class FakeQuantizedSplit(_FakeQuantizedUnaryOpMixin, aimet_ops.Split): # pylint:
         if x.is_floating_point() and self.input_quantizers[0]:
             x = self.input_quantizers[0](x)
 
-        outputs = self._super_forward(x, *others, **kwargs)
+        outputs = super().forward(x, *others, **kwargs)
 
         if self.output_quantizers[0]:
             # Use same output quantizer for all the output tensors
@@ -832,7 +832,7 @@ class FakeQuantizedConcat(_FakeQuantizedUnaryOpMixin, aimet_ops.Concat):
             quantize_fn = lambda inp: self.input_quantizers[0](inp) if inp.is_floating_point() else inp
             x = tree_map(quantize_fn, x)
 
-        output = self._super_forward(*x)
+        output = super().forward(*x)
 
         if output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -863,7 +863,7 @@ class FakeQuantizedWhere(FakeQuantizationMixin, aimet_ops.Where): # pylint: disa
         if isinstance(other, Tensor) and other.is_floating_point() and self.input_quantizers[2]:
             other = self.input_quantizers[2](other)
 
-        output = self._super_forward(condition, input, other, **kwargs)
+        output = super().forward(condition, input, other, **kwargs)
 
         if output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)
@@ -889,7 +889,7 @@ class FakeQuantizedMaskedFill(FakeQuantizationMixin, aimet_ops.MaskedFill): # py
         if isinstance(value, Tensor) and value.is_floating_point() and self.input_quantizers[1]:
             value = self.input_quantizers[1](value)
 
-        output = self._super_forward(mask, value)
+        output = super().forward(mask, value)
 
         if output.is_floating_point() and self.output_quantizers[0]:
             output = self.output_quantizers[0](output)


### PR DESCRIPTION
This is a refactoring PR to remove `_super_forward` method that was temporarily replacing `super().forward`.
For more context about why `_super_forward` was added in the first place, see #2848 