### PR TITLE
Onnx memory optimization

### DIFF
--- a/Docs/api_docs/onnx_adaround.rst
+++ b/Docs/api_docs/onnx_adaround.rst
@@ -21,6 +21,10 @@ Adaround Parameters
     :members:
 
 
+**Note** :
+ - It is recommended to use onnx-simplifier before adarounding the model.
+
+
 Code Example - Adaptive Rounding (AdaRound)
 ===========================================
 
@@ -30,7 +34,7 @@ This example shows how to use AIMET to perform Adaptive Rounding (AdaRound).
 
 .. literalinclude:: ../onnx_code_examples/adaround.py
     :language: python
-    :lines: 41-42
+    :lines: 41-43
 
 **User should write this function to pass calibration data**
 

--- a/Docs/api_docs/onnx_adaround.rst
+++ b/Docs/api_docs/onnx_adaround.rst
@@ -21,8 +21,7 @@ Adaround Parameters
     :members:
 
 
-**Note** :
- - It is recommended to use onnx-simplifier before adarounding the model.
+**Note:** It is recommended to use onnx-simplifier before adarounding the model.
 
 
 Code Example - Adaptive Rounding (AdaRound)

--- a/Docs/api_docs/onnx_auto_quant.rst
+++ b/Docs/api_docs/onnx_auto_quant.rst
@@ -16,6 +16,11 @@ Top-level API
     :members:
     :member-order: bysource
 
+
+**Note** :
+ - It is recommended to use onnx-simplifier before applying auto-quant.
+
+
 Code Examples
 ===============
 .. literalinclude:: ../onnx_code_examples/auto_quant_v2.py

--- a/Docs/api_docs/onnx_auto_quant.rst
+++ b/Docs/api_docs/onnx_auto_quant.rst
@@ -17,8 +17,7 @@ Top-level API
     :member-order: bysource
 
 
-**Note** :
- - It is recommended to use onnx-simplifier before applying auto-quant.
+**Note:** It is recommended to use onnx-simplifier before applying auto-quant.
 
 
 Code Examples

--- a/Docs/api_docs/onnx_cross_layer_equalization.rst
+++ b/Docs/api_docs/onnx_cross_layer_equalization.rst
@@ -31,8 +31,7 @@ Note: High Bias fold will not happen when the below API is used, if the model do
 
 |
 
-**Note** :
- - It is recommended to use onnx-simplifier before applying cross layer equalization.
+**Note:** It is recommended to use onnx-simplifier before applying cross layer equalization.
 
 
 Code Example

--- a/Docs/api_docs/onnx_cross_layer_equalization.rst
+++ b/Docs/api_docs/onnx_cross_layer_equalization.rst
@@ -31,6 +31,10 @@ Note: High Bias fold will not happen when the below API is used, if the model do
 
 |
 
+**Note** :
+ - It is recommended to use onnx-simplifier before applying cross layer equalization.
+
+
 Code Example
 ============
 
@@ -38,7 +42,7 @@ Code Example
 
 .. literalinclude:: ../onnx_code_examples/cross_layer_equalization.py
     :language: python
-    :lines: 39
+    :lines: 39-40
 
 
 **Cross Layer Equalization in auto mode**

--- a/Docs/api_docs/onnx_mixed_precision.rst
+++ b/Docs/api_docs/onnx_mixed_precision.rst
@@ -11,8 +11,7 @@ Top-level API
 
 |
 
-**Note** :
- - It is recommended to use onnx-simplifier before applying mixed-precision.
+**Note:** It is recommended to use onnx-simplifier before applying mixed-precision.
 
 
 Quantizer Groups definition

--- a/Docs/api_docs/onnx_mixed_precision.rst
+++ b/Docs/api_docs/onnx_mixed_precision.rst
@@ -11,6 +11,10 @@ Top-level API
 
 |
 
+**Note** :
+ - It is recommended to use onnx-simplifier before applying mixed-precision.
+
+
 Quantizer Groups definition
 ===========================
 .. autoclass:: aimet_onnx.amp.quantizer_groups.QuantizerGroup

