### PR TITLE
fix/Fix per-channel quantization bug in multi-output for aimet_onnx

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -519,9 +519,10 @@ class ConnectedGraph(AimetCommonConnectedGraph):
                 del self._products[product.name]
             else:
                 for output in self.model.graph.output:
-                    if output.name in product.name:
+                    if product.name.startswith(output.name + '_to_') or \
+                        product.name.endswith('_to_' + output.name) or \
+                        product.name == output.name:
                         del self._products[product.name]
-                        self._create_link_for_output_product(output.name, branch_op.name)
 
         self._products[branch_op_product.name] = branch_op_product
 


### PR DESCRIPTION
1. Ignore output connections in branches with multiple outputs to properly track ordered_ops.
2. Prevent malfunction when multiple outputs have partially overlapping names.