### PR TITLE
Let cmake use exact system default python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,8 +109,14 @@ if (ENABLE_TORCH AND ENABLE_TENSORFLOW)
 endif()
 
 # Find Python libraries
+execute_process(
+    COMMAND python3 -V       # "Python 3.XX.YY\n"
+    COMMAND cut -d " " -f 2  # "3.XX.YY\n"
+    COMMAND head -c -1       # "3.XX.YY"
+    OUTPUT_VARIABLE Python3_VERSION
+)
 set(Python3_FIND_VIRTUALENV "STANDARD")
-find_package(Python3 COMPONENTS Interpreter Development)
+find_package(Python3 ${Python3_VERSION} EXACT COMPONENTS Interpreter Development)
 message(STATUS "Found Python3: ${Python3_FOUND}, at ${Python3_LIBRARIES}")
 
 # -------------------------------

--- a/Jenkins/fast-release/Dockerfile.torch-gpu
+++ b/Jenkins/fast-release/Dockerfile.torch-gpu
@@ -83,8 +83,6 @@ RUN echo "%users ALL = (ALL) NOPASSWD: ALL" >> /etc/sudoers
 # Python
 RUN add-apt-repository ppa:deadsnakes/ppa && \
     apt-get update -y > /dev/null && \
-    apt-get remove -y python3.10 && \
-    apt-get autoremove  -y && \
     apt-get install --no-install-recommends -y \
         python${PYTHON_VERSION} \
         python${PYTHON_VERSION}-dev \


### PR DESCRIPTION
## Problem Description
Currently our fast-release dockerfile deletes default system Python (=3.10) and installs different version of Python as system default.
https://github.com/quic/aimet/blob/ef5ec17e89915803e42896a2b7f6424bf1f8d93e/Jenkins/fast-release/Dockerfile.torch-gpu#L86-L87
However, permanently deleting Python 3.10 can make Ubuntu unstable since there are so many other apt-get packages that are dependent on python 3.10.

## Main Changes
1. Do **NOT** remove python 3.10 from docker image
2. Let cmake find the **EXACT** system default python.
This is necessary when, for example, your system has both 3.8 and 3.10 and you want to use 3.8 for aimet packaging, since cmake `find_package` by default tries to find the latest compatible python in your system 
