### PR TITLE
Remove duplicate TOC entries

### DIFF
--- a/Docs/user_guide/model_quantization.rst
+++ b/Docs/user_guide/model_quantization.rst
@@ -140,13 +140,6 @@ depend on the ML framework the model is written in.
 
 :hideitem:`PyTorch`
 --------------------
-.. toctree::
-   :titlesonly:
-   :hidden:
-   
-    PyTorch Model Guidelines <../api_docs/torch_model_guidelines>
-    AIMET PyTorch Quantization APIs <../api_docs/torch_quantization>
-
 - Pytorch:
     
    :doc:`PyTorch Model Guidelines<../api_docs/torch_model_guidelines>`


### PR DESCRIPTION
## Main Changes
Deleted duplicate TOC entries.
Due to this duplicate entry, our documentation has been exhibiting an ugly behavior where expanding one of them also expands the other automatically.
![image](https://github.com/user-attachments/assets/c1b560bc-57fd-421a-b7b6-182be3c46b0a)