### PR TITLE
Use 0-D scale for per-tensor quantizers

### DIFF
--- a/Docs/torch_docs/quantized_modules.rst
+++ b/Docs/torch_docs/quantized_modules.rst
@@ -65,15 +65,15 @@ Example: Create a linear layer which performs only per-channel weight quantizati
 
 Example: Create an elementwise multiply layer which quantizes only the output and the second input
     >>> qmul = aimet.nn.QuantizedMultiply()
-    >>> qmul.output_quantizers[0] = Q.affine.QuantizeDequantize(shape=(1, ), bitwidth=8, symmetric=False)
-    >>> qmul.input_quantizers[1] = Q.affine.QuantizeDequantize(shape=(1, ), bitwidth=8, symmetric=False)
+    >>> qmul.output_quantizers[0] = Q.affine.QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
+    >>> qmul.input_quantizers[1] = Q.affine.QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
 
 In some cases, it may make sense for multiple tensors to share the same quantizer. In this case, we can assign the same
 quantizer to multiple indices.
 
 Example: Create an elementwise add layer which shares the same quantizer between its inputs
     >>> qadd = aimet.nn.QuantizedAdd()
-    >>> quantizer = Q.affine.QuantizeDequantize(shape=(1, ), bitwidth=8, symmetric=False)
+    >>> quantizer = Q.affine.QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
     >>> qadd.input_quantizers[0] = quantizer
     >>> qadd.input_quantizers[1] = quantizer
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/peft.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/peft.py
@@ -239,7 +239,7 @@ class PeftQuantUtils:
         """
 
         def _create_quantizer():
-            quantizer = QuantizeDequantize(shape=(1,), bitwidth=bitwidth, symmetric=False)
+            quantizer = QuantizeDequantize(shape=(), bitwidth=bitwidth, symmetric=False)
             quantizer.set_range(torch.as_tensor(scale_min), torch.as_tensor(scale_max))
             self._freeze_quantizer(quantizer)
             return quantizer

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim_config/builder.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim_config/builder.py
@@ -165,8 +165,9 @@ class LazyQuantizeWrapper(torch.nn.Module):
             # pylint: disable=protected-access
             if quantizer is not None and quantizer_info.encoding_min_max_fixed_vals and \
                     'min' in quantizer._initial_parameters and 'max' in quantizer._initial_parameters:
-                quantizer.min = torch.nn.Parameter(quantizer_info.encoding_min_max_fixed_vals[0] * torch.ones((1,)))
-                quantizer.max = torch.nn.Parameter(quantizer_info.encoding_min_max_fixed_vals[1] * torch.ones((1,)))
+                with torch.no_grad():
+                    quantizer.min.copy_(quantizer_info.encoding_min_max_fixed_vals[0])
+                    quantizer.max.copy_(quantizer_info.encoding_min_max_fixed_vals[1])
                 quantizer.allow_overwrite(False)
                 quantizer.requires_grad_(False)
 
@@ -329,7 +330,7 @@ class LazyQuantizer:
 
         :return: param shape for quantization parameter
         """
-        return [1]
+        return tuple()
 
     def realize(self):
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -153,7 +153,7 @@ class BaseQuantizationMixin(abc.ABC):
         Example:
 
             >>> qlinear = QuantizedLinear(10, 10)
