### PR TITLE
Explicitly disable quantizer if tensor is not float

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -467,6 +467,8 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
                 tensor.dtype in utils.torch_dtypes_to_ignore_for_quantization or \
                 (tensor_quantizer.is_const and torch.numel(tensor) == 1) or \
                 not tensor_quantizer.enabled:
+            # If the tensor is unquantizable or if it's a  scalar-constant, disable the quantizer explicitly
+            tensor_quantizer.enabled = False
             return False
         return True
 


### PR DESCRIPTION
- Backend doesn't expect non-float tensors to have encodings. Compare op's output is a tensor of bools for which the encoding shouldn't have been present. This change fixes this issue by disabling the quantizer.