### PR TITLE
Version selection page

### DIFF
--- a/Docs/beta/_static/aimet-furo.css
+++ b/Docs/beta/_static/aimet-furo.css
@@ -34,3 +34,23 @@
     /* Allow output block to take up maximum 25 lines */
     max-height: 25em;
 }
+
+/* Handle the scrollable TOC (sidebar-tree) and the
+ * non-scrollable portion of the TOC tree (fixed-sidebar-tree).
+ * Kind of a hack, but there are limited ways to tie the sidebar
+ * to the RST file content.
+*/
+
+.fixed-sidebar-tree li:not(:first-of-type) {
+    display: none;
+ }
+ .fixed-sidebar-tree li:first-of-type {
+    list-style: none;
+    margin: 0;
+    position: relative;
+    margin: var(--sidebar-item-spacing-vertical) 0;
+}
+ 
+ .sidebar-tree li:first-of-type {
+    display: none;
+}

--- a/Docs/beta/_templates/sidebar/doc_versions.html
+++ b/Docs/beta/_templates/sidebar/doc_versions.html
@@ -1,11 +1,7 @@
 <div class="doc-versions" data-toggle="doc-versions" role="note" aria-label="versions">
 
-  <span class="doc-current-version" data-toggle="doc-current-version">
-    Version: {{ current_version }}
-  </span>
-  <br>
-  <span class="doc-other-versions" data-toggle="doc-other-versions">
-        {{ versions_page }}
-  </span>
-
+  <div class="fixed-sidebar-tree">
+    {{ toctree(includehidden=True, collapse=False, titles_only=True, maxdepth=1) }}
+  </div>
+  
 </div>

--- a/Docs/beta/conf.py
+++ b/Docs/beta/conf.py
@@ -134,7 +134,7 @@ autosectionlabel_prefix_document = True
 # a list of builtin themes.
 #
 html_theme = 'furo'
-html_title = 'AI Model Efficiency Toolkit'
+html_title = 'AI Model Efficiency Toolkit v. ' + release
 # html_short_title = 'AIMET Docs v. ' + version
 # html_logo = 'images/brain_logo.png'
 # html_favicon = 'images/brain_logo16.png'
@@ -193,8 +193,7 @@ html_sidebars = {
 # Parameters for use in templates
 
 html_context = {
-  'current_version' : "1.36",
-  'versions_page' : '<a href="https://dummypageXYZ/versions.html">Other versions</a>'
+  'current_version' : "1.36"
 }
 
 # -- Options for HTMLHelp output ---------------------------------------------

--- a/Docs/beta/index.rst
+++ b/Docs/beta/index.rst
@@ -10,6 +10,7 @@ AI Model Efficiency Toolkit Documentation
    :hidden:
    :includehidden:
 
+   Previous AIMET Versions <versions> 
    Quick Start <install/quick-start>
    Installation <install/index>
    User Guide <opt-guide/index>


### PR DESCRIPTION
Modify version link in sidebar. Added version selection page.

Solution uses the toctree to link the page from the sidebar, and CSS to edit the contents of both the version link and the TOC. There might be a more elegant way to do this, but it probably involves writing code.