### PR TITLE
Rename get_encoding (singular) to get_encodings (plural)

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/modules/custom.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/modules/custom.py
@@ -179,7 +179,7 @@ class QuantizedConcat(_DispatchMixin, QuantizationMixin, Concat):
         def cat(tensors, dim=0, *, out=None):
             input_qtzr = self.input_quantizers[0]
             tensors = tuple(_quantize_if_applicable(x, input_qtzr) for x in tensors)
-            output_encodings = self.output_quantizers[0].get_encoding() if self.output_quantizers[0] else None
+            output_encodings = self.output_quantizers[0].get_encodings() if self.output_quantizers[0] else None
             return fn(tensors, dim=dim, out=out, output_encodings=output_encodings)
 
         return cat

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
@@ -516,7 +516,7 @@ class _DispatchMixin(metaclass=_DispatchMeta):
             )
             others = args[len(self.input_quantizers):]
 
-            output_encodings = self.output_quantizers[0].get_encoding() if self.output_quantizers[0] else None
+            output_encodings = self.output_quantizers[0].get_encodings() if self.output_quantizers[0] else None
             kwargs.update(output_encodings=output_encodings)
             return fn(*qtzd_args, *others, **kwargs)
 
@@ -897,7 +897,7 @@ class QuantizedEmbeddingBag(_DispatchMixin, QuantizationMixin, nn.EmbeddingBag):
                 qtzr = self.input_quantizers[0]
                 per_sample_weights = _quantize_if_applicable(per_sample_weights, qtzr)
 