-            >>> qlinear.output_quantizers[0] = Quantize((1, ), 8, symmetric=False)
+            >>> qlinear.output_quantizers[0] = Quantize((), 8, symmetric=False)
             >>> with qlinear.compute_encodings():
             >>>     qlinear(torch.randn(16, 10))
             >>> print(qlinear.output_quantizers[0].is_initialized())

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -54,10 +54,6 @@ class AffineEncoding(EncodingBase):
     """
     def __init__(self, scale: torch.Tensor, offset: torch.Tensor, bitwidth: int, signed=False, symmetry=False,
                  block_size: Optional[List] = None):
-        if scale.numel() == 1:
-            scale = scale.view([])
-        if offset.numel() == 1:
-            offset = offset.view([])
         self._scale = scale
         self._offset = offset
         self._symmetry = symmetry
@@ -77,11 +73,12 @@ class AffineEncoding(EncodingBase):
         """
         Returns the granularity of the quantizer encoding
         """
-        if self.scale.numel() == 1:
+        if self.scale.dim() == 0:
             return "pertensor"
         if self.block_size is not None:
             return "blockwise"
-        if any(dim > 1 for dim in self.scale.shape):
+        non_singleton_dims = tuple(dim for dim in self.scale.shape if dim > 1)
+        if len(non_singleton_dims) <= 1:
             return "perchannel"
         return "unknown"
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -77,7 +77,7 @@ class AffineQuantizerBase(QuantizerBase):
         super().__init__()
         if isinstance(shape, int):
             shape = (shape,)
-        self.shape = shape
+        self.shape = torch.Size(shape)
         self.block_size = block_size
         self.bitwidth = bitwidth
         self._symmetric = symmetric

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
@@ -69,7 +69,7 @@ class _Observer(Generic[_Statistics], ABC):
     def __init__(self, shape: tuple):
         if isinstance(shape, int):
             shape = (shape,)
-        self.shape = shape
+        self.shape = tuple(shape)
 
     @abstractmethod
     def collect_stats(self, input_tensor: torch.Tensor) -> _Statistics:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/encoding.py
@@ -53,8 +53,6 @@ class FloatEncoding(EncodingBase):
     def __init__(self, mantissa_bits: int, exponent_bits: int, maxval: torch.Tensor):
         self._mantissa_bits = mantissa_bits
         self._exponent_bits = exponent_bits
-        if maxval.numel() == 1:
-            maxval = maxval.view([])
         self._maxval = maxval
 
     @property
@@ -97,9 +95,10 @@ class FloatEncoding(EncodingBase):
         """
         Returns the granularity of the quantizer encoding
         """
-        if self.maxval.numel() == 1:
+        if self.maxval.dim() == 0:
             return "pertensor"
-        if any(dim > 1 for dim in self.maxval.shape):
+        non_singleton_dims = tuple(dim for dim in self.maxval.shape if dim > 1)
+        if len(non_singleton_dims) <= 1:
             return "perchannel"
         return "unknown"
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
@@ -125,7 +125,7 @@ class FloatQuantizeDequantize(QuantizerBase): # pylint: disable=abstract-method
         tensor([[ 1.8984, -0.0947], [-1.0859, -0.1729]])
 
         >>> from aimet_torch.v2.quantization.encoding_analyzer import MinMaxEncodingAnalyzer
-        >>> encoding_analyzer = MinMaxEncodingAnalyzer(shape=(1,))
+        >>> encoding_analyzer = MinMaxEncodingAnalyzer(shape=[])
         >>> qdq = Q.float.FloatQuantizeDequantize(dtype=torch.float16, encoding_analyzer=encoding_analyzer)
         >>> qdq.is_float16()
         True

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -370,7 +370,7 @@ class QuantizedTensor(QuantizedTensorBase):
             >>> from aimet_torch.v2.quantization as Q
             >>> x = torch.tensor([[2.57, -2.312],
             ...                   [0.153, 0.205]])
-            >>> quantizer = Q.affine.Quantize(shape=(1, ), bitwidth=8, symmetric=True)
+            >>> quantizer = Q.affine.Quantize(shape=(), bitwidth=8, symmetric=True)
             >>> quantizer.set_range(-128 * 0.1, 127 * 0.1)
             >>> x_q = quantizer(x)
             >>> x_q
@@ -414,7 +414,7 @@ class DequantizedTensor(QuantizedTensorBase):
 
             >>> import aimet_torch.v2.quantization as Q
             >>> x = torch.tensor([[0.39, 51.0], [3.521, 9.41]])
-            >>> quant_dequant = Q.affine.QuantizeDequantize((1, ), 8, symmetric=False)
+            >>> quant_dequant = Q.affine.QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
             >>> quant_dequant.set_range(-10, 41)
             >>> x_qdq = quant_dequant(x)
             >>> x_qdq
@@ -452,7 +452,7 @@ class DequantizedTensor(QuantizedTensorBase):
 
             >>> import aimet_torch.v2.quantization as Q
             >>> x = torch.tensor([[0.39, 51.0], [3.521, 9.41]])
-            >>> quant_dequant = Q.affine.QuantizeDequantize((1, ), 8, symmetric=False)
+            >>> quant_dequant = Q.affine.QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
             >>> quant_dequant.set_range(-10, 41)
             >>> x_qdq = quant_dequant(x)
             >>> x_qdq

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
@@ -634,10 +634,10 @@ class TestQuantizationSimStaticGrad:
     def test_add_quantization_wrappers_with_modulelist(self):
         """With a one-deep model using ModuleList"""
         q_conv2d = aimet_nn.QuantizedConv2d(1, 10, 5)
-        q_conv2d.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        q_conv2d.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                            bitwidth=8,
                                                            symmetric=False)
-        q_conv2d.param_quantizers['weight'] = QuantizeDequantize(shape=(1,),
+        q_conv2d.param_quantizers['weight'] = QuantizeDequantize(shape=(),
                                                                  bitwidth=8,
                                                                  symmetric=True)
 
@@ -663,10 +663,10 @@ class TestQuantizationSimStaticGrad:
     def test_add_quantization_wrappers_with_modulelist_two_deep(self):
         """With a two-deep model using ModuleList"""
         q_conv2d = aimet_nn.QuantizedConv2d(1, 10, 5)
-        q_conv2d.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        q_conv2d.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                            bitwidth=8,
                                                            symmetric=False)
-        q_conv2d.param_quantizers['weight'] = QuantizeDequantize(shape=(1,),
+        q_conv2d.param_quantizers['weight'] = QuantizeDequantize(shape=(),
                                                                  bitwidth=8,
                                                                  symmetric=True)
 
@@ -1079,7 +1079,7 @@ class TestQuantizationSimStaticGrad:
 
         sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf,
                                    dummy_input=torch.rand(1, 1, 12, 12))
-        sim.model.conv1.input_quantizers[0] = QuantizeDequantize((1,), 8, False)
+        sim.model.conv1.input_quantizers[0] = QuantizeDequantize((), 8, False)
 
         # Find encodings
         sim.compute_encodings(dummy_forward_pass, None)
@@ -1157,10 +1157,10 @@ class TestQuantizationSimStaticGrad:
         sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf,
                                    dummy_input=torch.rand(1, 1, 12, 12))
 
-        sim.model.conv1.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.conv1.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                                   bitwidth=8,
                                                                   symmetric=False)
-        sim.model.conv1.input_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.conv1.input_quantizers[0] = QuantizeDequantize(shape=(),
                                                                  bitwidth=8,
                                                                  symmetric=False)
 
@@ -1790,16 +1790,16 @@ class TestQuantizationSimStaticGrad:
 
         sim = QuantizationSimModel(model, dummy_input=dummy_input,
                                    quant_scheme=QuantScheme.post_training_tf)
-        sim.model.sfmax.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.sfmax.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                             bitwidth=8,
                                                             symmetric=False)
-        sim.model.sfmax.input_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.sfmax.input_quantizers[0] = QuantizeDequantize(shape=(),
                                                            bitwidth=8,
                                                            symmetric=False)
-        sim.model.avgpool.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.avgpool.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                             bitwidth=8,
                                                             symmetric=False)
-        sim.model.avgpool.input_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.avgpool.input_quantizers[0] = QuantizeDequantize(shape=(),
                                                             bitwidth=8,
                                                             symmetric=False)
         sim.compute_encodings(forward_pass, None)
@@ -2739,16 +2739,16 @@ class TestQuantizationSimLearnedGrid:
     def test_qc_trainable_wrapper(self):
         torch.manual_seed(0)
         q_conv1 = aimet_nn.QuantizedConv2d(1, 32, kernel_size=5)
-        q_conv1.param_quantizers['weight'] = QuantizeDequantize(shape=(1,),
+        q_conv1.param_quantizers['weight'] = QuantizeDequantize(shape=(),
                                                                 bitwidth=8,
                                                                 symmetric=False)
-        q_conv1.param_quantizers['bias'] = QuantizeDequantize(shape=(1,),
+        q_conv1.param_quantizers['bias'] = QuantizeDequantize(shape=(),
                                                               bitwidth=8,
                                                               symmetric=False)
-        q_conv1.input_quantizers[0] = QuantizeDequantize(shape=(1,),
+        q_conv1.input_quantizers[0] = QuantizeDequantize(shape=(),
                                                           bitwidth=8,
                                                           symmetric=False)
-        q_conv1.output_quantizers[0] = QuantizeDequantize(shape=(1,),
+        q_conv1.output_quantizers[0] = QuantizeDequantize(shape=(),
                                                            bitwidth=8,
                                                            symmetric=False)
         q_conv1.param_quantizers['weight'].set_range(-1, 1)
@@ -2814,10 +2814,10 @@ class TestQuantizationSimLearnedGrid:
                                        config_file=config_file_path)
 
         # Enable input parameters to add (multiple input parameter exist)
-        sim.model.add.input_quantizers[0] = QuantizeDequantize(shape=(1,),
+        sim.model.add.input_quantizers[0] = QuantizeDequantize(shape=(),
                                                                bitwidth=8,
                                                                symmetric=False)
-        sim.model.add.input_quantizers[1] = QuantizeDequantize(shape=(1,),
+        sim.model.add.input_quantizers[1] = QuantizeDequantize(shape=(),
                                                                bitwidth=8,
                                                                symmetric=False)
 

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_export.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_export.py
@@ -96,23 +96,23 @@ class TestQuantsimOnnxExport:
             quantized_module = FakeQuantizationMixin.from_module(module)
 
             if name == "conv1":
-                input_quantizer = QuantizeDequantize((1,),
+                input_quantizer = QuantizeDequantize((),
                                                      bitwidth=8,
                                                      symmetric=False,
-                                                     encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                     encoding_analyzer=MinMaxEncodingAnalyzer(()))
                 quantized_module.input_quantizers[0] = input_quantizer
             else:
-                output_quantizer = QuantizeDequantize((1,),
+                output_quantizer = QuantizeDequantize((),
                                                       bitwidth=8,
                                                       symmetric=False,
-                                                      encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                      encoding_analyzer=MinMaxEncodingAnalyzer(()))
                 quantized_module.output_quantizers[0] = output_quantizer
 
             if hasattr(module, 'weight'):
-                weight_quantizer = QuantizeDequantize((1,),
+                weight_quantizer = QuantizeDequantize((),
                                                       bitwidth=4,
                                                       symmetric=True,
-                                                      encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                      encoding_analyzer=MinMaxEncodingAnalyzer(()))
                 quantized_module.param_quantizers['weight'] = weight_quantizer
 
             setattr(sim_model, name, quantized_module)
@@ -151,23 +151,23 @@ class TestQuantsimOnnxExport:
             quantized_module = FakeQuantizationMixin.from_module(module)
 
             if name == "conv1_a":
-                input_quantizer = QuantizeDequantize((1,),
+                input_quantizer = QuantizeDequantize((),
                                                      bitwidth=8,
                                                      symmetric=False,
-                                                     encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                     encoding_analyzer=MinMaxEncodingAnalyzer(()))
                 quantized_module.input_quantizers[0] = input_quantizer
 
-            output_quantizer = QuantizeDequantize((1,),
+            output_quantizer = QuantizeDequantize((),
                                                   bitwidth=8,
                                                   symmetric=False,
-                                                  encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                  encoding_analyzer=MinMaxEncodingAnalyzer(()))
             quantized_module.output_quantizers[0] = output_quantizer
 
             if hasattr(module, 'weight'):
-                weight_quantizer = QuantizeDequantize((1,),
+                weight_quantizer = QuantizeDequantize((),
                                                       bitwidth=4,
                                                       symmetric=True,
-                                                      encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                      encoding_analyzer=MinMaxEncodingAnalyzer(()))
                 quantized_module.param_quantizers['weight'] = weight_quantizer
 
             setattr(sim_model, name, quantized_module)
@@ -208,14 +208,14 @@ class TestQuantsimOnnxExport:
         model = torch.nn.Sequential(pixel_shuffle)
 
         quantized_pixel_shuffle = FakeQuantizationMixin.from_module(pixel_shuffle)
-        quantized_pixel_shuffle.input_quantizers[0] = QuantizeDequantize((1,),
+        quantized_pixel_shuffle.input_quantizers[0] = QuantizeDequantize((),
                                                                          bitwidth=8,
                                                                          symmetric=False,
-                                                                         encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
-        quantized_pixel_shuffle.output_quantizers[0] = QuantizeDequantize((1,),
+                                                                         encoding_analyzer=MinMaxEncodingAnalyzer(()))
+        quantized_pixel_shuffle.output_quantizers[0] = QuantizeDequantize((),
                                                                           bitwidth=8,
                                                                           symmetric=False,
-                                                                          encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                                          encoding_analyzer=MinMaxEncodingAnalyzer(()))
         sim_model = torch.nn.Sequential(quantized_pixel_shuffle)
         dummy_input = torch.randn(1, 4, 8, 8)
 
@@ -259,15 +259,15 @@ class TestQuantsimOnnxExport:
         dummy_input = torch.randn(1, 3, 224, 224)
         sim_model = copy.deepcopy(model)
         sim_model.cust = FakeQuantizationMixin.from_module(sim_model.cust)
-        sim_model.cust.input_quantizers[0] = QuantizeDequantize((1,),
+        sim_model.cust.input_quantizers[0] = QuantizeDequantize((),
                                                                 bitwidth=8,
                                                                 symmetric=False,
-                                                                encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                                encoding_analyzer=MinMaxEncodingAnalyzer(()))
         for i in range(1, 5):
-            sim_model.cust.output_quantizers[i] = QuantizeDequantize((1,),
+            sim_model.cust.output_quantizers[i] = QuantizeDequantize((),
                                                                      bitwidth=8,
                                                                      symmetric=False,
-                                                                     encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                                     encoding_analyzer=MinMaxEncodingAnalyzer(()))
 
         with aimet_nn.compute_encodings(sim_model):
             _ = sim_model(dummy_input)
@@ -293,24 +293,24 @@ class TestQuantsimOnnxExport:
 
         sim_model  = copy.deepcopy(model)
         sim_model.sfmax = FakeQuantizationMixin.from_module(sim_model.sfmax)
-        sim_model.sfmax.input_quantizers[0] = QuantizeDequantize((1,),
+        sim_model.sfmax.input_quantizers[0] = QuantizeDequantize((),
                                                                  bitwidth=8,
                                                                  symmetric=False,
-                                                                 encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
-        sim_model.sfmax.output_quantizers[0] = QuantizeDequantize((1,),
-                                                                 bitwidth=8,
-                                                                 symmetric=False,
-                                                                 encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                                 encoding_analyzer=MinMaxEncodingAnalyzer(()))
+        sim_model.sfmax.output_quantizers[0] = QuantizeDequantize((),
+                                                                  bitwidth=8,
+                                                                  symmetric=False,
+                                                                  encoding_analyzer=MinMaxEncodingAnalyzer(()))
 
         sim_model.avgpool = FakeQuantizationMixin.from_module(sim_model.avgpool)
-        sim_model.avgpool.input_quantizers[0] = QuantizeDequantize((1,),
-                                                                 bitwidth=8,
-                                                                 symmetric=False,
-                                                                 encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
-        sim_model.avgpool.output_quantizers[0] = QuantizeDequantize((1,),
-                                                                 bitwidth=8,
-                                                                 symmetric=False,
-                                                                 encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+        sim_model.avgpool.input_quantizers[0] = QuantizeDequantize((),
+                                                                  bitwidth=8,
+                                                                  symmetric=False,
+                                                                  encoding_analyzer=MinMaxEncodingAnalyzer(()))
+        sim_model.avgpool.output_quantizers[0] = QuantizeDequantize((),
+                                                                    bitwidth=8,
+                                                                    symmetric=False,
+                                                                    encoding_analyzer=MinMaxEncodingAnalyzer(()))
         with aimet_nn.compute_encodings(sim_model):
             _ = sim_model(dummy_input)
 

--- a/TrainingExtensions/torch/test/python/v2/encodings/test_affine_encoding.py
+++ b/TrainingExtensions/torch/test/python/v2/encodings/test_affine_encoding.py
@@ -180,7 +180,7 @@ class TestAffineEncoding:
         with pytest.raises(RuntimeError):
             encoding.to(dtype)
 
-    @pytest.mark.parametrize("shape", ((10, 1), (10,)))
+    @pytest.mark.parametrize("shape", ((10, 1), (10,), (1,)))
     def test_perchannel_encoding(self, shape):
         """
         When: Create an encoding with scale whose shape has more than one element
