### PR TITLE
Fix a runtime error when importing encodings

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -259,8 +259,7 @@ class BaseQuantizationMixin(abc.ABC):
             if quantizer is None:
                 if strict:
                     raise RuntimeError
-                else:
-                    continue
+                continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)
@@ -310,8 +309,7 @@ class BaseQuantizationMixin(abc.ABC):
             if quantizer is None:
                 if strict:
                     raise RuntimeError
-                else:
-                    continue
+                continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)
@@ -361,8 +359,7 @@ class BaseQuantizationMixin(abc.ABC):
             if quantizer is None:
                 if strict:
                     raise RuntimeError
-                else:
-                    continue
+                continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -256,8 +256,11 @@ class BaseQuantizationMixin(abc.ABC):
                     # Dangling quantizers have to be removed when importing non-partial encodings
                     self.input_quantizers[i] = None
                 continue
-            if quantizer is None and strict:
-                raise RuntimeError
+            if quantizer is None:
+                if strict:
+                    raise RuntimeError
+                else:
+                    continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)
@@ -304,8 +307,11 @@ class BaseQuantizationMixin(abc.ABC):
                     # Dangling quantizers have to be removed when importing non-partial encodings
                     self.output_quantizers[i] = None
                 continue
-            if quantizer is None and strict:
-                raise RuntimeError
+            if quantizer is None:
+                if strict:
+                    raise RuntimeError
+                else:
+                    continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)
@@ -352,8 +358,11 @@ class BaseQuantizationMixin(abc.ABC):
                     # Dangling quantizers have to be removed when importing non-partial encodings
                     self.param_quantizers[param_name] = None
                 continue
-            if quantizer is None and strict:
-                raise RuntimeError
+            if quantizer is None:
+                if strict:
+                    raise RuntimeError
+                else:
+                    continue
             if isinstance(encoding, dict):
                 encoding = [encoding]
             quantizer.set_legacy_encodings(encoding)

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -274,6 +274,32 @@ class TestPercentileScheme:
             },
             "param_encodings": {"conv1.weight": [sample_encoding2]}
         }
+        encodings3 = {
+            "activation_encodings": {
+                "conv1": {
+                    "input": {"0": sample_encoding},
+                    "output": {"0": sample_encoding}
+                }
+            },
+            "param_encodings": {"conv1.weight": [sample_encoding]}
+        }
+
+        """
+        When: Call load_encodings with strict=True
+        Then: Runtime error is raised
+        """
+        sim = QuantizationSimModel(model, dummy_input)
+        with pytest.raises(RuntimeError):
+            sim.load_encodings(encodings3, strict=True)
+
+        """
+        When: Call load_encodings with strict=False
+        Then: Skip to load encodings that doesn't exist 
+        """
+        sim = QuantizationSimModel(model, dummy_input)
+        sim.load_encodings(encodings3, strict=False)
+        assert sim.model.conv1.output_quantizers[0] is None
+
 
         """
         When: Call load_encodings with partial=False


### PR DESCRIPTION
The quantizer can be None when strict is False. In this case, we need to skip setting encodings.