### PR TITLE
Replace lapacke with eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ endif()
 find_package(Threads)
 
 find_package(PkgConfig)
-pkg_search_module(LAPACKE REQUIRED lapacke)
+find_package (Eigen3 REQUIRED)
 
 #find_package(OpenCV REQUIRED)
 pkg_search_module(OPENCV opencv) # in case opencv will not be found, it would be built form source
@@ -194,7 +194,6 @@ if (ENABLE_ONNX)
     set_onnxruntime_variables()
     set_torch_cmake_prefix_path()
 
-    find_package(Eigen3 REQUIRED)
 endif()
 
 if (ENABLE_TENSORFLOW)

--- a/Jenkins/Dockerfile.onnx-cpu
+++ b/Jenkins/Dockerfile.onnx-cpu
@@ -219,8 +219,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.onnx-gpu
+++ b/Jenkins/Dockerfile.onnx-gpu
@@ -230,8 +230,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.tf-cpu
+++ b/Jenkins/Dockerfile.tf-cpu
@@ -101,6 +101,7 @@ RUN apt-get update > /dev/null && \
         less \
         libavcodec-dev \
         libavformat-dev \
+        libeigen3-dev \
         libgtest-dev \
         libgtk2.0-dev \
         libsox-dev \

--- a/Jenkins/Dockerfile.tf-cpu
+++ b/Jenkins/Dockerfile.tf-cpu
@@ -201,8 +201,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.tf-gpu
+++ b/Jenkins/Dockerfile.tf-gpu
@@ -212,8 +212,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.tf-gpu
+++ b/Jenkins/Dockerfile.tf-gpu
@@ -112,6 +112,7 @@ RUN apt-get update > /dev/null && \
         less \
         libavcodec-dev \
         libavformat-dev \
+        libeigen3-dev \
         libgtest-dev \
         libgtk2.0-dev \
         libsox-dev \

--- a/Jenkins/Dockerfile.tf-torch-cpu
+++ b/Jenkins/Dockerfile.tf-torch-cpu
@@ -218,8 +218,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.torch-cpu
+++ b/Jenkins/Dockerfile.torch-cpu
@@ -223,8 +223,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.torch-cpu-pt113
+++ b/Jenkins/Dockerfile.torch-cpu-pt113
@@ -223,8 +223,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.torch-gpu
+++ b/Jenkins/Dockerfile.torch-gpu
@@ -235,8 +235,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/Dockerfile.torch-gpu-pt113
+++ b/Jenkins/Dockerfile.torch-gpu-pt113
@@ -235,8 +235,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Jenkins/fast-release/Dockerfile.torch-gpu
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu
@@ -165,8 +165,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/ModelOptimizations/DlCompression/CMakeLists.txt
+++ b/ModelOptimizations/DlCompression/CMakeLists.txt
@@ -42,13 +42,12 @@ add_library(MoDlCompression STATIC
       )
 
 target_include_directories(MoDlCompression
-      PRIVATE ${LAPACKE_INCLUDE_DIRS} ${OPENCV_INCLUDE_DIRS}
+      PRIVATE ${EIGEN3_INCLUDE_DIR} ${OPENCV_INCLUDE_DIRS}
       PUBLIC
          ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_link_libraries(MoDlCompression PUBLIC
     pybind11
-    ${LAPACKE_LINK_LIBRARIES}
     ${OPENCV_LINK_LIBRARIES}
     z
     )

--- a/ModelOptimizations/DlCompression/src/SvdAlgorithm.hpp
+++ b/ModelOptimizations/DlCompression/src/SvdAlgorithm.hpp
@@ -43,9 +43,11 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <Eigen/SVD>
 
 #ifdef USE_OPENCV
 
+#include <opencv2/core/eigen.hpp>
 #include <opencv2/core/core.hpp>
 
 #endif   // USE_OPENCV

--- a/packaging/dockers/Dockerfile.torch_gpu
+++ b/packaging/dockers/Dockerfile.torch_gpu
@@ -43,8 +43,6 @@ EXPOSE 25000
 RUN apt-get update && apt-get install -y openssh-server && rm -rf /var/lib/apt/lists/*
 RUN mkdir /var/run/sshd
 
-RUN apt-get update && apt-get install -y liblapacke liblapacke-dev && rm -rf /var/lib/apt/lists/*
-
 RUN apt-get update && apt-get install -y libjpeg8-dev && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Main Changes
Replaced lapacke with eigen, which can be **fully statically compiled**.
This means **we can kick out this line from installation instruction** and now it's truly a single-liner `pip install aimet-torch`
![image](https://github.com/user-attachments/assets/9cf17f14-9876-41bf-a556-61dcbcd29a99)