### PR TITLE
Remove manual CMake build from Dockerfiles.

### DIFF
--- a/Jenkins/Dockerfile.tf-cpu
+++ b/Jenkins/Dockerfile.tf-cpu
@@ -94,6 +94,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -178,15 +179,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.38.1 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 ENV PATH=/usr/local/bin:$PATH
 

--- a/Jenkins/Dockerfile.tf-gpu
+++ b/Jenkins/Dockerfile.tf-gpu
@@ -106,6 +106,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -190,15 +191,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.38.1 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 ENV PATH=/usr/local/bin:$PATH
 

--- a/Jenkins/Dockerfile.tf-torch-cpu
+++ b/Jenkins/Dockerfile.tf-torch-cpu
@@ -94,6 +94,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -187,15 +188,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.38.1 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
 RUN mkdir /opt/onnxruntime && \

--- a/Jenkins/Dockerfile.torch-cpu
+++ b/Jenkins/Dockerfile.torch-cpu
@@ -95,6 +95,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -194,15 +195,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.27.4 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
 RUN mkdir /opt/onnxruntime && \

--- a/Jenkins/Dockerfile.torch-cpu-pt113
+++ b/Jenkins/Dockerfile.torch-cpu-pt113
@@ -95,6 +95,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -194,15 +195,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.27.4 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
 RUN mkdir /opt/onnxruntime && \

--- a/Jenkins/Dockerfile.torch-gpu
+++ b/Jenkins/Dockerfile.torch-gpu
@@ -107,6 +107,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -206,15 +207,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.27.4 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
 RUN mkdir /opt/onnxruntime && \

--- a/Jenkins/Dockerfile.torch-gpu-pt113
+++ b/Jenkins/Dockerfile.torch-gpu-pt113
@@ -107,6 +107,7 @@ RUN dpkg --add-architecture i386
 RUN apt-get update > /dev/null && \
     apt-get install --no-install-recommends -y \
         build-essential \
+        cmake \
         emacs \
         environment-modules \
         less \
@@ -206,15 +207,6 @@ RUN python3 -m pip --no-cache-dir install \
         transformers==4.27.4 \
         wget && \
     python3 -m ipykernel.kernelspec
-
-# Install cmake
-RUN mkdir -p /opt/cmake  &&  \
-    wget -P /tmp https://github.com/Kitware/CMake/releases/download/v3.19.3/cmake-3.19.3-Linux-x86_64.sh && \
-    sh /tmp/cmake-3.19.3-Linux-x86_64.sh --prefix=/opt/cmake --skip-license && \
-    rm -f /tmp/cmake-3.19.3-Linux-x86_64.sh && \
-    ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
-    ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
-    ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
 
 # Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
 RUN mkdir /opt/onnxruntime && \


### PR DESCRIPTION
Any base image building upon Ubuntu 22.04 already comes with CMake 3.22; we can just make use of the system package.