### PR TITLE
Simplify fast-release docker image

### DIFF
--- a/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
@@ -200,4 +200,14 @@ RUN cd /usr/local && \
     chown -R root:users cutlass-3.3.0 && \
     ln -s cutlass-3.3.0 cutlass
 
-RUN python3 -m pip --no-cache-dir install torch==2.2
+RUN python3 -m pip --no-cache-dir install \
+    furo \
+    nbsphinx \
+    sphinx \
+    sphinx-autodoc-typehints \
+    sphinx-copybutton \
+    sphinx-design \
+    sphinx-jinja \
+    sphinx-rtd-theme \
+    sphinx-tabs \
+    torch==2.2

--- a/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu-pt21-py310
@@ -91,9 +91,7 @@ RUN add-apt-repository ppa:deadsnakes/ppa && \
         python${PYTHON_VERSION}-venv \
         python3-pip \
         python3-setuptools \
-        build-essential \
-        # lmdb dependency
-        libffi-dev && \
+        build-essential && \
         rm -rf /var/lib/apt/lists/*
 
 # Register the version in alternatives
@@ -140,80 +138,7 @@ RUN apt-get update > /dev/null && \
         rm -rf /var/lib/apt/lists/*
 
 # Python3 Packages
-RUN python3 -m pip --no-cache-dir install \
-        astroid==2.5.6 \
-        attrs>=19.1.0 \
-        behave==1.2.6 \
-        blosc==1.10.1 \
-        cffi \
-        click \
-        cma \
-        cumm-cu120 \
-        cvxpy \
-        cylp \
-        cython \
-        dataclasses \
-        datasets \
-        Deprecated \
-        deepspeed \
-        docutils \
-        furo \
-        graphviz \
-        grpcio \
-        grpcio-tools \
-        h5py \
-        ipykernel \
-        ipython \
-        Jinja2>=3.0.3 \
-        jupyter \
-        keras==2.2.4 \
-        lmdb==1.2.1 \
-        matplotlib>=3 \
-        mock \
-        nbsphinx==0.8.12 \
-        networkx \
-        'numpy<2' \
-        onnx \
-        onnxscript \
-        onnxsim \
-        onnxruntime==1.15.1 \
-        onnxruntime-extensions \
-        opencv-python \
-        peft \
-        piccolo-theme \
-        Pillow==9.3.0 \
-        pluggy==0.12.0 \
-        psutil \
-        ptflops \
-        pybind11 \
-        pydot \
-        pyDOE2 \
-        pylint==2.8.3 \
-        pymoo \
-        pytest \
-        pytest-cov \
-        pytorch-ignite \
-        PyYAML \
-        safetensors \
-        scikit-learn \
-        scipy \
-        spconv-cu120 \
-        sphinx \
-        sphinx-autodoc-typehints \
-        sphinx-design \
-        sphinx-jinja \
-        sphinx-rtd-theme \
-        sphinx-tabs \
-        tensorboard \
-        timm==0.4.12 \
-        torch==2.2.2 \
-        torchaudio==2.2.2 \
-        torchtext \
-        torchvision==0.17.2 \
-        tqdm \
-        transformers==4.27.4 \
-        wget && \
-    python3 -m ipykernel.kernelspec
+RUN python3 -m pip --no-cache-dir install 'numpy<2'
 
 # Install cmake
 RUN mkdir -p /opt/cmake  &&  \
@@ -223,12 +148,6 @@ RUN mkdir -p /opt/cmake  &&  \
     ln -fs /opt/cmake/bin/cmake /usr/local/bin/cmake && \
     ln -fs /opt/cmake/bin/ctest /usr/local/bin/ctest && \
     ln -fs /opt/cmake/bin/cpack /usr/local/bin/cpack
-
-# Onnxruntime C/C++ package needed to create custom C++ onnx ops for quantsim
-RUN mkdir /opt/onnxruntime && \
-    export ONNXRUNTIME_VER=$(python3 -c 'import onnxruntime; print(onnxruntime.__version__)') && \
-    wget -qO- "https://github.com/microsoft/onnxruntime/releases/download/v${ONNXRUNTIME_VER}/onnxruntime-linux-x64-${ONNXRUNTIME_VER}.tgz" | tar xvz --strip-components 1 -C /opt/onnxruntime && \
-    ln -s /opt/onnxruntime /usr/local/bin/onnxruntime_headers
 
 ENV PATH=/usr/local/bin:$PATH
 
@@ -261,22 +180,6 @@ RUN sed -i 's/PermitRootLogin prohibit-password/PermitRootLogin yes/' /etc/ssh/s
 # SSH login fix. Otherwise user is kicked off after login
 RUN sed 's@session\s*required\s*pam_loginuid.so@session optional pam_loginuid.so@g' -i /etc/pam.d/sshd
 
-RUN python3 -m pip install git-pylint-commit-hook osqp twine
-
-RUN python3 -m pip install holoviews netron jsonschema pandas
-
-# Note: bokeh requires Pillow while we need to use Pillow-SIMD for performance reasons.
-RUN python3 -m pip install bokeh hvplot
-
-# Remove onnxruntime install and replace with onnxruntime-gpu
-RUN export ONNXRUNTIME_VER=$(python3 -c 'import onnxruntime; print(onnxruntime.__version__)') && \
-    python3 -m pip uninstall -y onnxruntime && \
-    python3 -m pip --no-cache-dir install onnxruntime-gpu==$ONNXRUNTIME_VER
-
-# Remove existing Pillow & Pillow-SIMD and replace with correct version of Pillow-SIMD.
-RUN python3 -m pip uninstall -y Pillow Pillow-SIMD
-RUN python3 -m pip --no-cache-dir install Pillow-SIMD==9.0.0.post1
-
 RUN apt-get update && apt-get install -y gnupg2
 RUN wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add - && echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-14 main" >> /etc/apt/sources.list
 RUN apt-get update --fix-missing -y && apt upgrade -y && apt-get install -y clang-11 clang-format clang-tidy-11 && \
@@ -296,3 +199,5 @@ RUN cd /usr/local && \
     mv cutlass cutlass-3.3.0 && \
     chown -R root:users cutlass-3.3.0 && \
     ln -s cutlass-3.3.0 cutlass
+
+RUN python3 -m pip --no-cache-dir install torch==2.2


### PR DESCRIPTION
Removed pip packages unnecessary for build from docker image for PyPI release (aka fast-release).