### PR TITLE
Quant Stats Visualizer - Adding Box Plot visualization for Advanced Stats

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization.py
@@ -155,15 +155,14 @@ def visualize_advanced_stats(sim: QuantizationSimModel, dummy_input, save_path: 
     .. note::
 
         For plotting advanced stats, the quantizer encoding analyzers should have observers of type
-        :class:`_HistogramObserver`, that is :attr:`QuantScheme.post_training_tf_enhanced` and
-        :attr:`QuantScheme.training_range_learning_with_tf_enhanced quant schemes. If observers are of the type
+        :class:`_HistogramObserver`. If observers are of the type
         :class:`_MinMaxObserver`, then advanced stats cannot be extracted and only the min and max values are
         shown in the boxplots.
 
     .. note::
 
-        In case of Per-channel or Blockwise quantization, for the param quantizers that are quantized this way,
-        advanced stats are not extracted due to the presence of multiple histograms. For these
+        In case of Per-channel or Blockwise quantizers,
+        percentiles are not extracted due to the presence of multiple histograms. For these
         quantizers, only min and max values are shown in the boxplots.
 
     Creates an interactive visualization of min and max activations/weights of all quantized modules in the input
@@ -173,7 +172,7 @@ def visualize_advanced_stats(sim: QuantizationSimModel, dummy_input, save_path: 
         - Table containing names and ranges for layers exceeding threshold values
         - Select different views of the table to group layers exceeding threshold values
         - Filter layers listed in the table by name
-        - Select one or more layers from the table for advanced analysis
+        - Select one or more layers from the table for viewing their boxplots and highlighting them in the main plot
 
     Saves the visualization as a .html at the given path.
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization.py
@@ -44,7 +44,8 @@ import torch
 from bokeh.events import DocumentReady, Reset
 from bokeh.layouts import row, column
 from bokeh.models import ColumnDataSource, TextInput, CustomJS, Range1d, HoverTool, CustomJSHover, Div, \
-    BooleanFilter, CDSView, Spacer, DataTable, StringFormatter, ScientificFormatter, TableColumn, Tooltip, Select
+    BooleanFilter, CDSView, Spacer, DataTable, StringFormatter, ScientificFormatter, TableColumn, Tooltip, Select, \
+    Whisker, FactorRange
 from bokeh.models.tools import ResetTool
 from bokeh.models.dom import HTML
 from bokeh.plotting import figure, save, curdoc
@@ -54,15 +55,15 @@ from aimet_torch.v2.quantization.base import QuantizerBase
 from aimet_torch.v2.quantization.encoding_analyzer import _MinMaxObserver, _HistogramObserver
 
 
-def _visualize(sim: QuantizationSimModel, dummy_input, mode: str, percentile_list: list = None, save_path: str = "./quant_stats_visualization.html") -> None:
+def _visualize(sim: QuantizationSimModel, dummy_input, mode: str, save_path: str = "./quant_stats_visualization.html", percentile_list: list = None) -> None:
     """
     Helper function for the visualization APIs.
 
     :param sim: Calibrated QuantSim Object.
     :param dummy_input: Dummy Input.
     :param mode: Whether to plot basic or advanced stats.
-    :param percentile_list: Percentiles to be extracted and used.
     :param save_path: Path for saving the visualization. Format is 'path_to_dir/file_name.html'. Default is './quant_stats_visualization.html'.
+    :param percentile_list: Percentiles to be extracted and used.
     """
 
     # Ensure that sim is an instance of aimet_torch.quantsim.QuantizationSimModel
@@ -90,6 +91,7 @@ def _visualize(sim: QuantizationSimModel, dummy_input, mode: str, percentile_lis
         raise RuntimeError(
             "No stats found to plot. Either there were no quantized modules, or calibration was not performed before calling this function, or no observers of type _MinMaxObserver or _HistogramObserver were present.")
 
+
     stats_dict = dict()
     keys_list = ["name", 0, 100] + percentile_list
     stats_dict["idx"] = list(range(len(stats_list)))
@@ -99,10 +101,13 @@ def _visualize(sim: QuantizationSimModel, dummy_input, mode: str, percentile_lis
         for i in keys_list:
             stats_dict[i][idx] = stats[i]
 
-    visualizer = QuantStatsVisualizer(stats_dict)
+    if mode == "advanced":
+        _get_additional_boxplot_stats(stats_dict)
+
+    visualizer = QuantStatsVisualizer(stats_dict, percentile_list)
 
     # Save an interactive bokeh plot as a standalone html
-    visualizer.export_plot_as_html(save_path)
+    visualizer.export_plot_as_html(save_path, mode)
 
 
 def visualize_stats(sim: QuantizationSimModel, dummy_input, save_path: str = "./quant_stats_visualization.html") -> None:
@@ -128,7 +133,7 @@ def visualize_stats(sim: QuantizationSimModel, dummy_input, save_path: str = "./
         ...     for data, _ in data_loader:
         ...         sim.model(data)
         ...
-        >>> visualize_stats(sim, dummy_input, "./quant_stats_visualization.html")
+        >>> visualize_stats(sim, dummy_input, save_path="./quant_stats_visualization.html")
 
     :param sim: Calibrated QuantizationSimModel
     :param dummy_input: Sample input used to trace the model
@@ -136,16 +141,22 @@ def visualize_stats(sim: QuantizationSimModel, dummy_input, save_path: str = "./
     """
 
     percentile_list = []
-    _visualize(sim, dummy_input, mode="basic", percentile_list=percentile_list, save_path=save_path)
+    _visualize(sim, dummy_input, mode="basic", save_path=save_path, percentile_list=percentile_list)
 
 
-def visualize_advanced_stats(sim: QuantizationSimModel, dummy_input, additional_percentiles: tuple = (1, 99), save_path: str = "./quant_advanced_stats_visualization.html") -> None:
+def visualize_advanced_stats(sim: QuantizationSimModel, dummy_input, save_path: str = "./quant_advanced_stats_visualization.html", additional_percentiles: tuple = (1, 99)) -> None:
     """Produces an interactive html to view the advanced stats collected by each quantizer during calibration
 
     .. note::
 
         The QuantizationSimModel input is expected to have been calibrated before using this function. Stats will only
         be plotted for activations/parameters with quantizers containing calibration statistics.
+
+    .. note::
+
+        For plotting advanced stats, the quantizer encoding analyzers should have observers of type
+        :class:`_HistogramObserver`, that is :attr:`QuantScheme.post_training_tf_enhanced` and
+        :attr:`QuantScheme.training_range_learning_with_tf_enhanced quant schemes.
 
     Creates an interactive visualization of min and max activations/weights of all quantized modules in the input
     QuantSim object. The features include:
@@ -165,17 +176,17 @@ def visualize_advanced_stats(sim: QuantizationSimModel, dummy_input, additional_
         ...     for data, _ in data_loader:
         ...         sim.model(data)
         ...
-        >>> visualize_advanced_stats(sim, dummy_input, "./quant_advanced_stats_visualization.html")
+        >>> visualize_advanced_stats(sim, dummy_input, save_path="./quant_advanced_stats_visualization.html", additional_percentiles=(1, 99))
 
     :param sim: Calibrated QuantizationSimModel
     :param dummy_input: Sample input used to trace the model
-    :param additional_percentiles: Percentiles other than those related to the boxplot (25, 50, 75) to be shown.
     :param save_path: Path for saving the visualization. Default is "./quant_advanced_stats_visualization.html"
+    :param additional_percentiles: Percentiles other than those related to the boxplot (25, 50, 75) to be shown.
     """
 
     percentile_list = _add_key_percentiles(additional_percentiles)
     percentile_list = sorted(percentile_list)
-    _visualize(sim, dummy_input, mode="advanced", percentile_list=percentile_list, save_path=save_path)
+    _visualize(sim, dummy_input, mode="advanced", save_path=save_path, percentile_list=percentile_list)
 
 
 def _check_path(path: str):
@@ -281,6 +292,22 @@ def _get_percentile_stats_from_histogram(histogram, percentile_list):
     return None
 
 
+def _get_additional_boxplot_stats(stats_dict: dict):
+    """ Get additional values required to plot a boxplot"""
+    stats_dict["stridx"] = []
+    stats_dict["boxplot_upper"] = []
+    stats_dict["boxplot_lower"] = []
+    for i in range(len(stats_dict["idx"])):
+        stats_dict["stridx"].append(str(stats_dict["idx"][i]))
+        if (stats_dict[25][i] is not None) and (stats_dict[75][i] is not None):
+            inter_quantile_range = stats_dict[75][i] - stats_dict[25][i]
+            stats_dict["boxplot_upper"].append(stats_dict[75][i] + 1.5 * inter_quantile_range)
+            stats_dict["boxplot_lower"].append(stats_dict[25][i] - 1.5 * inter_quantile_range)
+        else:
+            stats_dict["boxplot_upper"].append(None)
+            stats_dict["boxplot_lower"].append(None)
+
+
 def _is_sorted(arr: list):
     for i in range(len(arr) - 1):
         if arr[i] > arr[i + 1]:
@@ -297,16 +324,30 @@ class DataSources:
                  stats_dict: dict,
                  plot: figure,
                  default_values: dict,
+                 percentiles: list
                  ):
         self.data_source = ColumnDataSource(
-            data=dict(idx=stats_dict["idx"], namelist=stats_dict["name"], minlist=stats_dict[0],
+            data=dict(idx=stats_dict["idx"],
+                      namelist=stats_dict["name"],
+                      minlist=stats_dict[0],
+                      min_namelist=["Min"] * len(stats_dict["idx"]),
                       maxlist=stats_dict[100],
+                      max_namelist=["Max"] * len(stats_dict["idx"]),
                       marker_yminlist=[default_values['default_ymin']] * len(stats_dict["idx"]),
                       marker_ymaxlist=[default_values['default_ymax']] * len(stats_dict["idx"]),
                       selected=[False] * len(stats_dict["idx"])))
-        for key in stats_dict.keys():
-            if key not in ["idx", "name", 0, 100]:
+        if "stridx" in stats_dict.keys():
+            self.data_source.add(data=stats_dict["stridx"], name="stridx")
+        if "boxplot_upper" in stats_dict.keys():
+            self.data_source.add(data=stats_dict["boxplot_upper"], name="boxplot_upper_list")
+        if "boxplot_lower" in stats_dict.keys():
+            self.data_source.add(data=stats_dict["boxplot_lower"], name="boxplot_lower_list")
+        for key in [25, 50, 75]:
+            if key in stats_dict:
                 self.data_source.add(data=stats_dict[key], name=str(key) + "%ilelist")
+        for key in percentiles:
+            self.data_source.add(data=stats_dict[key], name=str(key) + "%ilelist")
+            self.data_source.add(data=[str(key)+" %ile" for _ in range(len(stats_dict["idx"]))], name=str(key) + "%ile_namelist")
 
         self.default_values_source = ColumnDataSource(
             data=dict(default_ymax=[default_values['default_ymax']],
@@ -326,11 +367,20 @@ class DataSources:
             data=dict(idx=[], namelist=[], minlist=[], maxlist=[]))
 
         self.selected_data_source = ColumnDataSource(
-            data=dict(idx=[], namelist=[], floor=[], ceil=[], minlist=[], maxlist=[])
+            data=dict(idx=[], namelist=[], floor=[], ceil=[], minlist=[], min_namelist=[], maxlist=[], max_namelist=[])
         )
-        for key in stats_dict.keys():
-            if key not in ["idx", "name", 0, 100]:
+        if "stridx" in stats_dict.keys():
+            self.selected_data_source.add(data=[], name="stridx")
+        if "boxplot_upper" in stats_dict.keys():
+            self.selected_data_source.add(data=[], name="boxplot_upper_list")
+        if "boxplot_lower" in stats_dict.keys():
+            self.selected_data_source.add(data=[], name="boxplot_lower_list")
+        for key in [25, 50, 75]:
+            if key in stats_dict:
                 self.selected_data_source.add(data=[], name=str(key) + "%ilelist")
+        for key in percentiles:
+            self.selected_data_source.add(data=[], name=str(key) + "%ilelist")
+            self.selected_data_source.add(data=[], name=str(key) + "%ile_namelist")
 
 
 class TableFilters:
@@ -413,7 +463,7 @@ class InputWidgets:
                                                 <li> <b> Max: </b> Quantized layers with max activation above upper threshold value </li>
                                                 <li> <b> Min | Max: </b> Union of Min and Max </li>
                                                 <li> <b> Min & Max: </b> Intersection of Min and Max </li>
-                                                </ol>  
+                                                </ol>
                                             """),
                                      position="right")
         self.table_view_select = Select(title="Select Table View",
@@ -445,7 +495,14 @@ class QuantStatsVisualizer:
     """
 
     # Class level constants
-    plot_dims = {"plot_width": 700, "plot_height": 400, "table_width": 800}
+    plot_dims = {"plot_width": 700,
+                 "plot_height": 400,
+                 "table_width": 800,
+                 "boxplot_width": 700,
+                 "boxplot_height": 400,
+                 "whisker_head": 20,
+                 "boxplot_vbar_width": 0.7,
+                 "boxplot_text_font_size": "10px"}
     initial_vals = {"default_ymin": -1e5, "default_ymax": 1e5}
     spacer_dims = {"sp1_width": 50, "sp1_height": 40}
     table_column_widths = {"Layer Index": 100,
@@ -453,14 +510,24 @@ class QuantStatsVisualizer:
                            "Min Activation": 100,
                            "Max Activation": 100}
 
-    def __init__(self, stats_dict: dict):
+    def __init__(self, stats_dict: dict, percentile_list: list):
         self.stats_dict = stats_dict
         self.plot = figure(
             title="Min Max Activations/Weights of quantized modules for given model",
             x_axis_label="Layer index",
             y_axis_label="Activation/Weight",
             tools="pan,wheel_zoom,box_zoom")
+        self.boxplot = figure(
+            x_range=FactorRange(),
+            title="Boxplots of selected layers",
+            x_axis_label="Layer index",
+            y_axis_label="Activation/Weight",
+            tools="pan,wheel_zoom,box_zoom")
         self.default_values = dict()
+        self.percentiles = []
+        for percentile in percentile_list:
+            if percentile not in [25, 50, 75]:
+                self.percentiles.append(percentile)
 
     def _add_plot_lines(self, datasources: DataSources):
         self.plot.segment(x0='xmin', x1='xmax', y0='ymin', y1='ymin', line_width=4, line_color='black',
@@ -493,6 +560,31 @@ class QuantStatsVisualizer:
         max_markers.view = tableobjects.views.max_thresh_view
 
         return min_markers, max_markers
+
+    def _add_boxplots(self, datasources: DataSources):
+        whisker = Whisker(base="stridx", upper="boxplot_upper_list", lower="boxplot_lower_list", source=datasources.selected_data_source)
+        whisker.upper_head.size = whisker.lower_head.size = QuantStatsVisualizer.plot_dims["whisker_head"]
+        self.boxplot.add_layout(whisker)
+        self.boxplot.vbar("stridx", QuantStatsVisualizer.plot_dims["boxplot_vbar_width"], "50%ilelist", "75%ilelist", source=datasources.selected_data_source, line_color="black")
+        self.boxplot.vbar("stridx", QuantStatsVisualizer.plot_dims["boxplot_vbar_width"], "25%ilelist", "50%ilelist", source=datasources.selected_data_source, line_color="black")
+        self.boxplot.circle(x="stridx", y="minlist", source=datasources.selected_data_source,
+                            name="min_points", color="orange")
+        self.boxplot.text(x="stridx", y="minlist", text="min_namelist",
+                          source=datasources.selected_data_source,
+                          x_offset=5, y_offset=5,
+                          text_font_size=QuantStatsVisualizer.plot_dims["boxplot_text_font_size"],
+                          name="min_labels")
+        self.boxplot.circle(x="stridx", y="maxlist", source=datasources.selected_data_source,
+                            name="max_points", color="orange")
+        self.boxplot.text(x="stridx", y="maxlist", text="max_namelist",
+                          source=datasources.selected_data_source,
+                          x_offset=5, y_offset=5,
+                          text_font_size=QuantStatsVisualizer.plot_dims["boxplot_text_font_size"],
+                          name="max_labels")
+        for percentile in self.percentiles:
+            self.boxplot.circle(x="stridx", y=str(percentile)+"%ilelist", source=datasources.selected_data_source, name=str(percentile) + "_" + "points", color="orange")
+            self.boxplot.text(x="stridx", y=str(percentile)+"%ilelist", text=str(percentile)+"%ile_namelist", source=datasources.selected_data_source,
+                                         x_offset=5, y_offset=5, text_font_size=QuantStatsVisualizer.plot_dims["boxplot_text_font_size"], name=str(percentile) + "_" + "labels")
 
     @staticmethod
     def _get_marker_hovertool(min_markers, max_markers):
@@ -542,8 +634,18 @@ class QuantStatsVisualizer:
 
         return selection_hover
 
-    def _define_callbacks(self, datasources, tableobjects, inputwidgets):
+    def _define_callbacks(self, datasources, tableobjects, inputwidgets, mode):
         customcallbacks = CustomCallbacks()
+
+        selection_columns = []
+
+        if mode == "basic":
+            selection_columns += ["idx", "namelist", "minlist", "min_namelist", "maxlist", "max_namelist"]
+        elif mode == "advanced":
+            selection_columns += ["idx", "namelist", "minlist", "min_namelist", "maxlist", "max_namelist", "stridx", "boxplot_upper_list", "boxplot_lower_list", "25%ilelist", "50%ilelist", "75%ilelist"]
+            for percentile in self.percentiles:
+                selection_columns.append(str(percentile) + "%ilelist")
+                selection_columns.append(str(percentile) + "%ile_namelist")
 
         customcallbacks.limit_change_callback = CustomJS(args=dict(
             limits_source=datasources.limits_source,
@@ -578,9 +680,12 @@ class QuantStatsVisualizer:
             select=inputwidgets.table_view_select,
             name_input=inputwidgets.name_input,
             plot=self.plot,
+            boxplot=self.boxplot,
             min_thresh_filter=tableobjects.filters.min_thresh_filter,
             max_thresh_filter=tableobjects.filters.max_thresh_filter,
             name_filter=tableobjects.filters.name_filter,
+            selection_columns=selection_columns,
+            mode=mode,
         ), code=(Path(__file__).parent / "quant_stats_visualization_JS_code/utils.js").read_text("utf8") + (Path(__file__).parent / "quant_stats_visualization_JS_code/reset_callback.js").read_text("utf8"))
 
         customcallbacks.name_filter_callback = CustomJS(args=dict(
@@ -608,6 +713,9 @@ class QuantStatsVisualizer:
             table_data_source=datasources.table_data_source,
             selected_data_source=datasources.selected_data_source,
             limits_source=datasources.limits_source,
+            boxplot=self.boxplot,
+            selection_columns=selection_columns,
+            mode=mode,
         ), code=(Path(__file__).parent / "quant_stats_visualization_JS_code/utils.js").read_text("utf8") + (Path(__file__).parent / "quant_stats_visualization_JS_code/table_selection_callback.js").read_text("utf8"))
 
         return customcallbacks
@@ -622,7 +730,7 @@ class QuantStatsVisualizer:
         inputwidgets.table_view_select.js_on_change('value', customcallbacks.select_table_view_callback)
         datasources.table_data_source.selected.js_on_change('indices', customcallbacks.table_selection_callback)
 
-    def _create_layout(self, inputwidgets, tableobjects):
+    def _create_layout(self, inputwidgets, tableobjects, mode):
         heading_1 = Div(text="<h2>Quant Stats Visualizer</h2>")
         heading_2 = Div(text="<h2>Quant Stats Data Table</h2>")
 
@@ -631,17 +739,25 @@ class QuantStatsVisualizer:
         row1 = row(inputwidgets.ymin_input, inputwidgets.ymax_input)
         row2 = row(inputwidgets.minclip_input, inputwidgets.maxclip_input)
         inputs1 = column(row1, row2)
-        layout = column(heading_1, inputs1, sp1, self.plot,
-                        column(heading_2, row(inputwidgets.table_view_select, inputwidgets.name_input),
-                               tableobjects.data_table))
+        if mode == "basic":
+            layout = column(heading_1, inputs1, sp1, self.plot,
+                            column(heading_2, row(inputwidgets.table_view_select, inputwidgets.name_input),
+                                   tableobjects.data_table))
+        elif mode == "advanced":
+            layout = column(heading_1, inputs1, sp1, row(self.plot, self.boxplot),
+                            column(heading_2, row(inputwidgets.table_view_select, inputwidgets.name_input),
+                                   tableobjects.data_table))
+        else:
+            raise ValueError(f"Expected mode to be 'basic' or 'advanced', got '{mode}'.")
 
         return layout
 
-    def export_plot_as_html(self, save_path: str) -> None:
+    def export_plot_as_html(self, save_path: str, mode: str) -> None:
         """
         Method for constructing the visualization and saving it to the given path.
 
         :param save_path: Path for saving the visualization.
+        :param mode: Whether to plot basic or advanced stats.
         """
 
         curdoc().theme = 'light_minimal'
@@ -669,10 +785,17 @@ class QuantStatsVisualizer:
         datasources = DataSources(stats_dict=self.stats_dict,
                                   plot=self.plot,
                                   default_values=self.default_values,
+                                  percentiles=self.percentiles
                                   )
 
         # Creating plot objects
         selections = self._add_plot_lines(datasources)
+
+        if mode == "advanced":
+            self.boxplot.width = QuantStatsVisualizer.plot_dims["boxplot_width"]
+            self.boxplot.height = QuantStatsVisualizer.plot_dims["boxplot_height"]
+            self.boxplot.y_range = Range1d()
+            self._add_boxplots(datasources)
 
         # Defining the table objects and name filter views
         tableobjects = TableObjects(datasources)
@@ -689,14 +812,14 @@ class QuantStatsVisualizer:
         inputwidgets = InputWidgets(self.default_values)
 
         # Defining Custom JavaScript callbacks
-        customcallbacks = self._define_callbacks(datasources, tableobjects, inputwidgets)
+        customcallbacks = self._define_callbacks(datasources, tableobjects, inputwidgets, mode)
 
         # Attach events to corresponding callbacks
         curdoc().js_on_event(DocumentReady, customcallbacks.reset_callback)
         self._attach_callbacks(datasources, inputwidgets, customcallbacks)
 
         # Define the formatting
-        layout = self._create_layout(inputwidgets, tableobjects)
+        layout = self._create_layout(inputwidgets, tableobjects, mode)
 
         # Save as standalone html
         save(layout, save_path)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/limit_change_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/limit_change_callback.js
@@ -36,58 +36,34 @@
 
 
 // Reading values from input widgets and setting plot y axis range
-const limits_data = limits_source.data;
-limits_data['ymax'] = [parseFloat(ymax_input.value)];
-limits_data['ymin'] = [parseFloat(ymin_input.value)];
-plot.y_range.start = limits_data['ymin'][0]*1.05;
-plot.y_range.end = limits_data['ymax'][0]*1.05;
-limits_data['maxclip'] = [parseFloat(maxclip_input.value)];
-limits_data['minclip'] = [parseFloat(minclip_input.value)];
+limits_source.data['ymax'] = [parseFloat(ymax_input.value)];
+limits_source.data['ymin'] = [parseFloat(ymin_input.value)];
+plot.y_range.start = limits_source.data['ymin'][0]*1.05;
+plot.y_range.end = limits_source.data['ymax'][0]*1.05;
+limits_source.data['maxclip'] = [parseFloat(maxclip_input.value)];
+limits_source.data['minclip'] = [parseFloat(minclip_input.value)];
 
-const source_data = data_source.data;
-const idx = source_data['idx'];
-const minlist = source_data['minlist'];
-const maxlist = source_data['maxlist'];
-const namelist = source_data['namelist'];
-source_data['marker_yminlist'] = source_data['minlist'].map(t => findMax(t, limits_data['ymin'][0]));
-source_data['marker_ymaxlist'] = source_data['maxlist'].map(t => findMin(t, limits_data['ymax'][0]));
+data_source.data['marker_yminlist'] = data_source.data['minlist'].map(t => findMax(t, limits_source.data['ymin'][0]));
+data_source.data['marker_ymaxlist'] = data_source.data['maxlist'].map(t => findMin(t, limits_source.data['ymax'][0]));
 
 // Updating the filters for finding layers that cross the min or max thresholds
-min_thresh_filter.booleans = minlist.map(t => t <= limits_data['minclip'][0]);
-max_thresh_filter.booleans = maxlist.map(t => t >= limits_data['maxclip'][0]);
-
-let table_booleans;
-const table_idx = [];
-const table_namelist = [];
-const table_minlist = [];
-const table_maxlist = [];
+min_thresh_filter.booleans = data_source.data['minlist'].map(t => t <= limits_source.data['minclip'][0]);
+max_thresh_filter.booleans = data_source.data['maxlist'].map(t => t >= limits_source.data['maxclip'][0]);
 
 var view = select.value;
-if (view == "All") {
-    table_booleans = name_filter.booleans;
-} else if (view == "Min") {
-    table_booleans = booleanAnd(name_filter.booleans, min_thresh_filter.booleans);
-} else if (view == "Max") {
-    table_booleans = booleanAnd(name_filter.booleans, max_thresh_filter.booleans);
-} else if (view == "Min | Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanOr(min_thresh_filter.booleans, max_thresh_filter.booleans));
-} else if (view == "Min & Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanAnd(min_thresh_filter.booleans, max_thresh_filter.booleans));
+let table_booleans = process_table_view(view, name_filter, min_thresh_filter, max_thresh_filter);
+
+for (let j = 0; j < table_columns.length; j++) {
+    table_data_source.data[table_columns[j]] = [];
 }
 
-for (let i = 0; i < idx.length; i++) {
+for (let i = 0; i < data_source.data['idx'].length; i++) {
     if (table_booleans[i] == true) {
-        table_idx.push(idx[i]);
-        table_namelist.push(namelist[i]);
-        table_minlist.push(minlist[i]);
-        table_maxlist.push(maxlist[i]);
+        for (let j = 0; j < table_columns.length; j++) {
+            table_data_source.data[table_columns[j]].push(data_source.data[table_columns[j]][i]);
+        }
     }
 }
-
-table_data_source.data["idx"] = table_idx;
-table_data_source.data["namelist"] = table_namelist;
-table_data_source.data["minlist"] = table_minlist;
-table_data_source.data["maxlist"] = table_maxlist;
 
 selected_data_source.data["floor"].push(limits_source.data['ymin'][0]*1.05);
 selected_data_source.data["ceil"].push(limits_source.data['ymax'][0]*1.05);

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/name_filter_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/name_filter_callback.js
@@ -38,52 +38,27 @@
 // Filter all names having entered pattern as a substring
 name_filter.booleans = Array.from(data_source.data['namelist']).map(t => t.includes(cb_obj.value));
 
-const limits_data = limits_source.data;
-const source_data = data_source.data;
-const idx = source_data['idx'];
-const minlist = source_data['minlist'];
-const maxlist = source_data['maxlist'];
-const namelist = source_data['namelist'];
-
-let table_booleans;
-const table_idx = [];
-const table_namelist = [];
-const table_minlist = [];
-const table_maxlist = [];
-
 var view = select.value;
-if (view == "All") {
-    table_booleans = name_filter.booleans;
-} else if (view == "Min") {
-    table_booleans = booleanAnd(name_filter.booleans, min_thresh_filter.booleans);
-} else if (view == "Max") {
-    table_booleans = booleanAnd(name_filter.booleans, max_thresh_filter.booleans);
-} else if (view == "Min | Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanOr(min_thresh_filter.booleans, max_thresh_filter.booleans));
-} else if (view == "Min & Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanAnd(min_thresh_filter.booleans, max_thresh_filter.booleans));
+let table_booleans = process_table_view(view, name_filter, min_thresh_filter, max_thresh_filter);
+
+for (let j = 0; j < table_columns.length; j++) {
+    table_data_source.data[table_columns[j]] = [];
 }
 
-for (let i = 0; i < idx.length; i++) {
+for (let i = 0; i < data_source.data['idx'].length; i++) {
     if (table_booleans[i] == true) {
-        table_idx.push(idx[i]);
-        table_namelist.push(namelist[i]);
-        table_minlist.push(minlist[i]);
-        table_maxlist.push(maxlist[i]);
+        for (let j = 0; j < table_columns.length; j++) {
+            table_data_source.data[table_columns[j]].push(data_source.data[table_columns[j]][i]);
+        }
     }
 }
-
-table_data_source.data["idx"] = table_idx;
-table_data_source.data["namelist"] = table_namelist;
-table_data_source.data["minlist"] = table_minlist;
-table_data_source.data["maxlist"] = table_maxlist;
 
 table_data_source.change.emit();
 
 const selected_indices = [];
 var layer_idx;
-for (let i = 0; i < table_idx.length; i++) {
-    layer_idx = table_idx[i];
+for (let i = 0; i < table_data_source.data['idx'].length; i++) {
+    layer_idx = table_data_source.data['idx'][i];
     if (data_source.data["selected"][layer_idx] == true) {
         selected_indices.push(i);
     }
@@ -92,5 +67,7 @@ for (let i = 0; i < table_idx.length; i++) {
 table_data_source.selected.indices = selected_indices;
 
 table_data_source.change.emit();
+
+// Change inconsequential property of table to make it re-render
 table.name = "placeholder_1";
 table.name = "placeholder_0";

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/reset_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/reset_callback.js
@@ -108,12 +108,16 @@ table_data_source.data["maxlist"] = table_maxlist;
 table_data_source.selected.indices = [];
 data_source.data["selected"] = Array(data_source.data["idx"].length).fill(false);
 
-selected_data_source.data["idx"] = [];
-selected_data_source.data["namelist"] = [];
 selected_data_source.data["floor"] = [];
 selected_data_source.data["ceil"] = [];
-selected_data_source.data["minlist"] = [];
-selected_data_source.data["maxlist"] = [];
+
+for (let j = 0; j < selection_columns.length; j++) {
+    selected_data_source.data[selection_columns[j]] = [];
+}
+
+if (mode == "advanced") {
+    boxplot.x_range.factors = [];
+}
 
 // Emitting the changes made to ColumnDataSources
 limits_source.change.emit();

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/reset_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/reset_callback.js
@@ -42,68 +42,39 @@ limits_source.data['xmax'] = default_values_source.data['default_xmax'];
 limits_source.data['xmin'] = default_values_source.data['default_xmin'];
 limits_source.data['maxclip'] = default_values_source.data['default_maxclip'];
 limits_source.data['minclip'] = default_values_source.data['default_minclip'];
-const limits_data = limits_source.data;
 
 // Resetting the plot ranges
-plot.y_range.start = limits_data['ymin'][0]*1.05;
-plot.y_range.end = limits_data['ymax'][0]*1.05;
-plot.x_range.start = limits_data['xmin'][0];
-plot.x_range.end = limits_data['xmax'][0];
+plot.y_range.start = limits_source.data['ymin'][0]*1.05;
+plot.y_range.end = limits_source.data['ymax'][0]*1.05;
+plot.x_range.start = limits_source.data['xmin'][0];
+plot.x_range.end = limits_source.data['xmax'][0];
 
 // Resetting the input widget values
-ymax_input.value = limits_data['ymax'][0].toString();
-ymin_input.value = limits_data['ymin'][0].toString();
-maxclip_input.value = limits_data['maxclip'][0].toString();
-minclip_input.value = limits_data['minclip'][0].toString();
+ymax_input.value = limits_source.data['ymax'][0].toString();
+ymin_input.value = limits_source.data['ymin'][0].toString();
+maxclip_input.value = limits_source.data['maxclip'][0].toString();
+minclip_input.value = limits_source.data['minclip'][0].toString();
 
-const source_data = data_source.data;
-const idx = source_data['idx'];
-const minlist = source_data['minlist'];
-const maxlist = source_data['maxlist'];
-const namelist = source_data['namelist'];
+data_source.data['marker_yminlist'] = data_source.data['minlist'].map(t => findMax(t, limits_source.data['ymin'][0]));
+data_source.data['marker_ymaxlist'] = data_source.data['maxlist'].map(t => findMin(t, limits_source.data['ymax'][0]));
 
-source_data['marker_yminlist'] = source_data['minlist'].map(t => findMax(t, limits_data['ymin'][0]));
-source_data['marker_ymaxlist'] = source_data['maxlist'].map(t => findMin(t, limits_data['ymax'][0]));
+min_thresh_filter.booleans = data_source.data['minlist'].map(t => t <= limits_source.data['minclip'][0]);
+max_thresh_filter.booleans = data_source.data['maxlist'].map(t => t >= limits_source.data['maxclip'][0]);
 
-min_thresh_filter.booleans = minlist.map(t => t <= limits_data['minclip'][0]);
-max_thresh_filter.booleans = maxlist.map(t => t >= limits_data['maxclip'][0]);
-
-name_filter.booleans = Array(idx.length).fill(true);
+name_filter.booleans = Array(data_source.data['idx'].length).fill(true);
 name_input.value = "";
-
-let table_booleans;
-const table_idx = [];
-const table_namelist = [];
-const table_minlist = [];
-const table_maxlist = [];
 
 select.value = "Min | Max";
 var view = select.value;
-if (view == "All") {
-    table_booleans = name_filter.booleans;
-} else if (view == "Min") {
-    table_booleans = booleanAnd(name_filter.booleans, min_thresh_filter.booleans);
-} else if (view == "Max") {
-    table_booleans = booleanAnd(name_filter.booleans, max_thresh_filter.booleans);
-} else if (view == "Min | Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanOr(min_thresh_filter.booleans, max_thresh_filter.booleans));
-} else if (view == "Min & Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanAnd(min_thresh_filter.booleans, max_thresh_filter.booleans));
-}
+let table_booleans = process_table_view(view, name_filter, min_thresh_filter, max_thresh_filter);
 
-for (let i = 0; i < idx.length; i++) {
+for (let i = 0; i < data_source.data['idx'].length; i++) {
     if (table_booleans[i] == true) {
-        table_idx.push(idx[i]);
-        table_namelist.push(namelist[i]);
-        table_minlist.push(minlist[i]);
-        table_maxlist.push(maxlist[i]);
+        for (let j = 0; j < table_columns.length; j++) {
+            table_data_source.data[table_columns[j]].push(data_source.data[table_columns[j]][i]);
+        }
     }
 }
-
-table_data_source.data["idx"] = table_idx;
-table_data_source.data["namelist"] = table_namelist;
-table_data_source.data["minlist"] = table_minlist;
-table_data_source.data["maxlist"] = table_maxlist;
 
 table_data_source.selected.indices = [];
 data_source.data["selected"] = Array(data_source.data["idx"].length).fill(false);
@@ -117,6 +88,7 @@ for (let j = 0; j < selection_columns.length; j++) {
 
 if (mode == "advanced") {
     boxplot.x_range.factors = [];
+    boxplot.width = boxplot_unit_width * 5;
 }
 
 // Emitting the changes made to ColumnDataSources

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/select_table_view_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/select_table_view_callback.js
@@ -35,51 +35,27 @@
 // =============================================================================
 
 
-const source_data = data_source.data;
-const idx = source_data['idx'];
-const minlist = source_data['minlist'];
-const maxlist = source_data['maxlist'];
-const namelist = source_data['namelist'];
-
-let table_booleans;
-const table_idx = [];
-const table_namelist = [];
-const table_minlist = [];
-const table_maxlist = [];
-
 var view = select.value;
-if (view == "All") {
-    table_booleans = name_filter.booleans;
-} else if (view == "Min") {
-    table_booleans = booleanAnd(name_filter.booleans, min_thresh_filter.booleans);
-} else if (view == "Max") {
-    table_booleans = booleanAnd(name_filter.booleans, max_thresh_filter.booleans);
-} else if (view == "Min | Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanOr(min_thresh_filter.booleans, max_thresh_filter.booleans));
-} else if (view == "Min & Max") {
-    table_booleans = booleanAnd(name_filter.booleans, booleanAnd(min_thresh_filter.booleans, max_thresh_filter.booleans));
+let table_booleans = process_table_view(view, name_filter, min_thresh_filter, max_thresh_filter);
+
+for (let j = 0; j < table_columns.length; j++) {
+    table_data_source.data[table_columns[j]] = [];
 }
 
-for (let i = 0; i < idx.length; i++) {
+for (let i = 0; i < data_source.data['idx'].length; i++) {
     if (table_booleans[i] == true) {
-        table_idx.push(idx[i]);
-        table_namelist.push(namelist[i]);
-        table_minlist.push(minlist[i]);
-        table_maxlist.push(maxlist[i]);
+        for (let j = 0; j < table_columns.length; j++) {
+            table_data_source.data[table_columns[j]].push(data_source.data[table_columns[j]][i]);
+        }
     }
 }
-
-table_data_source.data["idx"] = table_idx;
-table_data_source.data["namelist"] = table_namelist;
-table_data_source.data["minlist"] = table_minlist;
-table_data_source.data["maxlist"] = table_maxlist;
 
 table_data_source.change.emit();
 
 const selected_indices = [];
 var layer_idx;
-for (let i = 0; i < table_idx.length; i++) {
-    layer_idx = table_idx[i];
+for (let i = 0; i < table_data_source.data['idx'].length; i++) {
+    layer_idx = table_data_source.data['idx'][i];
     if (data_source.data["selected"][layer_idx] == true) {
         selected_indices.push(i);
     }

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/table_selection_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/table_selection_callback.js
@@ -72,6 +72,12 @@ if (mode=="advanced") {
     let box_abs = arrayMax([box_max, -box_min, whisker_max, -whisker_min]);
     boxplot.y_range.start = -box_abs;
     boxplot.y_range.end = box_abs;
+    if (selected_data_source.data['idx'].length > 5) {
+        boxplot.width = boxplot_unit_width * selected_data_source.data['idx'].length;
+    }
+    else {
+        boxplot.width = boxplot_unit_width * 5;
+    }
 }
 
 selected_data_source.change.emit();

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/table_selection_callback.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/table_selection_callback.js
@@ -44,22 +44,34 @@ table_data_source.selected.indices.forEach(i => {
 });
 data_source.change.emit();
 
-selected_data_source.data["namelist"] = [];
-selected_data_source.data["idx"] = [];
 selected_data_source.data["floor"] = [];
 selected_data_source.data["ceil"] = [];
-selected_data_source.data["minlist"] = [];
-selected_data_source.data["maxlist"] = [];
+
+for (let j = 0; j < selection_columns.length; j++) {
+    selected_data_source.data[selection_columns[j]] = [];
+}
+
 selected_data_source.change.emit();
 
 data_source.data["selected"].forEach((bool,index) => {
     if (bool==true) {
-        selected_data_source.data["namelist"].push(data_source.data["namelist"][index]);
-        selected_data_source.data["idx"].push(index);
         selected_data_source.data["floor"].push(limits_source.data['ymin'][0]*1.05);
         selected_data_source.data["ceil"].push(limits_source.data['ymax'][0]*1.05);
-        selected_data_source.data["minlist"].push(data_source.data["minlist"][index]);
-        selected_data_source.data["maxlist"].push(data_source.data["maxlist"][index]);
+        for (let j = 0; j < selection_columns.length; j++) {
+            selected_data_source.data[selection_columns[j]].push(data_source.data[selection_columns[j]][index]);
+        }
     }
 })
+
+if (mode=="advanced") {
+    boxplot.x_range.factors = selected_data_source.data["stridx"];
+    let box_min = arrayMin(selected_data_source.data["minlist"]) * 1.2;
+    let box_max = arrayMax(selected_data_source.data["maxlist"]) * 1.2;
+    let whisker_min = arrayMin(selected_data_source.data["boxplot_lower_list"]) * 1.2;
+    let whisker_max = arrayMax(selected_data_source.data["boxplot_upper_list"]) * 1.2;
+    let box_abs = arrayMax([box_max, -box_min, whisker_max, -whisker_min]);
+    boxplot.y_range.start = -box_abs;
+    boxplot.y_range.end = box_abs;
+}
+
 selected_data_source.change.emit();

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/utils.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/utils.js
@@ -56,3 +56,27 @@ function findMax(a, b) {
     }
     return b;
 }
+
+function arrayMin(arr) {
+    var min;
+    arr.forEach((val, index) => {
+        if (index==0) {
+            min = val;
+        } else {
+            min = findMin(val, min);
+        }
+    })
+    return min;
+}
+
+function arrayMax(arr) {
+    var max;
+    arr.forEach((val, index) => {
+        if (index==0) {
+            max = val;
+        } else {
+            max = findMax(val, max);
+        }
+    })
+    return max;
+}

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/utils.js
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/visualization_tools/quant_stats_visualization_JS_code/utils.js
@@ -80,3 +80,21 @@ function arrayMax(arr) {
     })
     return max;
 }
+
+function process_table_view(view, name_filter, min_thresh_filter, max_thresh_filter) {
+    let table_booleans;
+
+    if (view == "All") {
+        table_booleans = name_filter.booleans;
+    } else if (view == "Min") {
+        table_booleans = booleanAnd(name_filter.booleans, min_thresh_filter.booleans);
+    } else if (view == "Max") {
+        table_booleans = booleanAnd(name_filter.booleans, max_thresh_filter.booleans);
+    } else if (view == "Min | Max") {
+        table_booleans = booleanAnd(name_filter.booleans, booleanOr(min_thresh_filter.booleans, max_thresh_filter.booleans));
+    } else if (view == "Min & Max") {
+        table_booleans = booleanAnd(name_filter.booleans, booleanAnd(min_thresh_filter.booleans, max_thresh_filter.booleans));
+    }
+
+    return table_booleans
+}


### PR DESCRIPTION
1. Add code for plotting boxplots
2. Backend changes for handling boxplot data
3. Adding labels to additional percentiles shown in boxplots
4. Cleanup JavaScript callbacks by packaging repetitive code as a function in utils
5. Generalize the code in JavaScript callbacks by adaptively iterating over columns present in datasources instead of manually listing them
6. Update docstring for `visualize_advanced_stats`
7. Swapped the order of arguments `save_path` and `additional_percentiles` in `visualize_advanced_stats` for better user experience
8. Dynamically increase width of boxplot if number of selections is large