### PR TITLE
Migrate qmodule definitions of custom modules to nn/quantized/custom.py

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/quantized/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/quantized/__init__.py
@@ -1,0 +1,36 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/quantized/custom.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/quantized/custom.py
@@ -1,0 +1,113 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+""" Quantized definitions for custom modules of AIMET """
+
+import torch
+from torch import nn
+import torch.nn.functional as F
+import aimet_torch.nn.modules.custom as custom
+from ..true_quant import QuantizationMixin, _DispatchMixin
+
+
+def _binary_quant_init(self):
+    super(type(self), self).__quant_init__()
+    self.input_quantizers = nn.ModuleList([None, None])
+
+
+@QuantizationMixin.implements(custom.Sin)
+class QuantizedSin(_DispatchMixin, QuantizationMixin, custom.Sin):
+    """ Quantized Sin """
+    _builtin_torch_fn = torch.sin
+
+
+@QuantizationMixin.implements(custom.Cos)
+class QuantizedCos(_DispatchMixin, QuantizationMixin, custom.Cos):
+    """ Quantized Cos """
+    _builtin_torch_fn = torch.cos
+
+
+@QuantizationMixin.implements(custom.AvgPool2d)
+class QuantizedAvgPool2d(_DispatchMixin, QuantizationMixin, custom.AvgPool2d):
+    """ Quantized AvgPool2d """
+    _builtin_torch_fn = F.avg_pool2d
+
+
+@QuantizationMixin.implements(custom.Reshape)
+class QuantizedReshape(_DispatchMixin, QuantizationMixin, custom.Reshape):
+    """ Quantized Reshape """
+    _builtin_torch_fn = torch.reshape
+
+
+@QuantizationMixin.implements(custom.RSqrt)
+class QuantizedRSqrt(_DispatchMixin, QuantizationMixin, custom.RSqrt):
+    """ Quantized RSqrt """
+    _builtin_torch_fn = torch.rsqrt
+
+
+@QuantizationMixin.implements(custom.MatMul)
+class QuantizedMatMul(_DispatchMixin, QuantizationMixin, custom.MatMul):
+    """ Quantized MatMul """
+    __quant_init__ = _binary_quant_init
+    _builtin_torch_fn = torch.matmul
+
+
+@QuantizationMixin.implements(custom.Add)
+class QuantizedAdd(_DispatchMixin, QuantizationMixin, custom.Add):
+    """ Quantized Add """
+    __quant_init__ = _binary_quant_init
+    _builtin_torch_fn = torch.add
+
+
+@QuantizationMixin.implements(custom.Multiply)
+class QuantizedMultiply(_DispatchMixin, QuantizationMixin, custom.Multiply):
+    """ Quantized Multiply """
+    __quant_init__ = _binary_quant_init
+    _builtin_torch_fn = torch.mul
+
+
+@QuantizationMixin.implements(custom.Subtract)
+class QuantizedSubtract(_DispatchMixin, QuantizationMixin, custom.Subtract):
+    """ Quantized Subtract """
+    __quant_init__ = _binary_quant_init
+    _builtin_torch_fn = torch.sub
+
+
+@QuantizationMixin.implements(custom.Divide)
+class QuantizedDivide(_DispatchMixin, QuantizationMixin, custom.Divide):
+    """ Quantized Divide """
+    __quant_init__ = _binary_quant_init
+    _builtin_torch_fn = torch.div

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
@@ -437,11 +437,6 @@ class _DispatchMixin(metaclass=_DispatchMeta):
         return wrapper
 
 
-def _binary_quant_init(self):
-    super(type(self), self).__quant_init__()
-    self.input_quantizers = nn.ModuleList([None, None])
-
-
 @QuantizationMixin.implements(nn.Conv1d)
 class QuantizedConv1d(_DispatchMixin, QuantizationMixin, nn.Conv1d):  # pylint: disable=too-many-ancestors
     """ Quantized Conv1d """
@@ -568,66 +563,7 @@ class QuantizedPixelShuffle(_DispatchMixin, QuantizationMixin, nn.PixelShuffle):
     _builtin_torch_fn = F.pixel_shuffle
 
 
-@QuantizationMixin.implements(aimet_ops.Sin)
-class QuantizedSin(_DispatchMixin, QuantizationMixin, aimet_ops.Sin):
-    """ Quantized Sin """
-    _builtin_torch_fn = torch.sin
-
-
-@QuantizationMixin.implements(aimet_ops.Cos)
-class QuantizedCos(_DispatchMixin, QuantizationMixin, aimet_ops.Cos):
-    """ Quantized Cos """
-    _builtin_torch_fn = torch.cos
-
-
-@QuantizationMixin.implements(aimet_ops.AvgPool2d)
-class QuantizedAvgPool2d(_DispatchMixin, QuantizationMixin, aimet_ops.AvgPool2d):
+@QuantizationMixin.implements(torch.nn.AvgPool2d)
+class QuantizedAvgPool2d(_DispatchMixin, QuantizationMixin, nn.AvgPool2d):
     """ Quantized AvgPool2d """
     _builtin_torch_fn = F.avg_pool2d
