### PR TITLE
Remove source code incompatibility with Python<3.9

### DIFF
--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/utils/model_connection_utils.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/utils/model_connection_utils.py
@@ -49,8 +49,8 @@ class ModelLayerConnectionsProperties(Enum):
     OUTPUT_TENSORS = 'output_tensors'
     CALL_ARGS = 'call_args'
     CALL_KWARGS = 'call_kwargs'
-    TYPE = typing.OrderedDict[typing.OrderedDict[str, typing.List[str]],
-                              typing.OrderedDict[str, typing.Union[KerasTensor, typing.List[KerasTensor]]]]
+    TYPE = typing.Dict[typing.Dict[str, typing.List[str]],
+                       typing.Dict[str, typing.Union[KerasTensor, typing.List[KerasTensor]]]]
 
 class ModelLayerConnections:
     """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -150,7 +150,7 @@ class QuantizedModuleProtocol(Protocol):
     """
     input_quantizers: List[QuantizerProtocol]
     output_quantizers: List[QuantizerProtocol]
-    param_quantizers: OrderedDict[str, QuantizerProtocol]
+    param_quantizers: Dict[str, QuantizerProtocol]
 
     def export_input_encodings(self) -> List[List[Dict]]:
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/quantsim_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/experimental/quantsim_utils.py
@@ -234,7 +234,11 @@ def set_matmul_second_input_producer_to_8bit_symmetric(sim: 'QuantizationSimMode
         return connected_graph._module_to_op_dict[original_module]
 
     def get_closest_producer(op: Op):
-        quant_module = quant_modules.get(op.dotted_name.removeprefix(f'{model_name}.'), None)
+        prefix = f'{model_name}.'
+        dotted_name = op.dotted_name
+        if dotted_name.startswith(prefix):
+            dotted_name = dotted_name[len(prefix):]
+        quant_module = quant_modules.get(dotted_name, None)
         if quant_module:
             if quant_module.output_quantizers[0]:
                 return quant_module

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/mixed_precision/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/mixed_precision/utils.py
@@ -41,7 +41,7 @@
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Dict, Type, List, TypeAlias, Literal, Optional, Union, Generator
+from typing import Dict, Type, List, Literal, Optional, Union, Generator
 import functools
 
 import torch
@@ -57,7 +57,7 @@ from aimet_torch.quantsim_config.builder import LazyQuantizer
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Quant)
 
-SupportedDType: TypeAlias = Literal['Int16', 'Int8', 'Int4', 'Fp16']
+SupportedDType = Literal['Int16', 'Int8', 'Int4', 'Fp16']
 
 @dataclass
 class Precision:


### PR DESCRIPTION
* TypeAlias was added in Python 3.10
* OrderedDict[...] was added in 3.9
* removeprefix was added in 3.9