@@ -195,18 +195,18 @@ class TestAffineEncoding:
         assert encoding.granularity == "perchannel"
         assert encoding.mapping == "affine"
 
-    @pytest.mark.parametrize("shape", (tuple(), (1,)))
-    def test_pertensor_encoding(self, shape):
+    def test_pertensor_encoding(self):
         """
         When: Create an encoding with scale whose shape in {[], [1]}
         Then: encoding.{scale, offset, min, max} have shape == shape
               and granularity == "pertensor"
         """
+        shape = tuple()
         scale = torch.randn(shape)
         offset = torch.randn(shape)
         encoding = AffineEncoding(scale, offset, 8)
         for property in [encoding.min, encoding.max, encoding.scale, encoding.offset]:
-            assert property.shape == tuple()
+            assert property.shape == shape
         assert encoding.granularity == "pertensor"
         assert encoding.mapping == "affine"
 

--- a/TrainingExtensions/torch/test/python/v2/encodings/test_affine_encoding.py
+++ b/TrainingExtensions/torch/test/python/v2/encodings/test_affine_encoding.py
@@ -123,8 +123,8 @@ class TestAffineEncoding:
         When: Create an encoding with tensors on device
         Then: encoding.{min, max, scale, offset} are on device
         """
-        scale = torch.ones((1,)).to(device)
-        offset = torch.ones((1,)).to(device)
+        scale = torch.ones([]).to(device)
+        offset = torch.ones([]).to(device)
         encoding = AffineEncoding(scale, offset, bitwidth=8)
         for property in [encoding.min, encoding.max, encoding.scale, encoding.offset]:
             assert property.device == torch.device(device)
@@ -149,8 +149,8 @@ class TestAffineEncoding:
         When: Create an encoding with tensors of type dtype in {torch.float16, torch.float32}
         Then: encoding.{min, max, scale, offset} are dtype
         """
