### PR TITLE
Add support for op parameters derived from constant op

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -546,7 +546,8 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             op = my_op.get_module()
 
             weight_tensor = ParamUtils.get_param(self.model, op, WEIGHT_INDEX)
-            create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight')
+            if weight_tensor:
+                create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight')
 
             bias_tensor = ParamUtils.get_param(self.model, op, BIAS_INDEX)
             if bias_tensor:
@@ -571,10 +572,12 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             """
             op = my_op.get_module()
             weight_tensor = ParamUtils.get_param(self.model, op, WEIGHT_INDEX)
-            create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight_x')
+            if weight_tensor:
+                create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight_x')
 
             recurrent_weight_tensor = ParamUtils.get_param(self.model, op, RECURRENT_WEIGHT_INDEX)
-            create_and_connect_product(recurrent_weight_tensor.name, recurrent_weight_tensor.dims, my_op, recurrent_weight_tensor, 'weight_r')
+            if recurrent_weight_tensor:
+                create_and_connect_product(recurrent_weight_tensor.name, recurrent_weight_tensor.dims, my_op, recurrent_weight_tensor, 'weight_r')
 
         def create_batchnorm_params(my_op: Op):
             """ Create products for fusedbatchnorm """
@@ -590,13 +593,11 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
             moving_mean_tensor = ParamUtils.get_param(self.model, op, RUNNING_MEAN_INDEX)
             if moving_mean_tensor:
-                create_and_connect_product(moving_mean_tensor.name, moving_mean_tensor.dims, my_op,
-                                           moving_mean_tensor, None)
+                create_and_connect_product(moving_mean_tensor.name, moving_mean_tensor.dims, my_op, moving_mean_tensor, None)
 
             moving_variance_tensor = ParamUtils.get_param(self.model, op, RUNNING_VAR_INDEX)
             if moving_variance_tensor:
-                create_and_connect_product(moving_variance_tensor.name, moving_variance_tensor.dims, my_op,
-                                           moving_variance_tensor, None)
+                create_and_connect_product(moving_variance_tensor.name, moving_variance_tensor.dims, my_op, moving_variance_tensor, None)
 
         def handle_default(my_op: Op):
             """ Handler for other modules """

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim_config/quantsim_config.py
@@ -302,7 +302,7 @@ class QuantSimConfigurator(AimetCommonQuantSimConfigurator):
         for node in self._model.model.graph.node:
             if node.op_type in CONSTANT_TYPE:
                 for activation_name in node.output:
-                    if activation_name in self._quant_ops_dict and \
+                    if activation_name not in self._param_names and activation_name in self._quant_ops_dict and \
                             self._quant_ops_dict[activation_name] not in modified_quantize_ops:
                         self._modify_activation_quantize_op([self._quant_ops_dict[activation_name]],
                                                             ConfigDictKeys.IS_INPUT_QUANTIZED,

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
@@ -313,15 +313,9 @@ class ParamUtils:
         :param node: ONNX node to which the param feeds to
         :param param_index: Index at which param feeds to the ONNX node
         """
-        if node.op_type in OP_TYPES_WITH_PARAMS:
-            if len(node.input) >= param_index + 1:
-                param_name = node.input[param_index]
-                for param in model.graph.initializer:
-                    if param.name == param_name:
-                        return param.dims
-            logger.debug("Param not present in the node")
-        else:
-            logger.debug("Node type not in allowed op types with param list")
+        param = ParamUtils.get_param(model, node, param_index)
+        if param:
+            return param.dims
         return None
 
     @staticmethod
@@ -341,9 +335,11 @@ class ParamUtils:
         def find_param_in_model_constants(param_name: str, model: ModelProto):
             for node in model.graph.node:
                 if node.op_type == 'Constant' and param_name in node.output:
-                    param = node.attribute[0].t
-                    param.name = param_name
-                    return param
+                    for attribute in node.attribute:
+                        if attribute.name == 'value':
+                            param = attribute.t
+                            param.name = param_name
+                            return param
             return None
 
         assert node.op_type in OP_TYPES_WITH_PARAMS, "Node type not in allowed op types with param list"

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
@@ -332,12 +332,27 @@ class ParamUtils:
         :param node: ONNX node to which the param feeds to
         :param param_index: Index at which param feeds to the ONNX node
         """
-        assert node.op_type in OP_TYPES_WITH_PARAMS, "Node type not in allowed op types with param list"
-        if len(node.input) >= param_index + 1:
-            param_name = node.input[param_index]
+        def find_param_in_model_initializers(param_name: str, model: ModelProto):
             for param in model.graph.initializer:
                 if param.name == param_name:
                     return param
+            return None
+
+        def find_param_in_model_constants(param_name: str, model: ModelProto):
+            for node in model.graph.node:
+                if node.op_type == 'Constant' and param_name in node.output:
+                    param = node.attribute[0].t
+                    param.name = param_name
+                    return param
+            return None
+
+        assert node.op_type in OP_TYPES_WITH_PARAMS, "Node type not in allowed op types with param list"
+        if len(node.input) >= param_index + 1:
+            param_name = node.input[param_index]
+            param = find_param_in_model_initializers(param_name, model)
+            if param is None:
+                param = find_param_in_model_constants(param_name, model)
+            return param
         return None
 
 

--- a/TrainingExtensions/onnx/test/python/test_utils.py
+++ b/TrainingExtensions/onnx/test/python/test_utils.py
@@ -137,6 +137,20 @@ class TestUtils:
                 assert bias.name == 'conv1.bias'
                 break
 
+    def test_utils_const_param_model(self):
+        model = models_for_tests.const_param_model()
+        for node in model.graph.node:
+            if node.op_type == 'InstanceNormalization':
+                weights = ParamUtils.get_param(model, node, 1)
+                weights_shape = ParamUtils.get_shape(model, node, 1)
+                bias = ParamUtils.get_param(model, node, 2)
+                bias_shape = ParamUtils.get_shape(model, node, 2)
+                assert bias_shape == [32]
+                assert weights_shape == [32]
+                assert weights.name == '/down_blocks.0/resnets.0/norm1/Constant_1_output_0'
+                assert bias.name == '/down_blocks.0/resnets.0/norm1/Constant_2_output_0'
+                break
+
     def test_remove_node(self):
         """
         Test remove node from model


### PR DESCRIPTION
Fixes #3121 

1. Captured such parameters while constructing CG. Earlier they were treated as activations which was incorrect and leading to failures on QNN.
2. Added a check to prevent application of quantsim config meant for constant activations to such constant params.