--- a/Docs/api_docs/onnx_quant_analyzer.rst
+++ b/Docs/api_docs/onnx_quant_analyzer.rst
@@ -18,6 +18,11 @@ Top-level API
 |
 .. automethod:: aimet_onnx.quant_analyzer.QuantAnalyzer.analyze
 
+
+**Note** :
+ - It is recommended to use onnx-simplifier before applying quant-analyzer.
+
+
 Run specific utility
 =============
 We can avoid running all the utilities that Quant Analyzer offers and only run those of our interest. For this we

--- a/Docs/api_docs/onnx_quant_analyzer.rst
+++ b/Docs/api_docs/onnx_quant_analyzer.rst
@@ -19,8 +19,7 @@ Top-level API
 .. automethod:: aimet_onnx.quant_analyzer.QuantAnalyzer.analyze
 
 
-**Note** :
- - It is recommended to use onnx-simplifier before applying quant-analyzer.
+**Note:** It is recommended to use onnx-simplifier before applying quant-analyzer.
 
 
 Run specific utility

--- a/Docs/api_docs/onnx_quantsim.rst
+++ b/Docs/api_docs/onnx_quantsim.rst
@@ -13,8 +13,9 @@ Top-level API
 
 |
 
-**Note about Quantization Schemes** : Since ONNX Runtime will be used for optimized inference only, ONNX
-framework will support Post Training Quantization schemes i.e. TF or TF-enhanced to compute the encodings.
+**Points to note** :
+ - Passing model path instead of model, will save runtime memory equal to size of the model.
+ - **Note about Quantization Schemes** : Since ONNX Runtime will be used for optimized inference only, ONNX framework will support Post Training Quantization schemes i.e. TF or TF-enhanced to compute the encodings.
 
 **The following API can be used to Compute Encodings for Model**
 

--- a/Docs/api_docs/onnx_quantsim.rst
+++ b/Docs/api_docs/onnx_quantsim.rst
@@ -13,9 +13,9 @@ Top-level API
 
 |
 
-**Points to note** :
+**Note** :
  - Passing model path instead of model, will save runtime memory equal to size of the model.
- - **Note about Quantization Schemes** : Since ONNX Runtime will be used for optimized inference only, ONNX framework will support Post Training Quantization schemes i.e. TF or TF-enhanced to compute the encodings.
+ - Since ONNX Runtime will be used for optimized inference only, ONNX framework will support Post Training Quantization schemes i.e. TF or TF-enhanced to compute the encodings.
 
 **The following API can be used to Compute Encodings for Model**
 

--- a/Docs/api_docs/onnx_quantsim.rst
+++ b/Docs/api_docs/onnx_quantsim.rst
@@ -14,7 +14,7 @@ Top-level API
 |
 
 **Note** :
- - Passing model path instead of model, will save runtime memory equal to size of the model.
+ - It is recommended to use onnx-simplifier before creating quantsim model.
  - Since ONNX Runtime will be used for optimized inference only, ONNX framework will support Post Training Quantization schemes i.e. TF or TF-enhanced to compute the encodings.
 
 **The following API can be used to Compute Encodings for Model**
@@ -38,7 +38,7 @@ Code Examples
 
 .. literalinclude:: ../onnx_code_examples/quantization.py
     :language: python
-    :lines: 39-41
+    :lines: 39-42
 
 **User should write this function to pass calibration data**
 

--- a/Docs/onnx_code_examples/adaround.py
+++ b/Docs/onnx_code_examples/adaround.py
@@ -38,6 +38,7 @@
 
 """ AdaRound code example to be used for documentation generation. """
 
+from onnxsim import simplify
 from aimet_onnx.adaround.adaround_weight import AdaroundParameters, Adaround
 from aimet_onnx.quantsim import QuantizationSimModel
 
