### PR TITLE
Loosen sphinx version requirement in py38 fast-release Dockerfile

### DIFF
--- a/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py38
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py38
@@ -189,10 +189,10 @@ RUN python3 -m pip --no-cache-dir install \
         scikit-learn==1.1.3 \
         scipy==1.8.1 \
         spconv-cu116 \
-        sphinx==3.5.3 \
-        sphinx-autodoc-typehints==1.6.0 \
+        sphinx \
+        sphinx-autodoc-typehints \
         sphinx-design \
-        sphinx-jinja==1.1.1 \
+        sphinx-jinja \
         sphinx-rtd-theme \
         sphinx-tabs \
         tensorboard==2.4.0 \


### PR DESCRIPTION
The recently added furo requires sphinx >= 6.