### PR TITLE
Concretize block sizes just-in-time during export

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -284,7 +284,6 @@ class MinMaxQuantizer(AffineQuantizerBase): # pylint: disable=abstract-method
 
         @functools.wraps(original_forward)
         def forward_wrapper(input):
-            self._realize_block_size(input)
             expanded_input = torch_builtins.reshape_tensor_for_blocks(input, self.shape, self.block_size)
             batch_statistics = self.encoding_analyzer.update_stats(expanded_input)
             num_steps = math.pow(2, self.bitwidth) - 1
@@ -403,19 +402,6 @@ class MinMaxQuantizer(AffineQuantizerBase): # pylint: disable=abstract-method
         with torch.no_grad():
             self.min.copy_(min)
             self.max.copy_(max)
-
-    def _realize_block_size(self, inp):
-        """
-        Fill in block sizes for dimensions with block size -1
-        """
-        if self.block_size is not None and any(size == -1 for size in self.block_size):
-            block_size = []
-            for i in range(1, len(self.block_size) + 1):
-                if self.block_size[-i] == -1:
-                    block_size.insert(0, inp.shape[-i] // self.shape[-i])
-                else:
-                    block_size.insert(0, self.block_size[-i])
-            self.block_size = block_size
 
 
 class Quantize(MinMaxQuantizer):


### PR DESCRIPTION
Currently, the export artifacts of blockwise quantizers don't allow wildcard block sizes (-1), and therefore the wildcard block size should be **concretized** at some point before export.
However, the current BQ export mechanism concretizes block sizes too early and permanently during the first forward pass of the quantizer. This causes two problems.

1. Input shape of the BQ quantizers are fixed to that of the first input.
(originally you could use any input shape at any given time as long as it complies to the shape constraints)
2. If the input shape observed during the first forward pass differs from the dummy input shape passed to `sim.export`, the block size concretized earlier during the first forward pass may not be consistent with the shape of the export-time dummy input.

This PR fixes the problem by concretizing block sizes just-in-time during export, without leaving any permanent side effect to the quantizers