-        scale = torch.ones((1,)).to(dtype)
-        offset = torch.ones((1,)).to(dtype)
+        scale = torch.ones([]).to(dtype)
+        offset = torch.ones([]).to(dtype)
         encoding = AffineEncoding(scale, offset, bitwidth=8)
         for property in [encoding.min, encoding.max, encoding.scale, encoding.offset]:
             assert property.dtype == dtype
@@ -174,8 +174,8 @@ class TestAffineEncoding:
         When: call encoding.to() with invalid dtype in {torch.uint8, torch.int32}
         Then: raises RuntimeError
         """
-        scale = torch.ones((1,), dtype=torch.float32)
-        offset = torch.ones((1,), dtype=torch.float32)
+        scale = torch.ones([], dtype=torch.float32)
+        offset = torch.ones([], dtype=torch.float32)
         encoding = AffineEncoding(scale, offset, bitwidth=8)
         with pytest.raises(RuntimeError):
             encoding.to(dtype)

--- a/TrainingExtensions/torch/test/python/v2/encodings/test_float_encoding.py
+++ b/TrainingExtensions/torch/test/python/v2/encodings/test_float_encoding.py
@@ -107,7 +107,7 @@ class TestFloatEncoding:
         assert encoding.maxval.dtype == dtype
         assert new_encoding.maxval.dtype == new_dtype
 
-    @pytest.mark.parametrize("shape", ((10, 1), (10,)))
+    @pytest.mark.parametrize("shape", ((10, 1), (10,), (1,)))
     def test_perchannel_encoding(self, shape):
         """
         When: Create an encoding with maxval whose shape has more than one element
