### PR TITLE
 Fixed torch and ONNX installation instructions (added missing find-links option)

### DIFF
--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -52,9 +52,9 @@ The AIMET PyTorch GPU PyPI packages are available for environments that meet the
 
 **Pip install**
 
-.. code-block::
+.. code-block:: bash
 
-    apt-get install liblapacke
+    apt-get update && apt-get install liblapacke libpython3.10-dev
     python3 -m pip install aimet-torch
 
 
@@ -62,6 +62,14 @@ Release Packages
 ~~~~~~~~~~~~~~~~
 
 For other AIMET variants, install the *latest* version from the .whl files hosted at https://github.com/quic/aimet/releases
+
+**Prerequisite**
+
+The following pre-requisites apply to all variants. The GPU variants may need additional packages - please see `Advanced Installation Instructions`_ for details. 
+
+.. code-block:: bash
+
+    apt-get update && apt-get install liblapacke libpython3.10-dev
 
 **PyTorch**
 
@@ -93,7 +101,7 @@ For other AIMET variants, install the *latest* version from the .whl files hoste
 .. parsed-literal::
 
     # ONNX 1.16 GPU with CUDA 11.x
-    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cu117\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cu117\ |whl_suffix| -f |torch_pkg_url|
 
     # ONNX 1.16 CPU
     python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cpu\ |whl_suffix|

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -104,7 +104,7 @@ The following pre-requisites apply to all variants. The GPU variants may need ad
     python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cu117\ |whl_suffix| -f |torch_pkg_url|
 
     # ONNX 1.16 CPU
-    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cpu\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_onnx-\ |version|.cpu\ |whl_suffix| -f |torch_pkg_url|
 
 
 For older versions, please browse the releases at https://github.com/quic/aimet/releases and follow the documentation corresponding to that release to select and install the appropriate package.

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -54,14 +54,14 @@ The AIMET PyTorch GPU PyPI packages are available for environments that meet the
 
 .. code-block:: bash
 
-    apt-get update && apt-get install liblapacke libpython3.10-dev
+    apt-get install liblapacke libpython3-dev
     python3 -m pip install aimet-torch
 
 
 Release Packages
 ~~~~~~~~~~~~~~~~
 
-For other AIMET variants, install the *latest* version from the .whl files hosted at https://github.com/quic/aimet/releases
+For other AIMET variants, install the *latest* version from the .whl files hosted at https://github.com/quic/aimet/releases (compatible with python 3.10 only at this time).
 
 **Prerequisite**
 
@@ -71,7 +71,7 @@ The following pre-requisites apply to all variants. The GPU variants may need ad
 .. code-block:: bash
 
     # Install pre-requisite packages
-    apt-get update && apt-get install liblapacke libpython3.10-dev
+    apt-get install liblapacke libpython3-dev
 
     # Install an compatible version of pip (since the latest version is NOT compatible with our wheel packages)
     python3 -m pip install pip==24.0

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -68,13 +68,13 @@ For other AIMET variants, install the *latest* version from the .whl files hoste
 .. parsed-literal::
 
     # Pytorch 2.1 with CUDA 12.x
-    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cu121\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cu121\ |whl_suffix| -f |torch_pkg_url|
 
     # Pytorch 2.1 CPU only
-    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cpu\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cpu\ |whl_suffix| -f |torch_pkg_url|
     
     # Pytorch 1.13 with CUDA 11.x
-    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cu117\ |whl_suffix|
+    python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cu117\ |whl_suffix| -f |torch_pkg_url|
 
 
 **TensorFlow**
@@ -103,6 +103,7 @@ For older versions, please browse the releases at https://github.com/quic/aimet/
 
 .. |whl_suffix| replace:: -cp310-cp310-manylinux_2_34_x86_64.whl
 .. |download_url| replace:: \https://github.com/quic/aimet/releases/download/
+.. |torch_pkg_url| replace:: \https://download.pytorch.org/whl/torch_stable.html
 
 System Requirements
 ~~~~~~~~~~~~~~~~~~~

--- a/Docs/install/index.rst
+++ b/Docs/install/index.rst
@@ -65,11 +65,17 @@ For other AIMET variants, install the *latest* version from the .whl files hoste
 
 **Prerequisite**
 
-The following pre-requisites apply to all variants. The GPU variants may need additional packages - please see `Advanced Installation Instructions`_ for details. 
+The following pre-requisites apply to all variants. The GPU variants may need additional packages - please see `Advanced Installation Instructions`_ for details.
+
 
 .. code-block:: bash
 
+    # Install pre-requisite packages
     apt-get update && apt-get install liblapacke libpython3.10-dev
+
+    # Install an compatible version of pip (since the latest version is NOT compatible with our wheel packages)
+    python3 -m pip install pip==24.0
+
 
 **PyTorch**
 
@@ -80,7 +86,7 @@ The following pre-requisites apply to all variants. The GPU variants may need ad
 
     # Pytorch 2.1 CPU only
     python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cpu\ |whl_suffix| -f |torch_pkg_url|