-
-
-@QuantizationMixin.implements(aimet_ops.Reshape)
-class QuantizedReshape(_DispatchMixin, QuantizationMixin, aimet_ops.Reshape):
-    """ Quantized Reshape """
-    _builtin_torch_fn = torch.reshape
-
-
-@QuantizationMixin.implements(aimet_ops.RSqrt)
-class QuantizedRSqrt(_DispatchMixin, QuantizationMixin, aimet_ops.RSqrt):
-    """ Quantized RSqrt """
-    _builtin_torch_fn = torch.rsqrt
-
-
-@QuantizationMixin.implements(aimet_ops.MatMul)
-class QuantizedMatMul(_DispatchMixin, QuantizationMixin, aimet_ops.MatMul):
-    """ Quantized MatMul """
-    __quant_init__ = _binary_quant_init
-    _builtin_torch_fn = torch.matmul
-
-
-@QuantizationMixin.implements(aimet_ops.Add)
-class QuantizedAdd(_DispatchMixin, QuantizationMixin, aimet_ops.Add):
-    """ Quantized Add """
-    __quant_init__ = _binary_quant_init
-    _builtin_torch_fn = torch.add
-
-
-@QuantizationMixin.implements(aimet_ops.Multiply)
-class QuantizedMultiply(_DispatchMixin, QuantizationMixin, aimet_ops.Multiply):
-    """ Quantized Multiply """
-    __quant_init__ = _binary_quant_init
-    _builtin_torch_fn = torch.mul
-
-
-@QuantizationMixin.implements(aimet_ops.Subtract)
-class QuantizedSubtract(_DispatchMixin, QuantizationMixin, aimet_ops.Subtract):
-    """ Quantized Subtract """
-    __quant_init__ = _binary_quant_init
-    _builtin_torch_fn = torch.sub
-
-
-@QuantizationMixin.implements(aimet_ops.Divide)
-class QuantizedDivide(_DispatchMixin, QuantizationMixin, aimet_ops.Divide):
-    """ Quantized Divide """
-    __quant_init__ = _binary_quant_init
-    _builtin_torch_fn = torch.div

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
@@ -49,7 +49,6 @@ import torch.nn.functional as F
 from torch import Tensor
 from torch.overrides import BaseTorchFunctionMode, get_overridable_functions
 
-import aimet_torch.nn.modules.custom as aimet_ops
 from aimet_torch.v2.quantization.base import QuantizerBase
 from aimet_torch.v2.quantization.tensor import QuantizedTensorBase
 from aimet_torch.v2.utils import patch_attr, _ContextManager, allow_recompute

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -59,6 +59,14 @@ from aimet_torch.v2.nn import (
     QuantizedSoftmax,
     QuantizedLayerNorm,
     QuantizedGroupNorm,
+    QuantizedReLU,
+    QuantizedPReLU,
+    QuantizedConstantPad2d as QConstantPad2d,
+    QuantizedHardtanh,
+    QuantizedMaxPool2d,
+    QuantizedUpsamplingBilinear2d as QUpsamplingBilinear2d,
+    QuantizedPixelShuffle,
+    QuantizedAvgPool2d,
     FakeQuantizationMixin,
 )
 from aimet_torch.v2.nn.true_quant import _dispatch
@@ -643,16 +651,6 @@ def _pseudo_integer_kernel_helper(fn):
     return pseudo_kernel
 
 
-from aimet_torch.v2.nn import (
-    QuantizedReLU,
-    QuantizedPReLU,
-    QuantizedConstantPad2d as QConstantPad2d,
-    QuantizedHardtanh,
-    QuantizedMaxPool2d,
-    QuantizedUpsamplingBilinear2d as QUpsamplingBilinear2d,
-    QuantizedPixelShuffle,
-    QuantizedAvgPool2d,
-)
 pseudo_relu_kernel = _pseudo_integer_kernel_helper(F.relu)
 pseudo_prelu_kernel = _pseudo_integer_kernel_helper(F.prelu)
 pseudo_pad_kernel = _pseudo_integer_kernel_helper(F.pad)


### PR DESCRIPTION
Migrated all qmodule definitions of custom modules from nn/true_quant.py to nn/quantized/custom.py to resolve naming collision