@@ -122,16 +122,15 @@ class TestFloatEncoding:
         assert encoding.granularity == "perchannel"
         assert encoding.mapping == "float"
 
-    @pytest.mark.parametrize("shape", (tuple(), (1,)))
-    def test_pertensor_encoding(self, shape):
+    def test_pertensor_encoding(self):
         """
-        When: Create an encoding with maxval whose shape in {[], [1]}
+        When: Create an encoding with 0-D maxval
         Then: encoding.maxval have shape == shape
               and granularity == "pertensor"
         """
         mantissa_bits = 5
         exponent_bits = 10
-        maxval = torch.randn(shape)
+        maxval = torch.randn([])
         encoding = FloatEncoding(mantissa_bits, exponent_bits, maxval)
         assert encoding.maxval.shape == tuple()
         assert encoding.granularity == "pertensor"

--- a/TrainingExtensions/torch/test/python/v2/nn/test_activation.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_activation.py
@@ -79,7 +79,7 @@ class TestFakeQuantizedSoftmax:
         Then: The output should hold the same encoding as input
         """
         input = input.as_subclass(DequantizedTensor)
-        input.encoding = AffineEncoding(scale=torch.ones([]), offset=torch.zeros([]), bitwidth=8)
+        input.encoding = AffineEncoding(scale=torch.ones(()), offset=torch.zeros(()), bitwidth=8)
         output = FakeQuantizedReshape()(input, (100,))
 
         assert isinstance(output, DequantizedTensor)
@@ -94,10 +94,10 @@ class TestFakeQuantizedSoftmax:
         Given: Instantiate a fake-quantized module with input quantizer spec specified
         """
         quant_softmax = FakeQuantizedSoftmax()
