### PR TITLE
Add deprecation warning for QuantizationSimModel.quant_wrappers API

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -1741,15 +1741,19 @@ class QuantizationSimModel:
                             requires_grad=False,
                             allow_overwrite=False)
 
-    def qmodules(self):
-        """
-        Generator for yielding all quantization wrappers and their names
+    def named_qmodules(self):
+        """Generator that yields all quantized modules in the model and their names
         """
         for name, module in self.model.named_modules():
             if isinstance(module, (QcQuantizeRecurrent, LazyQuantizeWrapper, ExportableQuantModule)):
                 yield name, module
 
-    quant_wrappers = qmodules
+    def qmodules(self):
+        """Generator that yields all quantized modules in the model
+        """
+        yield from (module for _, module in self.named_qmodules())
+
+    quant_wrappers = named_qmodules
 
     def run_modules_for_traced_custom_marker(self, module_list: List[torch.nn.Module], dummy_input):
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim.py
@@ -1741,13 +1741,15 @@ class QuantizationSimModel:
                             requires_grad=False,
                             allow_overwrite=False)
 
-    def quant_wrappers(self):
+    def qmodules(self):
         """
         Generator for yielding all quantization wrappers and their names
         """
         for name, module in self.model.named_modules():
             if isinstance(module, (QcQuantizeRecurrent, LazyQuantizeWrapper, ExportableQuantModule)):
                 yield name, module
+
+    quant_wrappers = qmodules
 
     def run_modules_for_traced_custom_marker(self, module_list: List[torch.nn.Module], dummy_input):
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -232,6 +232,6 @@ class QuantizationSimModel(V1QuantizationSimModel):
     def _replace_quantization_wrapper_with_native_torch_quantization_nodes(quant_sim_model, device: torch.device):
         raise NotImplementedError()
 
-    @deprecated('Use {qmodules.__qualname__} instead.')
+    @deprecated(f'Use {V1QuantizationSimModel.named_qmodules.__qualname__} instead.')
     def quant_wrappers(self): # pylint: disable=missing-docstring
         return super().quant_wrappers()

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -53,6 +53,7 @@ from aimet_torch.v2.quantization.affine import AffineQuantizerBase
 from aimet_torch.v2.quantization.encoding_analyzer import PercentileEncodingAnalyzer
 from aimet_torch.v2.utils import patch_attr
 from aimet_torch import utils
+from aimet_torch.utils import deprecated
 
 
 qc_quantize_modules_dict = {
@@ -230,3 +231,7 @@ class QuantizationSimModel(V1QuantizationSimModel):
     @staticmethod
     def _replace_quantization_wrapper_with_native_torch_quantization_nodes(quant_sim_model, device: torch.device):
         raise NotImplementedError()
+
+    @deprecated('Use {qmodules.__qualname__} instead.')
+    def quant_wrappers(self): # pylint: disable=missing-docstring
+        return super().quant_wrappers()

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -67,8 +67,8 @@ class SequentialMse(V1SequentialMse):
 
         :param sim: Quant sim
         """
-        for _, quant_wrapper in sim.quant_wrappers():
-            quant_wrapper._compute_param_encodings(overwrite=True) # pylint: disable=protected-access
+        for _, qmodule in sim.qmodules():
+            qmodule._compute_param_encodings(overwrite=True) # pylint: disable=protected-access
 
     @staticmethod
     @contextlib.contextmanager
@@ -93,32 +93,32 @@ class SequentialMse(V1SequentialMse):
         original_input_quantizers = {}
         original_output_quantizers = {}
         original_param_quantizers = {}
-        for name, quant_wrapper in sim.quant_wrappers():
-            original_input_quantizers[name] = quant_wrapper.input_quantizers
-            original_output_quantizers[name] = quant_wrapper.output_quantizers
-            quant_wrapper.input_quantizers = nn.ModuleList([None for _ in quant_wrapper.input_quantizers])
-            quant_wrapper.output_quantizers = nn.ModuleList([None for _ in quant_wrapper.output_quantizers])
+        for name, qmodule in sim.qmodules():
+            original_input_quantizers[name] = qmodule.input_quantizers
+            original_output_quantizers[name] = qmodule.output_quantizers
+            qmodule.input_quantizers = nn.ModuleList([None for _ in qmodule.input_quantizers])
+            qmodule.output_quantizers = nn.ModuleList([None for _ in qmodule.output_quantizers])
 
-            if not isinstance(quant_wrapper, SUPPORTED_MODULES):
-                original_param_quantizers[name] = quant_wrapper.param_quantizers
-                quant_wrapper.param_quantizers = nn.ModuleDict({key: None for key in quant_wrapper.param_quantizers.keys()})
+            if not isinstance(qmodule, SUPPORTED_MODULES):
+                original_param_quantizers[name] = qmodule.param_quantizers
+                qmodule.param_quantizers = nn.ModuleDict({key: None for key in qmodule.param_quantizers.keys()})
 
             # disable param quantizers from exclusion list
             if modules_to_exclude:
                 with contextlib.suppress(KeyError):
                     fp32_module = name_to_fp32_module_dict[name]
                     if fp32_module in modules_to_exclude:
-                        original_param_quantizers[name] = quant_wrapper.param_quantizers
-                        quant_wrapper.param_quantizers = nn.ModuleDict({key: None for key in quant_wrapper.param_quantizers.keys()})
+                        original_param_quantizers[name] = qmodule.param_quantizers
+                        qmodule.param_quantizers = nn.ModuleDict({key: None for key in qmodule.param_quantizers.keys()})
 
         yield
 
