### PR TITLE
Allow defining non-leaf quantized modules

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -1246,6 +1246,10 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         :param trace: torch.jit trace of the module
         :return: Boolean whether recursive parsing needed or not. If needed returns True, False otherwise.
         """
+        from aimet_torch.v2.nn import BaseQuantizationMixin
+        if isinstance(module, BaseQuantizationMixin):
+            return self._is_recursive_parsing_needed(module.get_original_module(), trace)
+
         recursive_parsing_needed = True
         if is_torch_nn_leaf_module(module) or \
                 is_custom_leaf_module(module, self._find_aten_nodes_in_forward_pass(trace)) or \

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -778,7 +778,7 @@ def get_inout_tensor_shape_per_module(model: torch.nn.Module, input_tensor) -> D
 
         inout_tensor_shape_map[module] = (input_tensor_shape_list, output_tensor_shape_list)
 
-    run_hook_for_layers_with_given_input(model, input_tensor, record_tensor_shape)
+    run_hook_for_layers_with_given_input(model, input_tensor, record_tensor_shape, leaf_node_only=False)
     return inout_tensor_shape_map
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -315,15 +315,11 @@ class QuantizationSimModel:
         """
         for module_name, module_ref in model.named_children():
             if isinstance(module_ref, LazyQuantizeWrapper):
-                quantized_module = self._realize_quant_wrapper(module_ref)
+                quantized_module = module_ref.realize_v1_wrapper()
                 setattr(model, module_name, quantized_module)
 
             elif not utils.is_leaf_module(module_ref):
                 self._realize_quant_wrappers_in_model(module_ref)
-
-    @staticmethod
-    def _realize_quant_wrapper(module: torch.nn.Module) -> QcQuantizeWrapper:
-        return module.realize_v1_wrapper()
 
     def get_supported_kernels(self) -> Dict:
         """

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer_.py
@@ -656,10 +656,10 @@ class TestQuantizationSimStaticGrad:
                 return self.layers[2](inputs[0])
 
         model = Net()
-        sim = QuantizationSimModel(model, dummy_input=torch.rand(1, 1, 12, 12),
-                                   quant_scheme=QuantScheme.post_training_tf)
+        with pytest.raises(RuntimeError):
+            sim = QuantizationSimModel(model, dummy_input=torch.rand(1, 1, 12, 12),
+                                       quant_scheme=QuantScheme.post_training_tf)
 
-        self.verify_quantization_wrappers(model, sim.model)
 
     def test_add_quantization_wrappers_with_modulelist_two_deep(self):
         """With a two-deep model using ModuleList"""
@@ -691,10 +691,9 @@ class TestQuantizationSimStaticGrad:
                 return self.layers[2](inputs[0])
 
         model = Net()
-        sim = QuantizationSimModel(model, dummy_input=torch.rand(1, 3, 12, 12),
-                                   quant_scheme=QuantScheme.post_training_tf)
-
-        self.verify_quantization_wrappers(model, sim.model)
+        with pytest.raises(RuntimeError):
+            sim = QuantizationSimModel(model, dummy_input=torch.rand(1, 3, 12, 12),
+                                       quant_scheme=QuantScheme.post_training_tf)
 
     def test_add_quantization_wrappers_with_modulelist_with_layers_to_ignore(self):
         """With a two-deep model using ModuleList and layers_to_ignore"""


### PR DESCRIPTION
**This is a preliminary PR for supporting lora in aimet v2 more transparently**.

### Main changes (2bfa8e8)
This PR changes the internal workflow of QuantizationSimModel.\_\_init\_\_

**Current workflow**
1. Run jit trace and create connected graph
2. Quantsim configurator will configure each layer with proper settings
3. Convert torch.nn modules into aimet.nn quantized modules

**New workflow**
Reordered the above workflow into 3 -> 1 -> 2


### What this PR makes possible
* Now we can define non-leaf quantized modules
  * For example, now we can define `QuantizedLoraLinear`, a quantized definition of a `lora.Linear` which is non-leaf
```py
from peft.tuners.lora.layer import Linear as LoraLinear

@QuantizationMixin.implements(LoraLinear)
class QuantizedLoraLinear(QuantizationMixin, LoraLinear):
    def __quant_init__(self):
        raise NotImplementedError # TODO
```