-        quant_softmax.input_quantizers[0] = QuantizeDequantize((1,),
+        quant_softmax.input_quantizers[0] = QuantizeDequantize((),
                                                                bitwidth=8,
                                                                symmetric=False,
-                                                               encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                               encoding_analyzer=MinMaxEncodingAnalyzer(()))
 
         """
         When: Inspect `input_quantizer` attribute.
@@ -136,10 +136,10 @@ class TestFakeQuantizedSoftmax:
         Given: Instantiate a fake-quantized module with output quantizer spec specified
         """
         quant_softmax = FakeQuantizedSoftmax()
-        quant_softmax.output_quantizers[0] = QuantizeDequantize((1,),
+        quant_softmax.output_quantizers[0] = QuantizeDequantize((),
                                                                 bitwidth=8,
                                                                 symmetric=False,
-                                                                encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                                encoding_analyzer=MinMaxEncodingAnalyzer(()))
 
         """
         When: Inspect `output_quantizer` attribute.

--- a/TrainingExtensions/torch/test/python/v2/nn/test_linear.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_linear.py
@@ -65,10 +65,10 @@ class TestFakeQuantizedLinear:
         Given: Instantiate a fake-quantized module with input quantizer spec specified
         """
         quant_linear = FakeQuantizedLinear(10, 10)
-        quant_linear.input_quantizers[0] = QuantizeDequantize((1,),
+        quant_linear.input_quantizers[0] = QuantizeDequantize((),
                                                               bitwidth=8,
                                                               symmetric=False,
-                                                              encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                              encoding_analyzer=MinMaxEncodingAnalyzer(()))
         """
         When: Inspect `input_quantizer` attribute.
         Then: `input_quantizer` is set to `QuantizeDequantize` as a submodule
@@ -107,10 +107,10 @@ class TestFakeQuantizedLinear:
         Given: Instantiate a fake-quantized module with output quantizer spec specified
         """
         quant_linear = FakeQuantizedLinear(10, 10)
-        quant_linear.output_quantizers[0] = QuantizeDequantize((1,),
+        quant_linear.output_quantizers[0] = QuantizeDequantize((),
                                                                bitwidth=8,
                                                                symmetric=False,
-                                                               encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                               encoding_analyzer=MinMaxEncodingAnalyzer(()))
 
         """
         When: Inspect `output_quantizer` attribute.
@@ -189,14 +189,14 @@ class TestFakeQuantizedLinear:
         """
         fp_linear = nn.Linear(10, 10)
         quant_linear = FakeQuantizationMixin.from_module(fp_linear)
-        quant_linear.input_quantizers[0] = QuantizeDequantize((1,),
+        quant_linear.input_quantizers[0] = QuantizeDequantize((),
                                                               bitwidth=8,
                                                               symmetric=False,
-                                                              encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
-        quant_linear.output_quantizers[0] = QuantizeDequantize((1,),
+                                                              encoding_analyzer=MinMaxEncodingAnalyzer(()))
+        quant_linear.output_quantizers[0] = QuantizeDequantize((),
                                                                bitwidth=8,
                                                                symmetric=False,
-                                                               encoding_analyzer=MinMaxEncodingAnalyzer((1,)))
+                                                               encoding_analyzer=MinMaxEncodingAnalyzer(()))
         quant_linear.param_quantizers['weight'] = QuantizeDequantize((10,),
                                                                      bitwidth=4,
                                                                      symmetric=True,

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -413,11 +413,11 @@ class TestQuantizedLayers:
         fq_layer = FakeQuantizationMixin.from_module(layer)
         tq_layer = QuantizationMixin.from_module(layer)
         for i, _ in enumerate(inputs):
-            fq_layer.input_quantizers[i] = QuantizeDequantize(shape=(1,), bitwidth=8, symmetric=False)
-            tq_layer.input_quantizers[i] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
+            fq_layer.input_quantizers[i] = QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
+            tq_layer.input_quantizers[i] = Quantize(shape=(), bitwidth=8, symmetric=False)
 
         fq_layer.output_quantizers[0] = QuantizeDequantize(shape=(1, ), bitwidth=8, symmetric=False)
-        tq_layer.output_quantizers[0] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
+        tq_layer.output_quantizers[0] = Quantize(shape=(), bitwidth=8, symmetric=False)
 
         with fq_layer.compute_encodings():
             fq_layer(*inputs)
@@ -442,12 +442,12 @@ class TestQuantizedLayers:
     def test_layers_with_weight(self, layer, input):
         fq_layer = FakeQuantizationMixin.from_module(layer)
         tq_layer = QuantizationMixin.from_module(layer)
-        fq_layer.input_quantizers[0] = QuantizeDequantize(shape=(1,), bitwidth=8, symmetric=False)
+        fq_layer.input_quantizers[0] = QuantizeDequantize(shape=(), bitwidth=8, symmetric=False)
         fq_layer.output_quantizers[0] = QuantizeDequantize(shape=(1, ), bitwidth=8, symmetric=False)
-        fq_layer.param_quantizers["weight"] = QuantizeDequantize(shape=(1,), bitwidth=8, symmetric=True)
-        tq_layer.input_quantizers[0] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        tq_layer.output_quantizers[0] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        tq_layer.param_quantizers["weight"] = Quantize(shape=(1,), bitwidth=8, symmetric=True)
+        fq_layer.param_quantizers["weight"] = QuantizeDequantize(shape=(), bitwidth=8, symmetric=True)
+        tq_layer.input_quantizers[0] = Quantize(shape=(), bitwidth=8, symmetric=False)
+        tq_layer.output_quantizers[0] = Quantize(shape=(), bitwidth=8, symmetric=False)
+        tq_layer.param_quantizers["weight"] = Quantize(shape=(), bitwidth=8, symmetric=True)
 
         with fq_layer.compute_encodings():
             fq_layer(input)
@@ -464,9 +464,9 @@ class TestQuantizedLayers:
     @pytest.mark.cuda
     def test_layers_with_recompute(self):
         qlinear = QuantizedLinear(4096, 4096)
-        qlinear.input_quantizers[0] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        qlinear.output_quantizers[0] = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        qlinear.param_quantizers["weight"] = Quantize(shape=(1,), bitwidth=8, symmetric=True)
+        qlinear.input_quantizers[0] = Quantize(shape=(), bitwidth=8, symmetric=False)
+        qlinear.output_quantizers[0] = Quantize(shape=(), bitwidth=8, symmetric=False)
+        qlinear.param_quantizers["weight"] = Quantize(shape=(), bitwidth=8, symmetric=True)
         qlinear.cuda()
 
         # Using dummy backend is no good for testing memory saving in real life.
@@ -531,9 +531,9 @@ class TestQuantizedLayers:
 
     def test_remove_quantizers(self, input):
         qlinear = QuantizedLinear(10, 10, bias=False)
-        qlinear.input_quantizers[0] = input_qtzr = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        qlinear.output_quantizers[0] = output_qtzr = Quantize(shape=(1,), bitwidth=8, symmetric=False)
-        qlinear.param_quantizers["weight"] = weight_qtzr = Quantize(shape=(1,), bitwidth=8, symmetric=True)
+        qlinear.input_quantizers[0] = input_qtzr = Quantize(shape=(), bitwidth=8, symmetric=False)
+        qlinear.output_quantizers[0] = output_qtzr = Quantize(shape=(), bitwidth=8, symmetric=False)
+        qlinear.param_quantizers["weight"] = weight_qtzr = Quantize(shape=(), bitwidth=8, symmetric=True)
         with qlinear.compute_encodings():
             qlinear(input)
 
@@ -706,13 +706,13 @@ def test_sanity(qmodule, pseudo_kernel, inputs):
         inputs = (inputs,)
 
     for i, _ in enumerate(qmodule.input_quantizers):
-        qmodule.input_quantizers[i] = Quantize([], 8, False)
+        qmodule.input_quantizers[i] = Quantize((), 8, False)
 
     for i, _ in enumerate(qmodule.output_quantizers):
-        qmodule.output_quantizers[i] = Quantize([], 8, False)
+        qmodule.output_quantizers[i] = Quantize((), 8, False)
 
     if 'weight' in qmodule.param_quantizers:
-        qmodule.param_quantizers['weight'] = Quantize([], 8, True)
+        qmodule.param_quantizers['weight'] = Quantize((), 8, True)
 
     with qmodule.compute_encodings():
         _ = qmodule(*inputs)

--- a/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
@@ -905,8 +905,8 @@ def test_is_initialized_with_deepspeed_zero3(init_process_group, deepspeed_zero3
 @torch.no_grad()
 @pytest.mark.parametrize('symmetric', [True, False])
 def test_quantize_dequantize_then_quantize_and_dequantize_equality(x, symmetric):
-    qdq = QuantizeDequantize((1,), 8, symmetric)
-    q = Quantize((1,), 8, symmetric)
+    qdq = QuantizeDequantize((), 8, symmetric)
+    q = Quantize((), 8, symmetric)
 
     with qdq.compute_encodings(), q.compute_encodings():
         _ = qdq(x)
@@ -986,7 +986,7 @@ def test_bq_compute_encodings_and_forward():
                             bitwidth=4,
                             symmetric=True,
                             block_size=(2, 4, 3))
-    assert bq.encoding_analyzer.observer.shape == [2, 1, 2, 1, 4, 1]
+    assert bq.encoding_analyzer.observer.shape == (2, 1, 2, 1, 4, 1)
 
     bq.eval()
     param_tensor = torch.randn(4, 8, 12)
@@ -1199,7 +1199,7 @@ def test_import_signed_flag():
     When: Load unsigned-asymmetric encodings into signed-symmetric quantizer
     Then: signed-symmetric quantizer becomes unsigned-asymmetric
     """
-    asymmetric_quantizer = QuantizeDequantize((1,), 8, symmetric=False)
+    asymmetric_quantizer = QuantizeDequantize((), 8, symmetric=False)
     with asymmetric_quantizer.compute_encodings():
         asymmetric_quantizer(torch.randn(10))
     symmetric_quantizer.set_legacy_encodings(asymmetric_quantizer.get_legacy_encodings())

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_config_utils.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_config_utils.py
@@ -127,7 +127,7 @@ def test_set_blockwise_quantization_for_weights(device):
 
     for conv_layer in conv_layers:
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
     orig_device = get_device(conv_layers[0].param_quantizers['weight'])
@@ -142,7 +142,7 @@ def test_set_blockwise_quantization_for_weights(device):
 
     for conv_layer in conv_layers[1:]:
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
     set_blockwise_quantization_for_weights(qsim, lambda m: m == conv_layers[1], 4, True, [1, 4, -1, -1])
@@ -158,13 +158,13 @@ def test_set_blockwise_quantization_for_weights(device):
 
     for conv_layer in conv_layers[2:]:
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
 
     assert qsim.model.fc.param_quantizers['weight'].is_initialized()
     assert qsim.model.fc.param_quantizers['weight'].bitwidth == 8
-    assert len(qsim.model.fc.param_quantizers['weight'].shape) == 1
+    assert len(qsim.model.fc.param_quantizers['weight'].shape) == 0
 
     with pytest.raises(RuntimeError):
         # This should error out since the first conv's in_channels of 3 is invalid with block size 4
@@ -194,7 +194,7 @@ def test_set_grouped_blockwise_quantization_for_weights(device):
     for conv_layer in conv_layers:
         assert isinstance(conv_layer.param_quantizers['weight'], QuantizeDequantize)
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
     orig_device = get_device(conv_layers[0])
@@ -213,7 +213,7 @@ def test_set_grouped_blockwise_quantization_for_weights(device):
     for conv_layer in conv_layers[1:]:
         assert isinstance(conv_layer.param_quantizers['weight'], QuantizeDequantize)
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
     set_grouped_blockwise_quantization_for_weights(qsim, lambda m: m == conv_layers[1], 4, True, 8, [1, 4, -1, -1],
@@ -233,13 +233,13 @@ def test_set_grouped_blockwise_quantization_for_weights(device):
 
     for conv_layer in conv_layers[2:]:
         assert conv_layer.param_quantizers['weight'].is_initialized()
-        assert len(conv_layer.param_quantizers['weight'].shape) == 1
+        assert len(conv_layer.param_quantizers['weight'].shape) == 0
         assert conv_layer.param_quantizers['weight'].bitwidth == 8
 
     assert isinstance(qsim.model.fc.param_quantizers['weight'], QuantizeDequantize)
     assert qsim.model.fc.param_quantizers['weight'].is_initialized()
     assert qsim.model.fc.param_quantizers['weight'].bitwidth == 8
-    assert len(qsim.model.fc.param_quantizers['weight'].shape) == 1
+    assert len(qsim.model.fc.param_quantizers['weight'].shape) == 0
 
     with pytest.raises(RuntimeError):
         # This should error out since the first conv's in_channels of 3 is invalid with block size 4

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -266,8 +266,8 @@ class TestQuantsim:
         sim.compute_encodings(lambda model, _: model(new_dummy_input), None)
         assert torch.equal(conv1_input_min, sim.model.conv1.input_quantizers[0].min)
         assert torch.equal(conv1_input_max, sim.model.conv1.input_quantizers[0].max)
-        assert not any(torch.isclose(fc_output_min, sim.model.fc.output_quantizers[0].min))
-        assert not any(torch.isclose(fc_output_max, sim.model.fc.output_quantizers[0].max))
+        assert not torch.isclose(fc_output_min, sim.model.fc.output_quantizers[0].min)
+        assert not torch.isclose(fc_output_max, sim.model.fc.output_quantizers[0].max)
 
     def test_load_encodings(self):
         model = test_models.TinyModel()
@@ -400,14 +400,10 @@ class TestQuantsim:
 
         sim.compute_encodings(lambda model, _: model(dummy_input), None)
 
-        assert not any(torch.isclose(weight_min,
-                                     sim.model.conv1.param_quantizers['weight'].min))
-        assert not any(torch.isclose(weight_max,
-                                     sim.model.conv1.param_quantizers['weight'].max))
-        assert not any(torch.isclose(input_min,
-                                     sim.model.conv1.input_quantizers[0].min))
-        assert not any(torch.isclose(input_max,
-                                     sim.model.conv1.input_quantizers[0].max))
+        assert not torch.isclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
+        assert not torch.isclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
+        assert not torch.isclose(input_min, sim.model.conv1.input_quantizers[0].min)
+        assert not torch.isclose(input_max, sim.model.conv1.input_quantizers[0].max)
 
         weight_min = sim.model.conv1.param_quantizers['weight'].min.clone().detach()
         weight_max = sim.model.conv1.param_quantizers['weight'].max.clone().detach()
@@ -416,14 +412,10 @@ class TestQuantsim:
 
         sim.load_encodings(encodings2)
 
-        assert not any(torch.isclose(weight_min,
-                                     sim.model.conv1.param_quantizers['weight'].min))
-        assert not any(torch.isclose(weight_max,
-                                     sim.model.conv1.param_quantizers['weight'].max))
-        assert not any(torch.isclose(input_min,
-                                     sim.model.conv1.input_quantizers[0].min))
-        assert not any(torch.isclose(input_max,
-                                     sim.model.conv1.input_quantizers[0].max))
+        assert not torch.isclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
+        assert not torch.isclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
+        assert not torch.isclose(input_min, sim.model.conv1.input_quantizers[0].min)
+        assert not torch.isclose(input_max, sim.model.conv1.input_quantizers[0].max)
 
         """
         When: Call load_encodings with allow_overwrite=False
@@ -894,8 +886,8 @@ class TestQuantsim:
             dummy_input = torch.randn(1, 3)
 
             qsim = QuantizationSimModel(model, dummy_input, config_file=os.path.join(temp_dir, 'config.json'))
-            assert torch.equal(qsim.model.softmax.output_quantizers[0].min, torch.tensor([0.]))
-            assert torch.equal(qsim.model.softmax.output_quantizers[0].max, torch.tensor([1.]))
+            assert torch.equal(qsim.model.softmax.output_quantizers[0].min, torch.tensor(0.))
+            assert torch.equal(qsim.model.softmax.output_quantizers[0].max, torch.tensor(1.))
 
             qsim = QuantizationSimModel(model, dummy_input, config_file=os.path.join(temp_dir, 'config.json'),
                                         default_param_bw=16, default_output_bw=16,


### PR DESCRIPTION
### Main Change
- Before: Per-tensor quantizers represent qtzn scale as **1-D** vector that **happens to** contain only one element
- This PR: Per-tensor quantizers represent qtzn scale as **0-D** scalar that is **guaranteed** to contain only one element

### Rationale
1. Using 1-D vector to represent a per-tensor scale is ambiguous for the users to distinguish whether it's a per-tensor scale or a per-channel scale that happens to have only one channel
2. 0-D tensor is more flexible than 1-D vector with single element. Most critical diff is that 0-D scale is compatible with any shape of input, but scale represented as a 1-D vector w/ single element is only compatible with 1-or-higher-D inputs.