### PR TITLE
Preliminary refactoring for export versioning

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -43,7 +43,7 @@ import os
 import io
 import copy
 import pickle
-from typing import Tuple, List, Union, Dict, Callable, Optional, Any, runtime_checkable, Protocol, Mapping
+from typing import Tuple, List, Union, Dict, Callable, Optional, Any, runtime_checkable, Protocol, Mapping, TYPE_CHECKING
 from collections import OrderedDict, defaultdict
 import json
 import warnings
@@ -78,7 +78,8 @@ from aimet_torch.meta.connectedgraph import ConnectedGraph, Op
 from aimet_torch.v1.qc_quantize_recurrent import QcQuantizeRecurrent
 from aimet_torch.quantsim_config.builder import LazyQuantizeWrapper
 from aimet_torch.experimental.v2.quantsim.export_utils import _export_to_1_0_0
-from aimet_torch.v2.quantization.base.encoding import EncodingBase
+if TYPE_CHECKING:
+    from aimet_torch.v2.quantization.base.encoding import EncodingBase
 
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
@@ -131,12 +132,12 @@ class QuantParams:
 
 
 class QuantizerProtocol(Protocol):
-    def get_encodings(self) -> Optional[EncodingBase]:
+    def get_encodings(self) -> Optional["EncodingBase"]:
         """
         Return the quantizer's encodings as an EncodingBase object
         """
 
-    def set_encodings(self, encoding: EncodingBase):
+    def set_encodings(self, encoding: "EncodingBase"):
         """
         Set the quantizer's encodings
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -78,6 +78,7 @@ from aimet_torch.meta.connectedgraph import ConnectedGraph, Op
 from aimet_torch.v1.qc_quantize_recurrent import QcQuantizeRecurrent
 from aimet_torch.quantsim_config.builder import LazyQuantizeWrapper
 from aimet_torch.experimental.v2.quantsim.export_utils import _export_to_1_0_0
+from aimet_torch.v2.quantization.base.encoding import EncodingBase
 
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
@@ -129,11 +130,26 @@ class QuantParams:
         self.config_file = config_file
 
 
+class QuantizerProtocol(Protocol):
+    def get_encodings(self) -> Optional[EncodingBase]:
+        """
+        Return the quantizer's encodings as an EncodingBase object
+        """
+
+    def set_encodings(self, encoding: EncodingBase):
+        """
+        Set the quantizer's encodings
+        """
+
+
 @runtime_checkable
 class QuantizedModuleProtocol(Protocol):
     """
     Defines the minimum interface requirements for exporting encodings from a module.
     """
+    input_quantizers: List[QuantizerProtocol]
+    output_quantizers: List[QuantizerProtocol]
+    param_quantizers: OrderedDict[str, QuantizerProtocol]
 
     def export_input_encodings(self) -> List[List[Dict]]:
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/tensor_quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/tensor_quantizer.py
@@ -53,6 +53,7 @@ import aimet_torch.v1.quantsim_straight_through_grad as grad_fn
 from aimet_torch.v1.quantsim_straight_through_grad import IntermediateResult
 from aimet_torch.fp_quantization import fp8_quantizer, INIT_MAP
 from aimet_torch.v1.tensor_factory_utils import constant_like
+from aimet_torch.v2.quantization.base import EncodingBase
 
 _logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
 
@@ -124,6 +125,18 @@ class TensorQuantizer:
     def encoding_min_max_fixed_vals(self, min_max_vals: Optional[Tuple[float, float]]):
         """ self._encoding_min_max_fixed_vals setter """
 
+    def get_encodings(self) -> Optional[EncodingBase]:
+        """
+        Return the quantizer's encodings as an EncodingBase object
+        """
+        raise NotImplementedError
+
+    def set_encodings(self, encodings: EncodingBase):
+        """
+        Set the quantizer's encodings
+        """
+        raise NotImplementedError
+
 
 class PickableState:
     """
@@ -140,7 +153,7 @@ class PickableState:
                 self.encodings.append((enc.min, enc.max, enc.delta, enc.offset, enc.bw))
 
 
-class StaticGridTensorQuantizer(TensorQuantizer):
+class StaticGridTensorQuantizer(TensorQuantizer): # pylint: disable=abstract-method
     """
     Simulates quantization for the given tensor post training.
     """
