### PR TITLE
Ensure encoding symmetry in sequential MSE

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -139,9 +139,13 @@ class SequentialMse(V1SequentialMse):
         assert _is_reducible(x_min.shape, quantizer.min.shape)
         assert _is_reducible(x_max.shape, quantizer.max.shape)
 
-        with torch.no_grad():
-            quantizer.min.copy_(reduce(x_min, quantizer.shape, torch.min).values)
-            quantizer.max.copy_(reduce(x_max, quantizer.shape, torch.max).values)
+        inp = torch.stack([
+            reduce(x_min, quantizer.shape, torch.min).values,
+            reduce(x_max, quantizer.shape, torch.max).values,
+        ])
+
+        with quantizer.compute_encodings():
+            _ = quantizer(inp)
 
     @staticmethod
     def _is_symmetric_quantizer(quantizer: AffineQuantizerBase):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -35,7 +35,7 @@
 #
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
-
+# pylint: disable=redefined-builtin
 """ Sequential MSE implementation """
 
 from typing import List, Optional, Tuple


### PR DESCRIPTION
### Problem
In sequential MSE, we used to assign min/max of a symmetric quantizer directly by changing quantizer.{min, max} parameters.

However, this can lead to a drastic diff between the "effective" min/max that is being used for forward pass computation of the quantizer when `x_min` and `x_max` are not symmetrically aligned.
```pycon
>>> qtzr = Q.affine.Quantize([], bitwidth=4, symmetric=True)
>>> with torch.no_grad():
...     qtzr.min.copy_(-0.7)
...     qtzr.max.copy_(1.0)
...
>>> qtzr.get_min()
tensor(-0.9067, grad_fn=<MulBackward0>)
>>> qtzr.get_max()
tensor(0.7933, grad_fn=<MulBackward0>)
```
This is because symmetric quantizers try to keep symmetry of `get_min()` and `get_max()` even if the user forcefully assigns asymmetric values to `qtzr.min` and `max`.

### Fix
Align symmetry of `x_min` and `x_max` using letting a symmetric ancoding analyzer observe their values.