-            output_encodings = self.output_quantizers[0].get_encoding() if self.output_quantizers[0] else None
+            output_encodings = self.output_quantizers[0].get_encodings() if self.output_quantizers[0] else None
 
             return fn(input,
                       weight,
@@ -1010,7 +1010,7 @@ class QuantizedGRU(_DispatchMixin, QuantizationMixin, nn.GRU):
 
         def gru(*args):
             args = self._quantize_inputs(args, apply)
-            output_encodings = tuple(qtzr and qtzr.get_encoding() for qtzr in self.output_quantizers)
+            output_encodings = tuple(qtzr and qtzr.get_encodings() for qtzr in self.output_quantizers)
             return fn(*args, output_encodings=output_encodings)
 
         return gru
@@ -1045,7 +1045,7 @@ class QuantizedGRUCell(_DispatchMixin, QuantizationMixin, nn.GRUCell):
         def gru_cell(input, hx, *args, **kwargs):
             input = apply(input, self.input_quantizers[0])
             hx = apply(hx, self.input_quantizers[1])
-            output_encodings = self.output_quantizers[0] and self.output_quantizers[0].get_encoding()
+            output_encodings = self.output_quantizers[0] and self.output_quantizers[0].get_encodings()
             return fn(input, hx, *args, **kwargs, output_encodings=output_encodings)
 
         return gru_cell
@@ -1209,7 +1209,7 @@ class QuantizedLSTM(_DispatchMixin, QuantizationMixin, nn.LSTM):
 
         def lstm(*args):
             args = self._quantize_inputs(args, apply)
-            output_encodings = tuple(qtzr and qtzr.get_encoding() for qtzr in self.output_quantizers)
+            output_encodings = tuple(qtzr and qtzr.get_encodings() for qtzr in self.output_quantizers)
             return fn(*args, output_encodings=output_encodings)
 
         return lstm
@@ -1253,7 +1253,7 @@ class QuantizedLSTMCell(_DispatchMixin, QuantizationMixin, nn.LSTMCell):
             h_qtzr, c_qtzr = self.input_quantizers[1:]
             hx = (apply(h, h_qtzr), apply(c, c_qtzr))
 
-            output_encodings = tuple(qtzr and qtzr.get_encoding() for qtzr in self.output_quantizers)
+            output_encodings = tuple(qtzr and qtzr.get_encodings() for qtzr in self.output_quantizers)
             return fn(input, hx, *args, **kwargs, output_encodings=output_encodings)
 
         return lstm_cell
@@ -1609,7 +1609,7 @@ class QuantizedRNN(_DispatchMixin, QuantizationMixin, nn.RNN):
 
         def rnn(*args):
             args = self._quantize_inputs(args, apply)
-            output_encodings = tuple(qtzr and qtzr.get_encoding() for qtzr in self.output_quantizers)
+            output_encodings = tuple(qtzr and qtzr.get_encodings() for qtzr in self.output_quantizers)
             return fn(*args, output_encodings=output_encodings)
 
         return rnn
@@ -1655,7 +1655,7 @@ class QuantizedRNNCell(_DispatchMixin, QuantizationMixin, nn.RNNCell):
         def rnn_cell(input, hx, *args, **kwargs):
             input = apply(input, self.input_quantizers[0])
             hx = apply(hx, self.input_quantizers[1])
-            output_encodings = self.output_quantizers[0] and self.output_quantizers[0].get_encoding()
+            output_encodings = self.output_quantizers[0] and self.output_quantizers[0].get_encodings()
             return fn(input, hx, *args, **kwargs, output_encodings=output_encodings)
 
         return rnn_cell

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quant_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quant_analyzer.py
@@ -137,7 +137,7 @@ class QuantAnalyzer(V1QuantAnalyzer):
     def _get_quantizer_encodings(cls, quantizer: QuantizerBase) -> Optional[List]:
         v1_encodings = []
 
-        encoding = quantizer.get_encoding()
+        encoding = quantizer.get_encodings()
         if not encoding:
             return None
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -209,7 +209,7 @@ class AffineQuantizerBase(QuantizerBase, _GridMixin):
         Set quantization parameters to the given min-max range
         """
 
-    def get_encoding(self) -> Optional[AffineEncoding]:
+    def get_encodings(self) -> Optional[AffineEncoding]:
         """
         Return the quantizer's encodings as an AffineEncoding object
         """
@@ -229,7 +229,7 @@ class AffineQuantizerBase(QuantizerBase, _GridMixin):
         if not self.is_initialized():
             return None
 
-        return self.get_encoding()._to_legacy_format()
+        return self.get_encodings()._to_legacy_format()
 
     @torch.no_grad()
     def set_legacy_encodings(self, encodings: List[Dict]):
@@ -545,7 +545,7 @@ class Quantize(MinMaxQuantizer):
                 ' Please initialize the quantization parameters using `compute_encodings()`.'
             )
 
-        encoding = self.get_encoding()
+        encoding = self.get_encodings()
 
         # Subclasses of torch.Tensor with custom __torch_function__ (in our case, QuantizedTensorBase)
         # is known to introduce substantial CPU overhead.
@@ -679,7 +679,7 @@ class QuantizeDequantize(MinMaxQuantizer):
                 ' Please initialize the quantization parameters using `compute_encodings()`.'
             )
 
-        encoding = self.get_encoding()
+        encoding = self.get_encodings()
 
         # Subclasses of torch.Tensor with custom __torch_function__ (in our case, QuantizedTensorBase)
         # is known to introduce substantial CPU overhead.

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
@@ -51,6 +51,7 @@ from torch.utils._pytree import tree_map
 from packaging import version  # pylint: disable=wrong-import-order
 from aimet_torch.v2.quantization.base import EncodingBase
 from aimet_torch.v2.quantization.encoding_analyzer import EncodingAnalyzer
+from aimet_torch.utils import deprecated
 
 
 __all__ = ['QuantizerBase']
@@ -91,10 +92,17 @@ class QuantizerBase(abc.ABC, torch.nn.Module):
         """
 
     @abc.abstractmethod
-    def get_encoding(self) -> Optional[EncodingBase]:
+    def get_encodings(self) -> Optional[EncodingBase]:
         """
         Return the quantizer's encodings as an EncodingBase object
         """
+
+    @deprecated(f"Use {get_encodings.__qualname__} instead")
+    def get_encoding(self) -> Optional[EncodingBase]:
+        """
+        Alias of get_encodings
+        """
+        return self.get_encodings()
 
     def register_quantization_parameter(self, name: str, param: nn.Parameter):
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/float/quantizer.py
@@ -242,7 +242,7 @@ class FloatQuantizeDequantize(QuantizerBase): # pylint: disable=abstract-method
         self.exponent_bits = 5
         self.mantissa_bits = 10
 
-    def get_encoding(self) -> Optional[FloatEncoding]:
+    def get_encodings(self) -> Optional[FloatEncoding]:
         if self.is_initialized():
             return FloatEncoding(self.mantissa_bits, self.exponent_bits, self.maxval)
         return None

--- a/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_quantsim_utils.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_quantsim_utils.py
@@ -85,7 +85,7 @@ def test_clip_weights_to_7f7f():
     affected_quant_layers = []
     for _, quant_layer in qsim.named_qmodules():
         if 'weight' in quant_layer.param_quantizers and quant_layer.param_quantizers['weight'] is not None:
-            encoding = quant_layer.param_quantizers['weight'].get_encoding()
+            encoding = quant_layer.param_quantizers['weight'].get_encodings()
             quantized_weight = quantize(quant_layer.weight, encoding.scale, encoding.offset, -32768, 32767)
             assert torch.equal(torch.max(quantized_weight), torch.tensor(32767))
             affected_quant_layers.append(quant_layer)
@@ -94,6 +94,6 @@ def test_clip_weights_to_7f7f():
     clip_weights_to_7f7f(qsim)
 
     for quant_layer in affected_quant_layers:
-        encoding = quant_layer.param_quantizers['weight'].get_encoding()
+        encoding = quant_layer.param_quantizers['weight'].get_encodings()
         quantized_weight = quantize(quant_layer.weight, encoding.scale, encoding.offset, -32768, 32767)
         assert torch.equal(torch.max(quantized_weight), torch.tensor(32639))

--- a/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
@@ -1009,7 +1009,7 @@ def test_quantized_tensor_with_block_size():
                   block_size=(2, 4, 3))
     with bq.compute_encodings():
         _ = bq(tensor)
