### PR TITLE
Aimet docker version fix

### DIFF
--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -244,3 +244,7 @@ html_context = {
 }
 
 autosummary_generate = False
+
+from pygments.lexers.diff import DiffLexer
+from sphinx.highlighting import lexers
+lexers['diff'] = DiffLexer()

--- a/Docs/conf.py
+++ b/Docs/conf.py
@@ -173,6 +173,7 @@ rst_epilog = """
 .. |author| replace:: {author}
 .. |project| replace:: {project}
 .. |default-quantsim-config-file| replace:: aimet_common/quantsim_config/default_config.json
+.. |version| replace:: {version}
 """.format(project=project, author=author, version=version)
 
 # -- Options for LaTeX output ------------------------------------------------
@@ -243,7 +244,3 @@ html_context = {
 }
 
 autosummary_generate = False
-
-from pygments.lexers.diff import DiffLexer
-from sphinx.highlighting import lexers
-lexers['diff'] = DiffLexer()

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -3,7 +3,7 @@
    #
    #  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
    #
--   #  Redistribution and use in source and binary forms, with or without
+   #  Redistribution and use in source and binary forms, with or without
    #  modification, are permitted provided that the following conditions are met:
    #
    #  1. Redistributions of source code must retain the above copyright notice,
@@ -46,9 +46,9 @@ Quick Install
 The AIMET PyTorch GPU PyPI packages are available for environments that meet the following requirements:
 
 * 64-bit Intel x86-compatible processor
-* Linux Ubuntu 22.04 LTS [Python 3.10]
+* Linux Ubuntu 22.04 LTS [Python 3.10] or Ubuntu 20.04 LTS [Python 3.8]
 * Cuda 12.0
-* Torch 2.1.2
+* Torch 2.2.2
 
 **Pip install:**
 

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -3,7 +3,7 @@
    #
    #  Copyright (c) 2022-2023, Qualcomm Innovation Center, Inc. All rights reserved.
    #
-   #  Redistribution and use in source and binary forms, with or without
+-   #  Redistribution and use in source and binary forms, with or without
    #  modification, are permitted provided that the following conditions are met:
    #
    #  1. Redistributions of source code must retain the above copyright notice,
@@ -46,9 +46,9 @@ Quick Install
 The AIMET PyTorch GPU PyPI packages are available for environments that meet the following requirements:
 
 * 64-bit Intel x86-compatible processor
-* Linux Ubuntu 22.04 LTS [Python 3.10] or Ubuntu 20.04 LTS [Python 3.8]
+* Linux Ubuntu 22.04 LTS [Python 3.10]
 * Cuda 12.0
-* Torch 2.2.2
+* Torch 2.1.2
 
 **Pip install:**
 
@@ -68,9 +68,9 @@ For other aimet variants, install the latest version from the .whl files hosted 
 .. parsed-literal::
 
     # Pytorch 1.13 with CUDA 11.x
-    python3 -m pip install |download_url|\ |version|/aimet_torch-torch_gpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|\ |whl_suffix|
     # Pytorch 1.13 CPU only
-    python3 -m pip install |download_url|\ |version|/aimet_torch-torch_cpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|\ |whl_suffix|
 
 
 **TensorFlow**
@@ -78,9 +78,9 @@ For other aimet variants, install the latest version from the .whl files hosted 
 .. parsed-literal::
 
     # Tensorflow 2.10 GPU with CUDA 11.x
-    python3 -m pip install |download_url|\ |version|/aimet_tensorflow-tf_gpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_tensorflow-\ |version|\ |whl_suffix|
     # Tensorflow 2.10 CPU only
-    python3 -m pip install |download_url|\ |version|/aimet_tensorflow-tf_cpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_tensorflow-\ |version|\ |whl_suffix|
 
 
 **Onnx**
@@ -88,9 +88,9 @@ For other aimet variants, install the latest version from the .whl files hosted 
 .. parsed-literal::
 
     # ONNX 1.14 GPU
-    python3 -m pip install |download_url|\ |version|/aimet_onnx-onnx_gpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|\ |whl_suffix|
     # ONNX 1.14 CPU
-    python3 -m pip install |download_url|\ |version|/aimet_onnx-onnx_cpu\_\ |version|\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|\ |whl_suffix|
 
 For previous AIMET releases, browse packages at https://github.com/quic/aimet/releases. Each release includes multiple python packages of the following format:
 
@@ -101,8 +101,7 @@ For previous AIMET releases, browse packages at https://github.com/quic/aimet/re
     <PACKAGE_PREFIX>-<VARIANT>_<VERSION>\ |whl_suffix|
 
 
-.. |version| replace:: 1.31.0
-.. |whl_suffix| replace:: -cp38-cp38-linux_x86_64.whl
+.. |whl_suffix| replace:: -cp310-cp310-manylinux_2_34_x86_64.whl
 .. |download_url| replace:: \https://github.com/quic/aimet/releases/download/
 
 System Requirements


### PR DESCRIPTION
Updates the aimet version through the conf.py file instead of being hard coded. Remove training <variant> in index.rst. Update whl suffix to match the output of the packaged files. 