-        for name, quant_wrapper in sim.quant_wrappers():
-            quant_wrapper.input_quantizers = original_input_quantizers[name]
-            quant_wrapper.output_quantizers = original_output_quantizers[name]
+        for name, qmodule in sim.qmodules():
+            qmodule.input_quantizers = original_input_quantizers[name]
+            qmodule.output_quantizers = original_output_quantizers[name]
 
             if name in original_param_quantizers:
-                quant_wrapper.param_quantizers = original_param_quantizers[name]
+                qmodule.param_quantizers = original_param_quantizers[name]
 
     @staticmethod
     def compute_param_encodings(quantizer: QuantizerBase,

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -67,7 +67,7 @@ class SequentialMse(V1SequentialMse):
 
         :param sim: Quant sim
         """
-        for _, qmodule in sim.qmodules():
+        for _, qmodule in sim.named_qmodules():
             qmodule._compute_param_encodings(overwrite=True) # pylint: disable=protected-access
 
     @staticmethod
@@ -93,7 +93,7 @@ class SequentialMse(V1SequentialMse):
         original_input_quantizers = {}
         original_output_quantizers = {}
         original_param_quantizers = {}
-        for name, qmodule in sim.qmodules():
+        for name, qmodule in sim.named_qmodules():
             original_input_quantizers[name] = qmodule.input_quantizers
             original_output_quantizers[name] = qmodule.output_quantizers
             qmodule.input_quantizers = nn.ModuleList([None for _ in qmodule.input_quantizers])
@@ -113,7 +113,7 @@ class SequentialMse(V1SequentialMse):
 
         yield
 
-        for name, qmodule in sim.qmodules():
+        for name, qmodule in sim.named_qmodules():
             qmodule.input_quantizers = original_input_quantizers[name]
             qmodule.output_quantizers = original_output_quantizers[name]
 

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
@@ -2189,8 +2189,8 @@ class TestQuantizationSimStaticGrad:
 
         sim = QuantizationSimModel(model, dummy_input=dummy_input,
                                    quant_scheme=QuantScheme.post_training_tf)
-        for _, wrapper in sim.quant_wrappers():
-            wrapper.enable_per_channel_quantization()
+        for _, qmodule in sim.qmodules():
+            qmodule.enable_per_channel_quantization()
 
         # Quantize
         sim.compute_encodings(forward_pass, None)
@@ -2276,8 +2276,8 @@ class TestQuantizationSimStaticGrad:
 
         model = SmallMnist()
         sim = QuantizationSimModel(model, dummy_input=dummy_input, quant_scheme=quant_scheme)
-        for _, wrapper in sim.quant_wrappers():
-            wrapper.enable_per_channel_quantization()
+        for _, qmodule in sim.qmodules():
+            qmodule.enable_per_channel_quantization()
 
         # Quantize
         sim.compute_encodings(forward_pass, None)
@@ -2556,20 +2556,20 @@ class TestQuantizationSimStaticGrad:
             input_quant_checked = []
             output_quant_checked = []
             param_quant_checked = []
-            for name, quant in qsim.quant_wrappers():
+            for name, qmodule in qsim.qmodules():
                 if name in partial_torch_encodings['activation_encodings']:
                     if 'input' in partial_torch_encodings['activation_encodings'][name]:
-                        assert_input_output_quantizers(quant.input_quantizers, 'input')
+                        assert_input_output_quantizers(qmodule.input_quantizers, 'input')
                         input_quant_checked.append(name)
                     if 'output' in partial_torch_encodings['activation_encodings'][name]:
-                        assert_input_output_quantizers(quant.output_quantizers, 'output')
+                        assert_input_output_quantizers(qmodule.output_quantizers, 'output')
                         output_quant_checked.append(name)
 
-                param_types = quant.param_quantizers.keys()
+                param_types = qmodule.param_quantizers.keys()
                 for param_type in param_types:
                     module_param_name = name + "." + param_type
                     if module_param_name in partial_torch_encodings['param_encodings']:
-                        assert_param_quantizers(quant.param_quantizers, name, param_type)
+                        assert_param_quantizers(qmodule.param_quantizers, name, param_type)
                         param_quant_checked.append(module_param_name)
 
             actual_input_quant = {k for k, v in partial_torch_encodings['activation_encodings'].items() if 'input' in v}

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
@@ -2189,7 +2189,7 @@ class TestQuantizationSimStaticGrad:
 
         sim = QuantizationSimModel(model, dummy_input=dummy_input,
                                    quant_scheme=QuantScheme.post_training_tf)
-        for _, qmodule in sim.qmodules():
+        for _, qmodule in sim.named_qmodules():
             qmodule.enable_per_channel_quantization()
 
         # Quantize
@@ -2276,7 +2276,7 @@ class TestQuantizationSimStaticGrad:
 
         model = SmallMnist()
         sim = QuantizationSimModel(model, dummy_input=dummy_input, quant_scheme=quant_scheme)
-        for _, qmodule in sim.qmodules():
+        for _, qmodule in sim.named_qmodules():
             qmodule.enable_per_channel_quantization()
 
         # Quantize
@@ -2556,7 +2556,7 @@ class TestQuantizationSimStaticGrad:
             input_quant_checked = []
             output_quant_checked = []
             param_quant_checked = []
-            for name, qmodule in qsim.qmodules():
+            for name, qmodule in qsim.named_qmodules():
                 if name in partial_torch_encodings['activation_encodings']:
                     if 'input' in partial_torch_encodings['activation_encodings'][name]:
                         assert_input_output_quantizers(qmodule.input_quantizers, 'input')


### PR DESCRIPTION
## main changes
* Added deprecation warning for `sim.quant_wrappers()` API.
* Added `sim.named_qmodules()` as an alternative of `sim.quant_wrappers()`