### PR TITLE
Add profiling utility pytorch

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -477,7 +477,7 @@ def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: 
     should_close = False
     if isinstance(file, (str, os.PathLike)):
         mode = 'w' if new_file else 'a'
-        file = open(file, mode)
+        file = open(file, mode) # pylint: disable=consider-using-with
         should_close = True
     elif file is None:
         file = sys.stdout

--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -37,6 +37,7 @@
 """ Utility classes and functions that are used by NightlyTests files as well as
     common to both PyTorch and TensorFlow. """
 
+import sys
 from contextlib import contextmanager
 import json
 import logging
@@ -49,7 +50,7 @@ import subprocess
 import threading
 import time
 from enum import Enum
-from typing import Callable, Dict, List, Optional
+from typing import Callable, Dict, List, Optional, TextIO, Union, Any
 import multiprocessing
 import yaml
 from tqdm import tqdm
@@ -459,26 +460,44 @@ def convert_configs_values_to_bool(dictionary: Dict):
         else:
             pass
 
+
 @contextmanager
-def profile(file_path_and_name: str, label: str, new_file: bool = False, logger: Optional[logging.Logger] = None):
+def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None,
+            cleanup: Callable[[], Any] = None):
     """
     Profile a block of code and save profiling information into a file.
 
-    :param file_path_and_name: File path and name to save profiling information to
     :param label: String label associated with the block of code to profile (shows up in the profiling print)
+    :param file: File path and name or a file-like object to send output text to (Default: stdout)
     :param new_file: True if a new file is to be created to hold profiling info, False if an existing file should be
-        appended to
+        appended to. This flag is only valid when ``file`` is a path, not a file-like object.
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
+    :param cleanup: If provided, this will be called before ending profiling. This can be useful for synchronizing cuda streams.
     """
-    start = time.time()
-    yield
-    end = time.time()
-    profiling_string = f'{label}: {end - start}'
-    if logger:
-        logger.info(profiling_string)
-    if new_file:
-        with open(file_path_and_name, 'w') as f:
-            print(profiling_string, file=f)
-    else:
-        with open(file_path_and_name, 'a') as f:
-            print(f'{label}: {end - start}', file=f)
+    should_close = False
+    if isinstance(file, (str, os.PathLike)):
+        mode = 'w' if new_file else 'a'
+        file = open(file, mode)
+        should_close = True
+    elif file is None:
+        file = sys.stdout
+
+    assert hasattr(file, 'write')
+
+    try:
+        with Spinner(label):
+            start = time.perf_counter()
+            yield
+            if cleanup:
+                cleanup()
+            end = time.perf_counter()
+
+        profiling_string = f'{label}: {end - start:.2f}s'
+
+        if logger:
+            logger.info(profiling_string)
+
+        print(profiling_string, file=file)
+    finally:
+        if should_close:
+            file.close()

--- a/TrainingExtensions/common/test/python/test_utils.py
+++ b/TrainingExtensions/common/test/python/test_utils.py
@@ -68,14 +68,15 @@ def test_profile():
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
         assert len(lines) == 2
-        assert 'profile 1: ' in lines[0]
-        assert 'profile 2: ' in lines[1]
+        assert lines[0].startswith('profile 1: ')
+        assert lines[1].startswith('profile 2: ')
+
         with profile('profile 3', file_path_and_name, new_file=True, logger=logger):
             _ = 1 + 1
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
         assert len(lines) == 1
-        assert 'profile 3: ' in lines[0]
+        assert lines[0].startswith('profile 3: ')
 
         with profile('profile 4'):
             _ = 1 + 1

--- a/TrainingExtensions/common/test/python/test_utils.py
+++ b/TrainingExtensions/common/test/python/test_utils.py
@@ -61,18 +61,21 @@ def test_save_json_yaml():
 def test_profile():
     with tempfile.TemporaryDirectory() as tmpdir:
         file_path_and_name = os.path.join(tmpdir, 'temp_profile.txt')
-        with profile(file_path_and_name, 'profile 1', new_file=True, logger=logger):
+        with profile('profile 1', file_path_and_name, new_file=True, logger=logger):
             _ = 1 + 1
