### PR TITLE
Fix in-place function handling of QuantizedTensorBase

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -373,8 +373,6 @@ class QuantizedTensor(QuantizedTensorBase):
         """
         Returns ``self``
         """
-        if self.encoding is None:
-            raise EncodingError("Encoding does not exist")
         return self
 
     def dequantize(self) -> "DequantizedTensor":
@@ -453,8 +451,6 @@ class DequantizedTensor(QuantizedTensorBase):
         """
         Returns ``self``
         """
-        if self.encoding is None:
-            raise EncodingError("Encoding does not exist")
         return self
 
     def quantized_repr(self) -> torch.Tensor:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -409,6 +409,8 @@ class QuantizedTensor(QuantizedTensorBase):
     def quantized_repr(self) -> torch.Tensor:
         # FIXME(kyunggeu): This only works for affine encodings.
         #                  Needs to be generalized for any kind of encodings
+        if self.encoding is None:
+            raise EncodingError("Encoding does not exist")
         return self.quantize().as_subclass(torch.Tensor).to(self.encoding.dtype)
 
 
@@ -477,6 +479,8 @@ class DequantizedTensor(QuantizedTensorBase):
         """
         # FIXME(kyunggeu): This only works for affine encodings.
         #                  Needs to be generalized for any kind of encodings
+        if self.encoding is None:
+            raise EncodingError("Encoding does not exist")
         return self.quantize().as_subclass(torch.Tensor).to(self.encoding.dtype)
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -284,7 +284,7 @@ class QuantizedTensorBase(torch.Tensor):
         :param memory_format: Desired memory format of the returned tensor (default=torch.preserve_format)
         """
         # Note: use encoding.clone() here instead of deepcopy to propagate gradient through operation
-        encoding_clone = self.encoding._clone() # pylint:disable = protected-access
+        encoding_clone = self.encoding and self.encoding._clone() # pylint:disable = protected-access
         self_clone = super().clone(memory_format=memory_format).as_subclass(self.__class__)
         self_clone.encoding = encoding_clone
         return self_clone
@@ -295,7 +295,7 @@ class QuantizedTensorBase(torch.Tensor):
         Returns a new QuantizedTensorBase with data and encoding detached from the current graph
         """
         self_detached = super().detach().as_subclass(self.__class__)
-        self_detached.encoding = self.encoding._detach() # pylint:disable = protected-access
+        self_detached.encoding = self.encoding and self.encoding._detach() # pylint:disable = protected-access
         return self_detached
 
     @classmethod

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -108,6 +108,7 @@ class QuantizedTensorBase(torch.Tensor):
     # Operations that an encoding can always pass through
     _passthrough_ops = {
         torch.Tensor.contiguous,
+        torch.Tensor.requires_grad_,
         torch.Tensor.share_memory_,
     }
 
@@ -197,7 +198,6 @@ class QuantizedTensorBase(torch.Tensor):
         torch.unsqueeze_copy,
         torch.vsplit,
         torch.view_copy,
-        torch.Tensor.requires_grad_,
     }
 
     # In-place operations

--- a/TrainingExtensions/torch/test/python/v2/quantization/test_tensor.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/test_tensor.py
@@ -616,11 +616,12 @@ class TestQuantizedTensor:
         """
         x, *others = [affine_quantize(inp, scale, offset, bitwidth).dequantize()
                       if isinstance(inp, Tensor) else inp for inp in inputs]
+        orig_encoding = x.encoding
 
         y = in_place_func(x, *others)
 
         assert x is y
-        assert y.encoding is not None
+        assert y.encoding is orig_encoding
 
     def test_qtensor_without_encoding(self, scale, offset, bitwidth):
         """


### PR DESCRIPTION
I found an issue in applying in-place operations to QuantizedTensors.

## Problem
```py
x = QuantizedTensor(...)
x.encoding = ...

x.add_(1)             # Now x.encoding is stale
x_dq = x.dequantize() # x gets dequantized with stale encoding
```

## Solution
Applying in-place operations to QuantizedTensors will now detach the stale encoding from the tensor.
```py
x = QuantizedTensor(...)
x.encoding = ...

x.add_(1)             # Now x.encoding is stale
assert x.encoding is None
x_dq = x.dequantize() # This will throw error
```