### PR TITLE
Temporarily restore ExportableQuantModule for backwards-compatibility

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -218,6 +218,10 @@ class _QuantizedModuleProtocol(Protocol):
         """
 
 
+# Temporary alias for backwards-compatibility
+ExportableQuantModule = _QuantizedModuleProtocol
+
+
 # Types of modules which cannot be quantized
 unquantizable_modules = (
     torch.nn.Identity,


### PR DESCRIPTION
We renamed `ExportableQuantModule` to `QuantizedModuleProtocol` in https://github.com/quic/aimet/commit/45bea72d964db3a7ae63cef08e66e669df72af1a

However, though `ExportableQuantModule` was some internal/temporary thing introduced to make v1->v2 transition easier,
some of our users might be relying on importing `ExportableQuantModule`
As a temporary workaround, I restored the name `ExportableQuantModule` as a mere alias of `QuantizedModuleProtocol`