@@ -56,6 +57,7 @@ def apply_adaround_example(model, dataloader):
         Example code to run adaround
 
         """
+        model = simplify(model)
         params = AdaroundParameters(data_loader=dataloader, num_batches=1, default_num_iterations=5,
                                     forward_fn=pass_calibration_data,
                                     forward_pass_callback_args=None)

--- a/Docs/onnx_code_examples/adaround.py
+++ b/Docs/onnx_code_examples/adaround.py
@@ -57,7 +57,9 @@ def apply_adaround_example(model, dataloader):
         Example code to run adaround
 
         """
-        model = simplify(model)
+        # Simplify the model
+        model, _ = simplify(model)
+
         params = AdaroundParameters(data_loader=dataloader, num_batches=1, default_num_iterations=5,
                                     forward_fn=pass_calibration_data,
                                     forward_pass_callback_args=None)

--- a/Docs/onnx_code_examples/auto_quant_v2.py
+++ b/Docs/onnx_code_examples/auto_quant_v2.py
@@ -52,7 +52,8 @@ BATCH_SIZE = 32
 
 # Step 2. Prepare model and dataloader
 onnx_model = Model()
-onnx_model = simplify(onnx_model)
+# Simplify the model
+onnx_model, _ = simplify(onnx_model)
 
 input_shape = (1, 3, 224, 224)
 dummy_data = np.random.randn(*input_shape).astype(np.float32)

--- a/Docs/onnx_code_examples/auto_quant_v2.py
+++ b/Docs/onnx_code_examples/auto_quant_v2.py
@@ -40,6 +40,7 @@
 import math
 import onnxruntime as ort
 import numpy as np
+from onnxsim import simplify
 
 from aimet_onnx.auto_quant_v2 import AutoQuant
 from aimet_onnx.adaround.adaround_weight import AdaroundParameters
@@ -51,6 +52,7 @@ BATCH_SIZE = 32
 
 # Step 2. Prepare model and dataloader
 onnx_model = Model()
+onnx_model = simplify(onnx_model)
 
 input_shape = (1, 3, 224, 224)
 dummy_data = np.random.randn(*input_shape).astype(np.float32)

--- a/Docs/onnx_code_examples/cross_layer_equalization.py
+++ b/Docs/onnx_code_examples/cross_layer_equalization.py
@@ -41,5 +41,6 @@ from aimet_onnx.cross_layer_equalization import equalize_model
 
 def cross_layer_equalization():
     onnx_model = Model()
-    onnx_model = simplify(onnx_model)
+    # Simplify the model
+    onnx_model, _ = simplify(onnx_model)
     equalize_model(onnx_model)

--- a/Docs/onnx_code_examples/cross_layer_equalization.py
+++ b/Docs/onnx_code_examples/cross_layer_equalization.py
@@ -36,8 +36,10 @@
 # =============================================================================
 # pylint: skip-file
 
+from onnxsim import simplify
 from aimet_onnx.cross_layer_equalization import equalize_model
 
 def cross_layer_equalization():
     onnx_model = Model()
+    onnx_model = simplify(onnx_model)
     equalize_model(onnx_model)

--- a/Docs/onnx_code_examples/layer_output_generation_code_example.py
+++ b/Docs/onnx_code_examples/layer_output_generation_code_example.py
@@ -40,6 +40,7 @@
 # Step 0. Import statements
 import onnx
 from onnxruntime import InferenceSession
+from onnxsim import simplify
 
 from aimet_onnx.quantsim import QuantizationSimModel, load_encodings_to_sim
 from aimet_onnx.layer_output_utils import LayerOutputUtil
@@ -48,6 +49,7 @@ from aimet_onnx.layer_output_utils import LayerOutputUtil
 # Step 1. Obtain original or quantsim model
 # Load the model.
 model = onnx.load('path/to/aimet_export_artifacts/model.onnx')
+model = simplify(model)
 
 # Use same arguments as that were used for the exported QuantSim model. For sake of simplicity only mandatory arguments are passed below.
 quantsim = QuantizationSimModel(model=model, dummy_input=dummy_input_dict, use_cuda=False)

--- a/Docs/onnx_code_examples/layer_output_generation_code_example.py
+++ b/Docs/onnx_code_examples/layer_output_generation_code_example.py
@@ -49,7 +49,8 @@ from aimet_onnx.layer_output_utils import LayerOutputUtil
 # Step 1. Obtain original or quantsim model
 # Load the model.
 model = onnx.load('path/to/aimet_export_artifacts/model.onnx')
