### PR TITLE
Eps as minimum scale

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
@@ -314,14 +314,14 @@ class MinMaxEncodingAnalyzer(EncodingAnalyzer[_MinMaxRange]):
         if stats.min is None or stats.max is None:
             raise StatisticsNotFoundError('No statistics present to compute encodings.')
 
-        tiny_num = torch.finfo(stats.min.dtype).tiny
+        eps = torch.finfo(stats.min.dtype).eps
         # enforces that 0 is within the min/max
         min_with_zero = torch.clamp(stats.min, max=0)
         max_with_zero = torch.clamp(stats.max, min=0)
 
          # adjusts any min/max pairing that are too close
         tensor_diff = (max_with_zero - min_with_zero) / num_steps
-        adjustment_step = tiny_num * (tensor_diff < tiny_num)
+        adjustment_step = eps * (tensor_diff < eps)
 
         updated_max = max_with_zero + math.floor(num_steps / 2) * adjustment_step
         updated_min = min_with_zero - math.ceil(num_steps / 2) * adjustment_step
@@ -350,10 +350,10 @@ def adjust_min_max(curr_min, curr_max, num_steps, is_symmetric):
     curr_max.clamp_(min=0, max=torch.finfo(curr_max.dtype).max)
 
     # ensure that min/max aren't too close
-    tiny_num = torch.finfo(curr_min.dtype).tiny
+    eps = torch.finfo(curr_min.dtype).eps
     tensor_threshold = (curr_max - curr_min) / num_steps
-    curr_min[tensor_threshold < tiny_num] -= tiny_num * math.ceil(num_steps / 2)
-    curr_max[tensor_threshold < tiny_num] += tiny_num * math.floor(num_steps / 2)
+    curr_min[tensor_threshold < eps] -= eps * math.ceil(num_steps / 2)
+    curr_max[tensor_threshold < eps] += eps * math.floor(num_steps / 2)
 
     if is_symmetric:
         num_pos_steps = math.floor(num_steps / 2)
@@ -510,7 +510,7 @@ class SqnrEncodingAnalyzer(EncodingAnalyzer[_Histogram]):
         max_vals = torch.stack([stat.max for stat in stats])
         min_vals = torch.min(min_vals, torch.zeros_like(min_vals))
         max_vals = torch.max(max_vals, torch.zeros_like(max_vals))
-        max_vals = torch.max(max_vals, min_vals + torch.finfo(min_vals.dtype).tiny * num_steps)
+        max_vals = torch.max(max_vals, min_vals + torch.finfo(min_vals.dtype).eps * num_steps)
         if symmetric:
             return self._pick_test_candidates_symmetric(min_vals, max_vals, num_steps)
         return self._pick_test_candidates_asymmetric(min_vals, max_vals, num_steps)
@@ -552,7 +552,7 @@ class SqnrEncodingAnalyzer(EncodingAnalyzer[_Histogram]):
         test_deltas = max_delta[:, None] * search_space[None, :] / (num_deltas - 1)
         # test_deltas.shape = (num_histograms, num_deltas, 1)
         # test_offsets.shape = (1, 1, 1)
-        min_delta = torch.Tensor([torch.finfo(test_deltas.dtype).tiny]).to(**tensor_kwargs)
+        min_delta = torch.Tensor([torch.finfo(test_deltas.dtype).eps]).to(**tensor_kwargs)
         test_deltas = torch.max(test_deltas, min_delta)
         return test_deltas[:, :, None], test_offsets[:, None, None]
 
@@ -570,7 +570,7 @@ class SqnrEncodingAnalyzer(EncodingAnalyzer[_Histogram]):
         # Recompute delta/offset with clamped min/max
         # Returned delta/offset shapes = (num_histograms, num_deltas, num_offsets)
         test_deltas = (test_max - test_min) / num_steps
-        min_delta = torch.Tensor([torch.finfo(test_deltas.dtype).tiny]).to(device=test_deltas.device,
+        min_delta = torch.Tensor([torch.finfo(test_deltas.dtype).eps]).to(device=test_deltas.device,
                                                                            dtype=test_deltas.dtype)
         test_deltas = torch.max(test_deltas, min_delta)
         test_offsets = torch.round(test_min / test_deltas)

--- a/TrainingExtensions/torch/test/python/v2/quantization/test_encoding_analyzer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/test_encoding_analyzer.py
@@ -169,8 +169,8 @@ class TestMinMaxEncodingAnalyzer():
 
         num_steps = pow(2, 8) - 1
         asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        updated_min = torch.finfo(asymmetric_min.dtype).tiny * (2 ** (8 - 1))
-        updated_max = torch.finfo(asymmetric_min.dtype).tiny * ((2 **(8 - 1)) - 1)
+        updated_min = torch.finfo(asymmetric_min.dtype).eps * (2 ** (8 - 1))
+        updated_max = torch.finfo(asymmetric_min.dtype).eps * ((2 **(8 - 1)) - 1)
         assert torch.all(torch.eq(asymmetric_min,  torch.full(tuple(encoding_analyzer.observer.shape), -updated_min)))
         assert torch.all(torch.eq(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), updated_max)))
 