@@ -400,7 +413,7 @@ class StaticGridTensorQuantizer(TensorQuantizer):
             self.fp8_maxval = 0.9 * self.fp8_maxval + 0.1 * maxval
 
 
-class StaticGridPerTensorQuantizer(StaticGridTensorQuantizer):
+class StaticGridPerTensorQuantizer(StaticGridTensorQuantizer): # pylint: disable=abstract-method
     """
     Simulates quantization for the given tensor using a per-tensor scale/offset
     """
@@ -480,7 +493,7 @@ class StaticGridPerTensorQuantizer(StaticGridTensorQuantizer):
                     op.updateStats(tensor, tensor.is_cuda)
 
 
-class StaticGridPerChannelQuantizer(StaticGridTensorQuantizer):
+class StaticGridPerChannelQuantizer(StaticGridTensorQuantizer): # pylint: disable=abstract-method
     """
     Simulates quantization for the given tensor using a per-channel scale/offset
     """
@@ -570,7 +583,7 @@ class StaticGridPerChannelQuantizer(StaticGridTensorQuantizer):
                         op.updateStats(tensor_slice, tensor.is_cuda)
 
 
-class LearnedGridTensorQuantizer(TensorQuantizer):
+class LearnedGridTensorQuantizer(TensorQuantizer): # pylint: disable=abstract-method
     """
     Simulates quantization for a given tensor in the model, such that the scale/offset encodings are
     initialized and then "learnt" during training

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/tensor_quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/tensor_quantizer.py
@@ -39,7 +39,7 @@
 import functools
 import io
 import math
-from typing import List, Union, Tuple, Optional
+from typing import List, Union, Tuple, Optional, TYPE_CHECKING
 import abc
 
 import torch
@@ -53,7 +53,8 @@ import aimet_torch.v1.quantsim_straight_through_grad as grad_fn
 from aimet_torch.v1.quantsim_straight_through_grad import IntermediateResult
 from aimet_torch.fp_quantization import fp8_quantizer, INIT_MAP
 from aimet_torch.v1.tensor_factory_utils import constant_like
-from aimet_torch.v2.quantization.base import EncodingBase
+if TYPE_CHECKING:
+    from aimet_torch.v2.quantization.base import EncodingBase
 
 _logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
 
@@ -125,13 +126,13 @@ class TensorQuantizer:
     def encoding_min_max_fixed_vals(self, min_max_vals: Optional[Tuple[float, float]]):
         """ self._encoding_min_max_fixed_vals setter """
 
-    def get_encodings(self) -> Optional[EncodingBase]:
+    def get_encodings(self) -> Optional["EncodingBase"]:
         """
         Return the quantizer's encodings as an EncodingBase object
         """
         raise NotImplementedError
 
-    def set_encodings(self, encodings: EncodingBase):
+    def set_encodings(self, encodings: "EncodingBase"):
         """
         Set the quantizer's encodings
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/encoding.py
@@ -115,3 +115,16 @@ class EncodingBase(abc.ABC):
             if isinstance(item, torch.Tensor):
                 setattr(self_copy, name, item.clone())
         return self_copy
+
+    def to_qnn_encoding_dict(self, version=None):
+        """
+        Converts encoding object into QNN encoding dictionary
+        """
+        raise NotImplementedError
+
+    @classmethod
+    def from_qnn_encoding_dict(cls, encoding_dict, version=None) -> "EncodingBase":
+        """
+        Create an encoding object from a QNN encoding dictionary
+        """
+        raise NotImplementedError

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/base/quantizer.py
@@ -104,6 +104,12 @@ class QuantizerBase(abc.ABC, torch.nn.Module):
         """
         return self.get_encodings()
 
+    def set_encodings(self, encodings: EncodingBase):
+        """
+        Set the quantizer's encodings
+        """
+        raise NotImplementedError
+
     def register_quantization_parameter(self, name: str, param: nn.Parameter):
         """
         Register quantization parameter.


### PR DESCRIPTION
This is a preliminary refactoring code to keep the SW maintenance cost of export versioning more manageable.

## Main Changes
Defined some interface classes/methods so that aimet v2 `EncodingBase` will become the common middle layer between AIMET quantizers and different versions of QNN encoding formats.
This will free us from the curse of maintaining exponential combinations -- `{v1, v2}` x `{0.6.1, 1.0.0, ...}` -- of encoding import/export logics

![image](https://github.com/user-attachments/assets/077fdb2b-74f8-4922-9cec-ab8043c81c71)