-model = simplify(model)
+# Simplify the model
+model, _ = simplify(model)
 
 # Use same arguments as that were used for the exported QuantSim model. For sake of simplicity only mandatory arguments are passed below.
 quantsim = QuantizationSimModel(model=model, dummy_input=dummy_input_dict, use_cuda=False)

--- a/Docs/onnx_code_examples/mixed_precision.py
+++ b/Docs/onnx_code_examples/mixed_precision.py
@@ -64,7 +64,7 @@ def quantize_with_mixed_precision(model):
     forward_pass_call_back = CallbackFunc(forward_pass_callback, func_callback_args=None)
 
     # Create quant sim
-    model = simplify(model)
+    model, _ = simplify(model)  # Simplify the model
     sim = QuantizationSimModel(model, default_param_bw=default_bitwidth, default_output_bw=default_bitwidth)
     sim.compute_encodings(forward_pass_callback, forward_pass_callback_args=None)
     # Call the mixed precision algo with clean start = True i.e. new accuracy list and pareto list will be generated

--- a/Docs/onnx_code_examples/mixed_precision.py
+++ b/Docs/onnx_code_examples/mixed_precision.py
@@ -38,6 +38,7 @@
 
 # Step 0. Import statements
 import numpy as np
+from onnxsim import simplify
 from aimet_common.defs import QuantizationDataType, CallbackFunc
 from aimet_onnx.mixed_precision import choose_mixed_precision
 from aimet_onnx.quantsim import QuantizationSimModel
@@ -63,6 +64,7 @@ def quantize_with_mixed_precision(model):
     forward_pass_call_back = CallbackFunc(forward_pass_callback, func_callback_args=None)
 
     # Create quant sim
+    model = simplify(model)
     sim = QuantizationSimModel(model, default_param_bw=default_bitwidth, default_output_bw=default_bitwidth)
     sim.compute_encodings(forward_pass_callback, forward_pass_callback_args=None)
     # Call the mixed precision algo with clean start = True i.e. new accuracy list and pareto list will be generated
@@ -94,6 +96,7 @@ def quantize_with_mixed_precision_start_from_existing_cache(model):
     forward_pass_call_back = CallbackFunc(forward_pass_callback, func_callback_args=None)
 
     # Create quant sim
+    model = simplify(model)
     sim = QuantizationSimModel(model, default_param_bw=default_bitwidth, default_output_bw=default_bitwidth)
     sim.compute_encodings(forward_pass_callback, forward_pass_callback_args=None)
     # Call the mixed precision algo with clean start = True i.e. new accuracy list and pareto list will be generated

--- a/Docs/onnx_code_examples/quant_analyzer_code_example.py
+++ b/Docs/onnx_code_examples/quant_analyzer_code_example.py
@@ -103,7 +103,8 @@ def quant_analyzer_example():
 
     # Step 3. Prepare model, callback functions and dataloader
     onnx_model = Model()
-    onnx_model = simplify(onnx_model)
+    # Simplify the model
+    onnx_model, _ = simplify(onnx_model)
 
     input_shape = (1, 3, 224, 224)
     dummy_data = np.random.randn(*input_shape).astype(np.float32)

--- a/Docs/onnx_code_examples/quant_analyzer_code_example.py
+++ b/Docs/onnx_code_examples/quant_analyzer_code_example.py
@@ -42,6 +42,7 @@
 from typing import Any
 import numpy as np
 from onnxruntime import InferenceSession
+from onnxsim import simplify
 
 from aimet_common.defs import QuantScheme
 from aimet_common.utils import CallbackFunc
@@ -102,6 +103,7 @@ def quant_analyzer_example():
 
     # Step 3. Prepare model, callback functions and dataloader
     onnx_model = Model()
+    onnx_model = simplify(onnx_model)
 
     input_shape = (1, 3, 224, 224)
     dummy_data = np.random.randn(*input_shape).astype(np.float32)

