### PR TITLE
Simplify onnx IR using onnxscript

### DIFF
--- a/Jenkins/Dockerfile.torch-cpu
+++ b/Jenkins/Dockerfile.torch-cpu
@@ -157,6 +157,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/Jenkins/Dockerfile.torch-cpu-pt113
+++ b/Jenkins/Dockerfile.torch-cpu-pt113
@@ -157,6 +157,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/Jenkins/Dockerfile.torch-gpu
+++ b/Jenkins/Dockerfile.torch-gpu
@@ -169,6 +169,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/Jenkins/Dockerfile.torch-gpu-pt113
+++ b/Jenkins/Dockerfile.torch-gpu-pt113
@@ -169,6 +169,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
@@ -168,6 +168,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py38
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py38
@@ -165,6 +165,7 @@ RUN python3 -m pip --no-cache-dir install \
         networkx \
         'numpy<1.24,>=1.20.5' \
         onnx==1.14.1 \
+        onnxscript \
         onnxsim \
         onnxruntime==1.15.1 \
         onnxruntime-extensions \

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/__init__.py
@@ -36,6 +36,7 @@
 # =============================================================================
 
 # pylint: disable=missing-docstring
+from . import experimental
 from . import nn
 from . import quantization
 from . import quantsim

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/onnx/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/onnx/__init__.py
@@ -34,7 +34,4 @@
 #
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
-
-# pylint: disable=missing-docstring
-from . import onnx
-from .quantsim_utils import *  # pylint: disable=import-error
+""" Utility APIs for onnx export """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/onnx/_export.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/onnx/_export.py
@@ -1,0 +1,200 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+"""Utility APIs for onnx export"""
+
+import functools
+from typing import Sequence
+
+import onnxscript
+from onnxscript import opset15 as ops
+import torch
+from torch.onnx import is_in_onnx_export, symbolic_helper
+
+
+aimet_opset = onnxscript.values.Opset(domain="aimet", version=1)
+
+
+@onnxscript.script(aimet_opset, default_opset=ops)
+def quantize(tensor, scale, offset, qmin: int, qmax: int, block_size: Sequence[int]):
+    """Onnxscript implementation of affine quantize"""
+    # Upscale scale/offset by the factor of block_size
+    upscaled_shape = ops.Shape(scale) * block_size
+    scale = ops.Resize(scale, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    upscaled_shape = ops.Shape(offset) * block_size
+    offset = ops.Resize(offset, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    x_round = ops.Round(tensor / scale) - offset
+    x_int = ops.Clip(x_round, qmin, qmax)
+    return ops.Reshape(x_int, ops.Shape(tensor))
+
+
+@onnxscript.script(aimet_opset, default_opset=ops)
+def dequantize(tensor, scale, offset, block_size: Sequence[int]):
+    """Onnxscript implementation of affine dequantize"""
+    # Upscale scale/offset by the factor of block_size
+    upscaled_shape = ops.Shape(scale) * block_size
+    scale = ops.Resize(scale, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    upscaled_shape = ops.Shape(offset) * block_size
+    offset = ops.Resize(offset, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    x_dq = (tensor + offset) * scale
+    return ops.Reshape(x_dq, ops.Shape(tensor))
+
+
+@onnxscript.script(aimet_opset, default_opset=ops)
+def quantize_dequantize(tensor, scale, offset, qmin: int, qmax: int, block_size: Sequence[int]):
+    """Onnxscript implementation of affine quantize-dequantize"""
+    # Upscale scale/offset by the factor of block_size
+    upscaled_shape = ops.Shape(scale) * block_size
+    scale = ops.Resize(scale, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    upscaled_shape = ops.Shape(offset) * block_size
+    offset = ops.Resize(offset, roi=None, scales=None, sizes=upscaled_shape, mode='nearest')
+
+    x_round = ops.Round(tensor / scale) - offset
+    x_int = ops.Clip(x_round, qmin, qmax)
+    x_dq = (x_int + offset) * scale
+    return ops.Reshape(x_dq, ops.Shape(tensor))
+
+
+
+def _unsqueeze_scalar(g, tensor):
+    # pylint: disable=protected-access
+    shape = symbolic_helper._get_tensor_sizes(tensor) or []
+    if len(shape) == 0:
+        tensor = symbolic_helper._unsqueeze_helper(g, tensor, [0])
+    return tensor
+
+
+def _shape(tensor):
+    return symbolic_helper._get_tensor_sizes(tensor) # pylint: disable=protected-access
+
+
+def quantize_symbolic(g, tensor, scale, offset, qmin, qmax, block_size=None):
+    """Onnx symbolic function definition for affine quantize"""
+    # Unsqueeze scale, offset if scalars.
+    # This is necessary because ONNX Resize operator requires non-scalar input tensors
+    scale = _unsqueeze_scalar(g, scale)
+    offset = _unsqueeze_scalar(g, offset)
+
+    if block_size is None:
+        block_size = (1,)
+
+    if any(b == -1 for b in block_size):
+        # Concretize wildcard block sizes
+        old_block_size = block_size
+        new_block_size = list(reversed([
+            input_dim // num_blocks for input_dim, num_blocks in zip(_shape(tensor)[::-1], _shape(scale)[::-1])
+        ]))
+        assert all(old == new for old, new in zip(old_block_size, new_block_size) if old != -1)
+        block_size = new_block_size
+
+    return g.onnxscript_op(quantize, tensor, scale, offset,
+                           qmin_i=qmin, qmax_i=qmax, block_size_i=block_size).setType(tensor.type())
+
+
+def dequantize_symbolic(g, tensor, scale, offset, block_size=None):
+    """Onnx symbolic function definition for affine dequantize"""
+    # Unsqueeze scale, offset if scalars.
+    # This is necessary because ONNX Resize operator requires non-scalar input tensors
+    scale = _unsqueeze_scalar(g, scale)
+    offset = _unsqueeze_scalar(g, offset)
+
+    if block_size is None:
+        block_size = (1,)
+
+    if any(b == -1 for b in block_size):
+        # Concretize wildcard block sizes
+        old_block_size = block_size
+        new_block_size = list(reversed([
+            input_dim // num_blocks for input_dim, num_blocks in zip(_shape(tensor)[::-1], _shape(scale)[::-1])
+        ]))
+        assert all(old == new for old, new in zip(old_block_size, new_block_size) if old != -1)
+        block_size = new_block_size
+
+    return g.onnxscript_op(dequantize, tensor, scale, offset, block_size_i=block_size).setType(tensor.type())
+
+
+def quantize_dequantize_symbolic(g, tensor, scale, offset, qmin, qmax, block_size=None):
+    """Onnx symbolic function definition for affine quantize-dequantize"""
+    # Unsqueeze scale, offset if scalars.
+    # This is necessary because ONNX Resize operator requires non-scalar input tensors
+    scale = _unsqueeze_scalar(g, scale)
+    offset = _unsqueeze_scalar(g, offset)
+
+    if block_size is None:
+        block_size = (1,)
+
+    if any(b == -1 for b in block_size):
+        # Concretize wildcard block sizes
+        old_block_size = block_size
+        new_block_size = list(reversed([
+            input_dim // num_blocks for input_dim, num_blocks in zip(_shape(tensor)[::-1], _shape(scale)[::-1])
+        ]))
+        assert all(old == new for old, new in zip(old_block_size, new_block_size) if old != -1)
+        block_size = new_block_size
+
+    return g.onnxscript_op(quantize_dequantize, tensor, scale, offset,
+                           qmin_i=qmin, qmax_i=qmax, block_size_i=block_size).setType(tensor.type())
+
+
+
+def register_symbolic(symbolic_fn):
+    """
+    Register ONNX symbolic function definition for a regular python function.
+    """
+    def decorator(python_fn):
+        class SymbolicHelper(torch.autograd.Function): # pylint: disable=abstract-method
+            """Helper class for coupling an arbitrary python function with a onnx symbolic function"""
+            @staticmethod
+            def forward(ctx, *args, **kwargs):
+                return python_fn(*args, **kwargs)
+
+            backward = NotImplemented
+            symbolic = staticmethod(symbolic_fn)
+
+        @functools.wraps(python_fn)
+        def wrapper(*args, **kwargs):
+            if is_in_onnx_export():
+                return SymbolicHelper.apply(*args, **kwargs)
+            return python_fn(*args, **kwargs)
+
+        return wrapper
+
+    return decorator

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/torch_builtins.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/backends/torch_builtins.py
@@ -39,6 +39,7 @@ from typing import Optional, List
 import torch
 
 from aimet_torch.v2.utils import _is_expandable
+import aimet_torch.v2.experimental.onnx._export as _onnx
 
 
 def _is_value_representable(dtype: torch.dtype, value):
@@ -105,6 +106,7 @@ def _validate_arguments(tensor: torch.Tensor, scale: torch.Tensor, offset: torch
             raise RuntimeError(f"qmin ({qmin}) must be smaller than or equal to qmax ({qmax})")
 
 
+@_onnx.register_symbolic(_onnx.quantize_symbolic)
 def quantize(tensor: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor,
              qmin: int, qmax: int, block_size: Optional[List] = None) -> torch.Tensor:
     """
@@ -129,6 +131,9 @@ def quantize(tensor: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor,
     offset = offset.view(get_encoding_shape_with_blocks(offset.shape, block_size))
     return QuantizeFunc.apply(tensor, scale, offset, qmin, qmax).view(orig_tensor_shape)
 
+
+
+@_onnx.register_symbolic(_onnx.quantize_dequantize_symbolic)
 def quantize_dequantize(tensor: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor,
                         qmin: int, qmax: int, block_size: Optional[List] = None) -> torch.Tensor:
     """
@@ -161,6 +166,7 @@ def quantize_dequantize(tensor: torch.Tensor, scale: torch.Tensor, offset: torch
                                   offset.to(internal_dtype),
                                   qmin, qmax).to(output_dtype).view(orig_tensor_shape)
 
+@_onnx.register_symbolic(_onnx.dequantize_symbolic)
 def dequantize(tensor: torch.Tensor, scale: torch.Tensor, offset: torch.Tensor, block_size: Optional[List] = None) \
         -> torch.Tensor:
     """

--- a/TrainingExtensions/torch/test/python/v2/experimental/test_onnx.py
+++ b/TrainingExtensions/torch/test/python/v2/experimental/test_onnx.py
@@ -1,0 +1,211 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+import os
+import onnxruntime as ort
+import pytest
+import numpy as np
+import torch
+import onnx
+from onnx.onnx_ml_pb2 import AttributeProto
+import tempfile
+import aimet_torch.v2 as aimet
+import aimet_torch.v2.quantization as Q
+from aimet_torch.v2.quantsim import QuantizationSimModel
+from torchvision.models import resnet18
+
+
+@pytest.fixture(autouse=True, params=range(1))
+def seed(request):
+    seed = request.param
+    torch.manual_seed(seed)
+
+
+@pytest.mark.parametrize("qtzr_cls", [Q.affine.Quantize, Q.affine.QuantizeDequantize])
+@pytest.mark.parametrize("input_shape, scale_shape, block_size", [
+                         ([],          [],          None      ), # per-tensor
+                         ((100, 100),  (1,),        None      ), # per-tensor
+                         ((100, 100),  [],          None      ), # per-tensor
+                         ((100, 100),  (100, 1),    None      ), # per-channel
+                         ((100, 100),  (100, 1),    (1, 100)  ), # per-channel
+                         ((100, 100),  (100, 50),   (1, 2)    ), # blockwise
+                         ((100, 100),  (50, 100),   (2, 1)    ), # blockwise
+                         ((100, 100),  (50, 50),    (2, 2)    ), # blockwise
+                         ((100, 100),  (50, 50),    (-1, -1)  ), # blockwise
+])
+@pytest.mark.parametrize("symmetric", [True, False])
+def test_quantize_torch_ort_equal(qtzr_cls, input_shape, scale_shape, block_size, symmetric):
+    """
+    When: Export a quantizer with torch.onnx.export
+    """
+    x = torch.randn(input_shape)
+    qtzr = qtzr_cls(scale_shape, 8, symmetric, block_size=block_size)
+    with qtzr.compute_encodings():
+        _ = qtzr(x)
+
+    with tempfile.TemporaryDirectory() as dirname:
+        full_path = os.path.join(dirname, "qtzr.onnx")
+
+        with open(full_path, "wb") as f:
+            torch.onnx.export(qtzr, x, f, input_names=['input'], output_names=['output'])
+
+        with torch.no_grad():
+            y = qtzr(x)
+
+        """
+        Then: The saved onnx model should pass onnx model checker
+        """
+        model = onnx.load_model(full_path)
+        onnx.checker.check_model(model)
+
+        """
+        Then: The saved onnx model should contain exactly one graph node in "aimet" domain
+              with proper name and attributes
+        """
+        nodes = [node for node in model.graph.node if node.domain == 'aimet']
+        assert len(nodes) == 1
+        node, = nodes
+
+        assert node.name == '/quantize' if qtzr_cls is Q.affine.Quantize else '/quantize_dequantize'
+        assert node.attribute[0].name == 'block_size'
+        assert node.attribute[0].ints == ([1] if block_size is None else list(np.array(input_shape) // np.array(scale_shape)))
+        assert node.attribute[1].name == 'qmax'
+        assert node.attribute[1].i == (127 if symmetric else 255)
+        assert node.attribute[2].name == 'qmin'
+        assert node.attribute[2].i == (-128 if symmetric else 0)
+
+        """
+        Then: The saved onnx model should produce the same output with the original quantizer
+              given the same input
+        """
+        sess = ort.InferenceSession(full_path, providers=['CPUExecutionProvider'])
+        out, = sess.run(None, {'input': x.numpy()})
+        assert torch.equal(torch.from_numpy(out), y)
+
+
+@pytest.mark.parametrize("input_shape, scale_shape, block_size", [
+                         ([],          [],          None      ), # per-tensor
+                         ((100, 100),  (1,),        None      ), # per-tensor
+                         ((100, 100),  [],          None      ), # per-tensor
+                         ((100, 100),  (100, 1),    None      ), # per-channel
+                         ((100, 100),  (100, 1),    (1, 100)  ), # per-channel
+                         ((100, 100),  (100, 50),   (1, 2)    ), # blockwise
+                         ((100, 100),  (50, 100),   (2, 1)    ), # blockwise
+                         ((100, 100),  (50, 50),    (2, 2)    ), # blockwise
+                         ((100, 100),  (50, 50),    (-1, -1)  ), # blockwise
+])
+@pytest.mark.parametrize("symmetric", [True, False])
+def test_dequantize_torch_ort_equal(input_shape, scale_shape, block_size, symmetric):
+    """
+    When: Export dequantize with torch.onnx.export
+    """
+
+    class Dequantize(torch.nn.Module):
+        def forward(self, x: Q.QuantizedTensor):
+            return x.dequantize()
+
+    x = torch.randn(input_shape)
+    qtzr = Q.affine.Quantize(scale_shape, 8, symmetric, block_size=block_size)
+    with qtzr.compute_encodings():
+        x = qtzr(x)
+
+    with tempfile.TemporaryDirectory() as dirname:
+        full_path = os.path.join(dirname, "qtzr.onnx")
+
+        with open(full_path, "wb") as f:
+            torch.onnx.export(Dequantize(), x, f, input_names=['input'], output_names=['output'])
+
+        with torch.no_grad():
+            y = x.dequantize()
+
+        """
+        Then: The saved onnx model should pass onnx model checker
+        """
+        model = onnx.load_model(full_path)
+        onnx.checker.check_model(model)
+
+        """
+        Then: The saved onnx model should contain exactly one graph node in "aimet" domain
+              with proper name and attributes
+        """
+        nodes = [node for node in model.graph.node if node.domain == 'aimet']
+        assert len(nodes) == 1
+        node, = nodes
+
+        assert node.name == '/dequantize'
+        assert node.attribute[0].name == 'block_size'
+        assert node.attribute[0].ints == ([1] if block_size is None else list(np.array(input_shape) // np.array(scale_shape)))
+
+        """
+        Then: The saved onnx model should produce the same output with the original quantizer
+              given the same input
+        """
+        sess = ort.InferenceSession(full_path, providers=['CPUExecutionProvider'])
+        out, = sess.run(None, {'input': x.numpy()})
+        assert torch.equal(torch.from_numpy(out), y)
+
+
+
+@torch.no_grad()
+def test_resnet18():
+    """
+    When: Export quantized resnet18 and run it on onnx runtime
+    Then: The onnx model should produce output close enough to the original pytorch model
+    """
+    x = torch.randn(1, 3, 224, 224)
+    model = resnet18(pretrained=True).eval()
+    model = QuantizationSimModel(model, x).model
+
+    with aimet.nn.compute_encodings(model):
+        model(x)
+
+    y = model(x)
+
+    with tempfile.TemporaryDirectory() as dirname:
+        full_path = os.path.join(dirname, "resnet18.onnx")
+
+        with open(full_path, "wb") as f:
+            torch.onnx.export(model, x, f, input_names=['input'], output_names=['output'])
+
+        onnx_model = onnx.load_model(full_path)
+        onnx.checker.check_model(onnx_model)
+
+        sess = ort.InferenceSession(full_path, providers=['CPUExecutionProvider'])
+        out, = sess.run(None, {'input': x.numpy()})
+
+        # Allow off-by-3 error
+        atol = 3 * model.fc.output_quantizers[0].get_scale().item()
+        assert torch.allclose(torch.from_numpy(out), y, atol=atol)

--- a/packaging/dependencies/reqs_pip_torch_common.txt
+++ b/packaging/dependencies/reqs_pip_torch_common.txt
@@ -6,6 +6,7 @@ numpy<1.24,>=1.20.5
 onnx==1.14.1
 onnxruntime==1.15.1
 onnxruntime-extensions
+onnxscript
 onnxsim
 pandas==1.5.3
 protobuf==3.20.2


### PR DESCRIPTION
## Main changes
Simplified onnx IR resulting from `torch.onnx.export` using onnxscript, encapsulating affine quantize/dequantize functions into custom onnx functions `"aimet::quantize"`, `"aimet::dequantize"`, and `"aimet::quantize_dequantize"`

## Known Limitations
1. Only works with opset 15~17. (PyTorch 2.x uses opset17 as default)
2. The implementation of custom onnx qtzn functions (`"aimet::quantize"`, `"aimet::dequantize"`, and `"aimet::quantize_dequantize"`) is inefficient in terms of time and memory.