-        with profile(file_path_and_name, 'profile 2', logger=logger):
+        with profile('profile 2', file_path_and_name, logger=logger):
             _ = 1 + 1
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
         assert len(lines) == 2
         assert 'profile 1: ' in lines[0]
         assert 'profile 2: ' in lines[1]
-        with profile(file_path_and_name, 'profile 3', new_file=True, logger=logger):
+        with profile('profile 3', file_path_and_name, new_file=True, logger=logger):
             _ = 1 + 1
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
         assert len(lines) == 1
         assert 'profile 3: ' in lines[0]
+
+        with profile('profile 4'):
+            _ = 1 + 1

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -1210,7 +1210,7 @@ def deprecated(msg: str):
     return decorator
 
 
-def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None):
+def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None): # pylint: disable=redefined-outer-name
     """
     Profile a block of code and save profiling information into a file.
 
@@ -1221,10 +1221,10 @@ def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: 
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
     ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
-    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None))
+    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None)) # pylint: disable=no-member
 
 
-def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None):
+def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None): # pylint: disable=redefined-outer-name
     """
     Profile a block of code and save profiling information into a file.
 
@@ -1235,4 +1235,4 @@ def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
     ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
-    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None))
+    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None)) # pylint: disable=no-member

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -1220,7 +1220,10 @@ def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: 
         appended to. This flag is only valid when ``file`` is a path, not a file-like object.
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
-    ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+    if not torch.cuda.is_available():
+        return profile_async(label, file, new_file, logger)
+
+    ctx = _profile(label, file, new_file, logger, cleanup=torch.cuda.synchronize)
     return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None)) # pylint: disable=no-member
 
 
@@ -1234,5 +1237,5 @@ def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_
         appended to. This flag is only valid when ``file`` is a path, not a file-like object.
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
-    ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+    ctx = _profile(label, file, new_file, logger, cleanup=None)
     return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None)) # pylint: disable=no-member

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -39,12 +39,13 @@
 import importlib
 import inspect
 import itertools
-from typing import List, Tuple, Union, Dict, Callable, Any, Iterable
+from typing import List, Tuple, Union, Dict, Callable, Any, Iterable, Optional, TextIO
 import contextlib
 import os
 import pickle
 import sys
 import functools
+import logging
 import warnings
 
 import numpy as np
@@ -55,6 +56,7 @@ from torchvision import datasets, transforms
 
 from aimet_common.defs import QuantScheme, QuantizationDataType, MAP_QUANT_SCHEME_TO_PYMO
 from aimet_common.utils import AimetLogger, Handle, log_with_error_and_assert_if_false
+from aimet_common.utils import profile as _profile
 import aimet_common.libpymo as libpymo
 from aimet_torch import elementwise_ops
 from aimet_torch.tensor_quantizer import TensorQuantizer
@@ -1205,3 +1207,29 @@ def deprecated(msg: str):
             return _callable(*args, **kwargs)
         return fn_wrapper
     return decorator
+
+
+def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None):
+    """
+    Profile a block of code and save profiling information into a file.
+
+    :param label: String label associated with the block of code to profile (shows up in the profiling print)
+    :param file: File path and name or a file-like object to send output text to (Default: stdout)
+    :param new_file: True if a new file is to be created to hold profiling info, False if an existing file should be
+        appended to. This flag is only valid when ``file`` is a path, not a file-like object.
+    :param logger: If logger is provided, profiling string will also be printed with INFO logging level
+    """
+    return _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+
+
+def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None):
+    """
+    Profile a block of code and save profiling information into a file.
+
+    :param label: String label associated with the block of code to profile (shows up in the profiling print)
+    :param file: File path and name or a file-like object to send output text to (Default: stdout)
+    :param new_file: True if a new file is to be created to hold profiling info, False if an existing file should be
+        appended to. This flag is only valid when ``file`` is a path, not a file-like object.
+    :param logger: If logger is provided, profiling string will also be printed with INFO logging level
+    """
+    return _profile(label, file, new_file, logger, cleanup=None)

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -61,6 +61,7 @@ import aimet_common.libpymo as libpymo
 from aimet_torch import elementwise_ops
 from aimet_torch.tensor_quantizer import TensorQuantizer
 from aimet_torch.v2.nn.base import BaseQuantizationMixin