--- a/Docs/onnx_code_examples/quantization.py
+++ b/Docs/onnx_code_examples/quantization.py
@@ -75,7 +75,8 @@ def pass_calibration_data(session):
 
 def quantize_model():
     onnx_model = Model()
-    onnx_model = simplify(onnx_model)
+    # Simplify the model
+    onnx_model, _ = simplify(onnx_model)
     input_shape = (1, 3, 224, 224)
     dummy_data = np.random.randn(*input_shape).astype(np.float32)
     dummy_input = {'input' : dummy_data}

--- a/Docs/onnx_code_examples/quantization.py
+++ b/Docs/onnx_code_examples/quantization.py
@@ -36,9 +36,10 @@
 # =============================================================================
 # pylint: skip-file
 
+import numpy as np
+from onnxsim import simplify
 from aimet_onnx.quantsim import QuantizationSimModel
 from aimet_common.defs import QuantScheme
-import numpy as np
 
 
 def pass_calibration_data(session):
@@ -74,6 +75,7 @@ def pass_calibration_data(session):
 
 def quantize_model():
     onnx_model = Model()
+    onnx_model = simplify(onnx_model)
     input_shape = (1, 3, 224, 224)
     dummy_data = np.random.randn(*input_shape).astype(np.float32)
     dummy_input = {'input' : dummy_data}

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/adaround_weight.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/adaround_weight.py
@@ -149,8 +149,7 @@ class Adaround:
                                          default_param_bw=default_param_bw,
                                          config_file=default_config_file,
                                          user_onnx_libs=user_onnx_libs,
-                                         use_cuda=use_cuda,
-                                         simplify_model=False)
+                                         use_cuda=use_cuda)
 
         # For the params in the param_bw_override_list, override the default parameter bitwidths in the QuantSim
         if param_bw_override_list:

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/adaround_weight.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/adaround/adaround_weight.py
@@ -44,7 +44,6 @@ import json
 from typing import Tuple, Dict, List, Callable
 from onnx import onnx_pb
 from onnxruntime.quantization.onnx_quantizer import ONNXModel
-import onnxsim
 from tqdm import tqdm
 
 # Import AIMET specific modules
@@ -146,14 +145,6 @@ class Adaround:
         if not isinstance(model, ONNXModel):
             model = ONNXModel(model)
 