@@ -187,7 +187,7 @@ class TestMinMaxEncodingAnalyzer():
     @pytest.mark.parametrize('symmetric', [True, False])
     def test_overflow(self, symmetric):
         encoding_analyzer = MinMaxEncodingAnalyzer((1,))
-        float_input_min = (torch.arange(10) * torch.finfo(torch.float).tiny)
+        float_input_min = (torch.arange(10) * torch.finfo(torch.float).eps)
         encoding_analyzer.update_stats(float_input_min)
         num_steps = pow(2, 8) - 2
         min, max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=symmetric)
@@ -195,7 +195,7 @@ class TestMinMaxEncodingAnalyzer():
 
         # Scale should be at least as large as torch.min
         assert scale != 0
-        assert torch.allclose(scale, torch.tensor(torch.finfo(scale.dtype).tiny), atol=1e-10)
+        assert torch.allclose(scale, torch.tensor(torch.finfo(scale.dtype).eps), rtol=0.01)
 
         float_input_max = (torch.arange(10) * torch.finfo(torch.float).max)
         encoding_analyzer.update_stats(float_input_max)

--- a/TrainingExtensions/torch/test/python/v2/test_seq_mse_.py
+++ b/TrainingExtensions/torch/test/python/v2/test_seq_mse_.py
@@ -153,7 +153,7 @@ class TestSeqMse:
             assert list(cand_min.size())[0] == linear.out_features
 
     @pytest.mark.parametrize("enable_pcq", [True, False])
-    @pytest.mark.parametrize("param_bw", [2, 31])
+    @pytest.mark.parametrize("param_bw", [4, 16])
     @pytest.mark.parametrize("loss_fn", ['mse', 'l1', 'sqnr'])
     @pytest.mark.parametrize("qparam_requires_grad", [True, False])
     def test_optimize_module_linear(self, enable_pcq, param_bw, loss_fn, qparam_requires_grad):
@@ -180,15 +180,15 @@ class TestSeqMse:
 
         # If we use higher param_bw (for example 16, 31), then it should always choose larger candidates so
         # before and after param encodings should be almost same.
-        if param_bw == 31:
-            assert torch.allclose(before.min, after.min)
-            assert torch.allclose(before.max, after.max)
+        if param_bw >= 16:
+            assert torch.allclose(before.min, after.min, rtol=1e-4)
+            assert torch.allclose(before.max, after.max, rtol=1e-4)
         else:
             assert not torch.allclose(before.min, after.min)
             assert not torch.allclose(before.max, after.max)
 
     @pytest.mark.parametrize("enable_pcq", [True, False])
-    @pytest.mark.parametrize("param_bw", [2, 31])
+    @pytest.mark.parametrize("param_bw", [4, 16])
     @pytest.mark.parametrize("loss_fn", ['mse', 'l1', 'sqnr'])
     def test_optimize_module_conv(self, enable_pcq, param_bw, loss_fn):
         """ test optimize module for linear """
@@ -213,9 +213,9 @@ class TestSeqMse:
 
         # If we use higher param_bw (for example 16, 31), then it should always choose larger candidates so
         # before and after param encodings should be almost same.
-        if param_bw == 31:
-            assert torch.allclose(before.min, after.min)
-            assert torch.allclose(before.max, after.max)
+        if param_bw >= 16:
+            assert torch.allclose(before.min, after.min, rtol=1e-4)
+            assert torch.allclose(before.max, after.max, rtol=1e-4)
         else:
             assert not torch.allclose(before.min, after.min)
             assert not torch.allclose(before.max, after.max)


### PR DESCRIPTION
## Problem
Currently v2 encoding analyzer asserts `scale >= torch.finfo(...).tiny`.
However, this `tiny` is the smallest positive normal number, which is numerically extremely unstable

## Fix
Use **`torch.finfo.eps`** as minimum scale instead.
`eps` is a much more moderate value than `tiny`, and hence more numerically stable

|       | float32 | float16 | bfloat16 | float64 |
|----|---------|--------|----------|-----------|
|tiny|  1.18e-38 | 6.10e-05 | 1.18e-38 | 2.23e-308 |
|eps|  1.19e-07 | 9.77e-04 | 7.81e-03 | 2.22e-16 |

(p.s. 1.0 / (2**16-1) is equal to 1.53e-05, which is still larger than float32 eps)