+from aimet_torch.v2.utils import _ContextManager
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Utils)
 
@@ -1219,7 +1220,8 @@ def profile(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: 
         appended to. This flag is only valid when ``file`` is a path, not a file-like object.
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
-    return _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+    ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None))
 
 
 def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_file: bool = False, logger: Optional[logging.Logger] = None):
@@ -1232,4 +1234,5 @@ def profile_async(label: str, file: Union[str, os.PathLike, TextIO] = None, new_
         appended to. This flag is only valid when ``file`` is a path, not a file-like object.
     :param logger: If logger is provided, profiling string will also be printed with INFO logging level
     """
-    return _profile(label, file, new_file, logger, cleanup=None)
+    ctx = _profile(label, file, new_file, logger, cleanup=lambda: torch.cuda.synchronize)
+    return _ContextManager(action=ctx.__enter__, cleanup=lambda: ctx.__exit__(None, None, None))

--- a/TrainingExtensions/torch/test/python/test_utils.py
+++ b/TrainingExtensions/torch/test/python/test_utils.py
@@ -45,6 +45,7 @@ import torch
 import torch.nn
 import torchvision
 import torch.nn.functional as F
+import tempfile
 
 import aimet_torch.model_validator.validation_checks
 import aimet_torch.utils
@@ -707,6 +708,32 @@ class MiniModel(torch.nn.Module):
         for quantizer in all_quantizers:
             assert not quantizer.enabled
 
+
 def _assert_mode_recursive(root: torch.nn.Module, training: bool):
     for module in root.modules():
         assert module.training == training
+
+
+def test_profile():
+    from aimet_common.utils import AimetLogger
+    logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Utils)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        file_path_and_name = os.path.join(tmpdir, 'temp_profile.txt')
+        with utils.profile('profile 1', file_path_and_name, new_file=True, logger=logger):
+            _ = 1 + 1
+        with utils.profile('profile 2', file_path_and_name, logger=logger):
+            _ = 1 + 1
+        with open(file_path_and_name, 'r') as f:
+            lines = f.readlines()
+        assert len(lines) == 2
+        assert 'profile 1: ' in lines[0]
+        assert 'profile 2: ' in lines[1]
+        with utils.profile('profile 3', file_path_and_name, new_file=True, logger=logger):
+            _ = 1 + 1
+        with open(file_path_and_name, 'r') as f:
+            lines = f.readlines()
+        assert len(lines) == 1
+        assert 'profile 3: ' in lines[0]
+
+        with utils.profile('profile 4'):
+            _ = 1 + 1

--- a/TrainingExtensions/torch/test/python/test_utils.py
+++ b/TrainingExtensions/torch/test/python/test_utils.py
@@ -726,14 +726,22 @@ def test_profile():
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
         assert len(lines) == 2
-        assert 'profile 1: ' in lines[0]
-        assert 'profile 2: ' in lines[1]
+        assert lines[0].startswith('profile 1: ')
+        assert lines[1].startswith('profile 2: ')
+
         with utils.profile('profile 3', file_path_and_name, new_file=True, logger=logger):
             _ = 1 + 1
+
+        @utils.profile('profile 4', file_path_and_name)
+        def foobar():
+            _ = 1 + 1
+
+        foobar()
         with open(file_path_and_name, 'r') as f:
             lines = f.readlines()
-        assert len(lines) == 1
-        assert 'profile 3: ' in lines[0]
+        assert len(lines) == 2
+        assert lines[0].startswith('profile 3: ')
+        assert lines[1].startswith('profile 4: ')
 
         with utils.profile('profile 4'):
             _ = 1 + 1


### PR DESCRIPTION
## Main Changes
1. pytorch profile function will call `torch.cuda.synchronize()` by default for accurate speed measurement
2. Adjusted function signature of `profile` such that only "label" is a mandatory argument, and output will be sent to stdout by default
3. `profile` can be also used as a decorator