-        # TODO: Remove this once we no longer simplify the model within quantsim
-
-        try:
-            model.model, _ = onnxsim.simplify(model.model)
-            # pylint: disable=bare-except
-        except:
-            logger.info('ONNX Simplifier failed. Proceeding with unsimplified model.')
-            
         quant_sim = QuantizationSimModel(copy.deepcopy(model), quant_scheme=default_quant_scheme,
                                          default_param_bw=default_param_bw,
                                          config_file=default_config_file,

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -184,7 +184,7 @@ class QuantizationSimModel:
         #Load model in case it didn't simplify and was passed as path string
         self.model = onnx.load_model(model) if isinstance(model, str) else model
         if not isinstance(self.model, ONNXModel):
-            self.model = ONNXModel(model)
+            self.model = ONNXModel(self.model)
 
         if not dummy_input:
             dummy_input = make_dummy_input(self.model.model)

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -142,7 +142,7 @@ class EncodingMismatchInfo:
 class QuantizationSimModel:
     """ Creates a QuantizationSimModel model by adding quantization simulations ops to a given model """
 
-    # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes
+    # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes, too-many-statements
     def __init__(self,
                  model: ModelProto|str,
                  dummy_input: Dict[str, np.ndarray] = None,
@@ -175,7 +175,7 @@ class QuantizationSimModel:
         :param path: Directory to save the artifacts.
         """
         is_path_to_model = False
-        if(isinstance(model, str)):
+        if isinstance(model, str):
             model = onnx.load_model(model)
             is_path_to_model = True
 
@@ -190,7 +190,7 @@ class QuantizationSimModel:
             except:
                 logger.info('ONNX Simplifier failed. Proceeding with unsimplified model.')
 
-        if is_path_to_model == True:
+        if is_path_to_model is True:
             del model
             gc.collect()
 

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -141,7 +141,7 @@ class EncodingMismatchInfo:
 class QuantizationSimModel:
     """ Creates a QuantizationSimModel model by adding quantization simulations ops to a given model """
 
-    # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes, too-many-statements
+    # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes
     def __init__(self,
                  model: ModelProto|str,
                  dummy_input: Dict[str, np.ndarray] = None,

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -151,7 +151,7 @@ class QuantizationSimModel:
                  use_symmetric_encodings: bool = False, use_cuda: bool = True,
                  device: int = 0, config_file: str = None,
                  default_data_type: QuantizationDataType = QuantizationDataType.int,
-                 simplify_model: bool = True, user_onnx_libs: List[str] = None, path: str = None):
+                 user_onnx_libs: List[str] = None, path: str = None):
         """
         Constructor
 
@@ -168,7 +168,6 @@ class QuantizationSimModel:
                                  Possible options are QuantizationDataType.int and QuantizationDataType.float.
                                  Note that the mode default_data_type=QuantizationDataType.float is only supported with
                                  default_output_bw=16 and default_param_bw=16
-        :param simplify_model: Default True, uses onnx simplifier to simplify model
         :param user_onnx_libs: List of paths to all compiled ONNX custom ops libraries
         :param path: Directory to save the artifacts.
         """

--- a/TrainingExtensions/onnx/test/python/test_adaround_weight.py
+++ b/TrainingExtensions/onnx/test/python/test_adaround_weight.py
@@ -44,6 +44,7 @@ import numpy as np
 import torch
 from onnxruntime import SessionOptions, GraphOptimizationLevel, InferenceSession
 import pytest
+from onnxsim import simplify
 
 from aimet_common.quantsim_config.utils import get_path_for_per_channel_config
 from aimet_common import libquant_info
@@ -213,6 +214,7 @@ class TestAdaround:
                                     forward_fn=callback,
                                     forward_pass_callback_args=None)
 
+        model, _ = simplify(model)
         Adaround.apply_adaround(model, params, tmpdir, 'dummy', use_cuda=False)
 
     @pytest.mark.parametrize("model_factory, input_shape", [(models_for_tests.pointwise_conv1d, (1, 10, 32)),

--- a/TrainingExtensions/onnx/test/python/test_quant_analyzer.py
+++ b/TrainingExtensions/onnx/test/python/test_quant_analyzer.py
@@ -353,7 +353,7 @@ class TestQuantAnalyzer:
             layer_names.append(node.name)
 
         fold_all_batch_norms_to_weight(model)
-        sim = QuantizationSimModel(copy.deepcopy(model), dummy_input_dict, simplify_model=False)
+        sim = QuantizationSimModel(copy.deepcopy(model), dummy_input_dict)
         sim.compute_encodings(evaluate, dummy_input_dict)
         forward_pass_callback = CallbackFunc(calibrate, dummy_input_dict)
         eval_callback = CallbackFunc(evaluate, dummy_input_dict)
@@ -381,7 +381,7 @@ class TestQuantAnalyzer:
         model = models_for_tests._convert_to_onnx(models_for_tests.TinyModel(), dummy_input)
         dummy_input_dict = {'input': np.random.randn(1, 3, 32, 32).astype(np.float32)}
         fold_all_batch_norms_to_weight(model)
-        sim = QuantizationSimModel(copy.deepcopy(model), dummy_input_dict, simplify_model=False)
+        sim = QuantizationSimModel(copy.deepcopy(model), dummy_input_dict)
         sim.compute_encodings(evaluate, dummy_input_dict)
         forward_pass_callback = CallbackFunc(calibrate, dummy_input_dict)
         eval_callback = CallbackFunc(evaluate, dummy_input_dict)


### PR DESCRIPTION
Fixes #3423 

- Remove onnx-simplifier dependency from aimet-onnx. This allows us to have one model instance instead of two.
- Update API Docs with a note that recommends users to simplify the onnx model before passing it to aimet-onnx APIs.

