### PR TITLE
Bokeh server failing with an unknown error (occurs randomly)

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -290,6 +290,9 @@ def start_bokeh_server_session(port: int = None):
     server_started.wait(timeout=10)
 
     if 'port' not in d:
+        if proc:
+            proc.terminate()
+
         if 'exception' in d:
             e = d['exception']
             raise RuntimeError(f'Bokeh server failed with the following error: {e}')

--- a/TrainingExtensions/common/src/python/aimet_common/utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/utils.py
@@ -287,7 +287,7 @@ def start_bokeh_server_session(port: int = None):
     proc = multiprocessing.Process(target=start_bokeh_server, args=(port,))
 
     proc.start()
-    server_started.wait(timeout=3)
+    server_started.wait(timeout=10)
 
     if 'port' not in d:
         if 'exception' in d:


### PR DESCRIPTION
Fixes #3004 

- Increased the bokeh server timeout to 10s.
- Terminate the child process in case of an exception to avoid running indefinitely.