-    
+
     # Pytorch 1.13 with CUDA 11.x
     python3 -m pip install |download_url|\ |version|/aimet_torch-\ |version|.cu117\ |whl_suffix| -f |torch_pkg_url|
 
@@ -96,7 +102,7 @@ The following pre-requisites apply to all variants. The GPU variants may need ad
     python3 -m pip install |download_url|\ |version|/aimet_tensorflow-\ |version|.cpu\ |whl_suffix|
 
 
-**Onnx**
+**ONNX**
 
 .. parsed-literal::
 

--- a/Docs/install/install_docker.rst
+++ b/Docs/install/install_docker.rst
@@ -161,12 +161,16 @@ Set the package details as follows:
     export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
 
 Install the selected AIMET package as specified below:
+
 **NOTE:** Python dependencies will automatically get installed.
 
 .. code-block:: bash
 
-    python3 -m pip install ${download_url}/${wheel_file_name} ${find_pkg_url_str}
+    # Install an compatible version of pip (since the latest version is NOT compatible with our wheel packages)
+    python3 -m pip install pip==24.0
 
+    # Install the wheel package
+    python3 -m pip install ${download_url}/${wheel_file_name} ${find_pkg_url_str}
 
 Environment setup
 ~~~~~~~~~~~~~~~~~
@@ -176,4 +180,3 @@ Set the common environment variables as follows:
 .. code-block:: bash
 
     source /usr/local/lib/python3.10/dist-packages/aimet_common/bin/envsetup.sh
-

--- a/Docs/install/install_docker.rst
+++ b/Docs/install/install_docker.rst
@@ -157,12 +157,15 @@ Set the package details as follows:
     # ex. "aimet_torch-1.34.0.cu121-cp310-cp310-manylinux_2_34_x86_64.whl"
     export wheel_file_name="<wheel file name>"
 
+    # NOTE: Do the following ONLY for the PyTorch variant packages!
+    export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
+
 Install the selected AIMET package as specified below:
 **NOTE:** Python dependencies will automatically get installed.
 
 .. code-block:: bash
 
-    python3 -m pip install ${download_url}/${wheel_file_name}
+    python3 -m pip install ${download_url}/${wheel_file_name} ${find_pkg_url_str}
 
 
 Environment setup

--- a/Docs/install/install_docker.rst
+++ b/Docs/install/install_docker.rst
@@ -157,7 +157,7 @@ Set the package details as follows:
     # ex. "aimet_torch-1.34.0.cu121-cp310-cp310-manylinux_2_34_x86_64.whl"
     export wheel_file_name="<wheel file name>"
 
-    # NOTE: Do the following ONLY for the PyTorch variant packages!
+    # NOTE: Do the following ONLY for the PyTorch and ONNX variant packages!
     export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
 
 Install the selected AIMET package as specified below:

--- a/Docs/install/install_host.rst
+++ b/Docs/install/install_host.rst
@@ -137,12 +137,15 @@ Set the package details as follows:
     # ex. "aimet_torch-1.33.0.cu121-cp310-cp310-manylinux_2_34_x86_64.whl"
     export wheel_file_name="<wheel file name>"
 
+    # NOTE: Do the following ONLY for the PyTorch variant packages!
+    export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
+
 Install the selected AIMET package as specified below:
 **NOTE:** Python dependencies will automatically get installed.
 
 .. code-block:: bash
 
-    python3 -m pip install ${download_url}/${wheel_file_name}
+    python3 -m pip install ${download_url}/${wheel_file_name} ${find_pkg_url_str}
 
 Install common debian packages
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Docs/install/install_host.rst
+++ b/Docs/install/install_host.rst
@@ -137,7 +137,7 @@ Set the package details as follows:
     # ex. "aimet_torch-1.33.0.cu121-cp310-cp310-manylinux_2_34_x86_64.whl"
     export wheel_file_name="<wheel file name>"
 
-    # NOTE: Do the following ONLY for the PyTorch variant packages!
+    # NOTE: Do the following ONLY for the PyTorch and ONNX variant packages!
     export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
 
 Install the selected AIMET package as specified below:

--- a/Docs/install/install_host.rst
+++ b/Docs/install/install_host.rst
@@ -141,10 +141,15 @@ Set the package details as follows:
     export find_pkg_url_str="-f https://download.pytorch.org/whl/torch_stable.html"
 
 Install the selected AIMET package as specified below:
+
 **NOTE:** Python dependencies will automatically get installed.
 
 .. code-block:: bash
 
+    # Install an compatible version of pip (since the latest version is NOT compatible with our wheel packages)
+    python3 -m pip install pip==24.0
+
+    # Install the wheel package
     python3 -m pip install ${download_url}/${wheel_file_name} ${find_pkg_url_str}
 
 Install common debian packages
@@ -240,4 +245,3 @@ Set the common environment variables as follows:
 .. code-block:: bash
 
     source /usr/local/lib/python3.10/dist-packages/aimet_common/bin/envsetup.sh
-


### PR DESCRIPTION
- Added missing find-links URL option to torch and ONNX installation instructions
- Fixed onnx wheel instructions, added common pre-requisites
- Added pip version pinning