-    assert bq.get_encoding().block_size == bq.block_size
+    assert bq.get_encodings().block_size == bq.block_size
     q = bq(tensor)
     assert q.encoding.block_size == bq.block_size
     assert torch.equal(q.dequantize(), affine.dequantize(q, bq.get_scale(), bq.get_offset(), bq.block_size))

--- a/TrainingExtensions/torch/test/python/v2/test_seq_mse_.py
+++ b/TrainingExtensions/torch/test/python/v2/test_seq_mse_.py
@@ -173,10 +173,10 @@ class TestSeqMse:
         xq = torch.randn(32, 4, 32, 64)
         with wrapper.param_quantizers['weight'].compute_encodings():
             _ = wrapper.param_quantizers['weight'](wrapper.weight.data)
-        before = wrapper.param_quantizers['weight'].get_encoding()
+        before = wrapper.param_quantizers['weight'].get_encodings()
         params = SeqMseParams(num_batches=32, loss_fn=loss_fn)
         optimize_module(wrapper, xq, xq, params)
-        after = wrapper.param_quantizers['weight'].get_encoding()
+        after = wrapper.param_quantizers['weight'].get_encodings()
 
         # If we use higher param_bw (for example 16, 31), then it should always choose larger candidates so
         # before and after param encodings should be almost same.
@@ -203,10 +203,10 @@ class TestSeqMse:
         xq = torch.randn(32, 1, 6, 10, 10)
         with wrapper.param_quantizers['weight'].compute_encodings():
             _ = wrapper.param_quantizers['weight'](wrapper.weight.data)
-        before = wrapper.param_quantizers['weight'].get_encoding()
+        before = wrapper.param_quantizers['weight'].get_encodings()
         params = SeqMseParams(num_batches=32, loss_fn=loss_fn)
         optimize_module(wrapper, xq, xq, params)
-        after = wrapper.param_quantizers['weight'].get_encoding()
+        after = wrapper.param_quantizers['weight'].get_encodings()
 
         # If we use higher param_bw (for example 16, 31), then it should always choose larger candidates so
         # before and after param encodings should be almost same.
@@ -238,9 +238,9 @@ class TestSeqMse:
         assert not sim.model.fc2.param_quantizers['weight']._allow_overwrite
 
         # Compute encodings for all the activations and remaining non-supported modules
-        enc_before = sim.model.fc1.param_quantizers['weight'].get_encoding()
+        enc_before = sim.model.fc1.param_quantizers['weight'].get_encodings()
         sim.compute_encodings(calibrate, dummy_input)
-        enc_after = sim.model.fc1.param_quantizers['weight'].get_encoding()
+        enc_after = sim.model.fc1.param_quantizers['weight'].get_encodings()
         assert enc_before.scale == enc_after.scale
 
     @pytest.mark.parametrize("inp_symmetry", ['asym', 'symfp', 'symqt'])
@@ -269,7 +269,7 @@ class TestSeqMse:
         assert not sim_without.model.fc2.param_quantizers['weight'].min.requires_grad
         assert not sim_without.model.fc2.param_quantizers['weight'].max.requires_grad
         assert not sim_without.model.fc2.param_quantizers['weight']._allow_overwrite
-        without_checkpoints_enc = sim_without.model.fc2.param_quantizers['weight'].get_encoding()
+        without_checkpoints_enc = sim_without.model.fc2.param_quantizers['weight'].get_encodings()
 
         # Apply Sequential MSE with checkpoints config
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -283,7 +283,7 @@ class TestSeqMse:
             assert not sim_with.model.fc2.param_quantizers['weight'].min.requires_grad
             assert not sim_with.model.fc2.param_quantizers['weight'].max.requires_grad
             assert not sim_with.model.fc2.param_quantizers['weight']._allow_overwrite
-            with_checkpoints_enc = sim_with.model.fc2.param_quantizers['weight'].get_encoding()
+            with_checkpoints_enc = sim_with.model.fc2.param_quantizers['weight'].get_encodings()
 
         # encodings should be bit-exact
         assert without_checkpoints_enc.min == with_checkpoints_enc.min


### PR DESCRIPTION
Renamed "get_encoding" (singular) to "get_encoding**s**" (plural)

Calling get_encoding() will now print a deprecation warning
```pycon
>>> quantizer.get_encoding()
<stdin>:1: DeprecationWarning: QuantizerBase.get_encoding will be deprecated soon in the later versions. Use get_encodings instead
```