### PR TITLE
Batch size issue in the per-layer output utility

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/layer_output_utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/layer_output_utils.py
@@ -79,7 +79,6 @@ class SaveInputOutput:
         :return:
         """
         file_path = os.path.join(dir_path, file_name + '.raw')
-        numpy_tensor = np.expand_dims(numpy_tensor, axis=0)
 
         # Convert axis-layout of the tensor to NHWC if not already
         if numpy_tensor.ndim == 4 and axis_layout == 'NCHW':

--- a/TrainingExtensions/common/src/python/aimet_common/layer_output_utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/layer_output_utils.py
@@ -44,12 +44,12 @@ import numpy as np
 
 
 class SaveInputOutput:
-    """ This class saves the input batches and corresponding layer-output batches to the disk. """
+    """ This class saves the input instance and corresponding layer-outputs to the disk. """
 
     def __init__(self, dir_path: str, axis_layout: str):
         """
         Constructor
-        :param dir_path: Directory to save input and output batches.
+        :param dir_path: Directory to save input and output.
         :param axis_layout: Axis-layout of the tensor in source framework. Eg: NCHW or NHWC
         """
         self.dir_path = dir_path
@@ -88,13 +88,13 @@ class SaveInputOutput:
         with open(file_path, 'wb') as fptr:
             numpy_tensor.tofile(fptr)
 
-    def save(self, input_batch: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]], layer_output_batch: dict):
+    def save(self, input_instance: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]], layer_output: dict):
         """
         This function saves the input and layer-outputs in the form of raw files. Separate directories are used to store inputs
         and outputs. The correspondence between input and output is obtained using an identical number which is used for naming.
 
-        :param input_batch: Inputs for which we want to obtain layer-outputs.
-        :param layer_output_batch: Dictionary where key is output-name and value is batch of outputs.
+        :param input_instance: Input instance for which we want to obtain layer-outputs.
+        :param layer_output: Dictionary where key is output-name and value is output(s).
         :return:
         """
         input_dir = os.path.join(self.dir_path, 'inputs')
@@ -102,24 +102,21 @@ class SaveInputOutput:
         os.makedirs(input_dir, exist_ok=True)
         os.makedirs(output_dir, exist_ok=True)
 
-        batch_size = len(input_batch[0]) if isinstance(input_batch, (List, Tuple)) else len(input_batch)
+        if isinstance(input_instance, (List, Tuple)):
+            multi_input_dir = os.path.join(input_dir, 'input_' + str(self.input_cntr))
+            os.makedirs(multi_input_dir, exist_ok=True)
+            for i, ith_input in enumerate(input_instance):
+                SaveInputOutput.save_raw_tensor(ith_input, self.axis_layout, str(i), multi_input_dir)
+        else:
+            input_file_name = 'input_' + str(self.input_cntr)
+            SaveInputOutput.save_raw_tensor(input_instance, self.axis_layout, input_file_name, input_dir)
 
-        for idx in range(batch_size):
-            if isinstance(input_batch, (List, Tuple)):
-                multi_input_dir = os.path.join(input_dir, 'input_' + str(self.input_cntr))
-                os.makedirs(multi_input_dir, exist_ok=True)
-                for i, ith_input_batch in enumerate(input_batch):
-                    SaveInputOutput.save_raw_tensor(ith_input_batch[idx], self.axis_layout, str(i), multi_input_dir)
-            else:
-                input_file_name = 'input_' + str(self.input_cntr)
-                SaveInputOutput.save_raw_tensor(input_batch[idx], self.axis_layout, input_file_name, input_dir)
+        layer_output_dir = os.path.join(output_dir, 'layer_outputs_' + str(self.input_cntr))
+        os.makedirs(layer_output_dir, exist_ok=True)
+        for layer_output_name in layer_output:
+            SaveInputOutput.save_raw_tensor(layer_output[layer_output_name], self.axis_layout, layer_output_name, layer_output_dir)
 
-            layer_output_dir = os.path.join(output_dir, 'layer_outputs_' + str(self.input_cntr))
-            os.makedirs(layer_output_dir, exist_ok=True)
-            for layer_output_name in layer_output_batch:
-                SaveInputOutput.save_raw_tensor(layer_output_batch[layer_output_name][idx], self.axis_layout, layer_output_name, layer_output_dir)
-
-            self.input_cntr += 1
+        self.input_cntr += 1
 
 
 def save_layer_output_names(layer_output_names: list, dir_path: str):

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/layer_output_utils.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/layer_output_utils.py
@@ -85,21 +85,21 @@ class LayerOutputUtil:
         # Utility to save model inputs and their corresponding layer-outputs
         self.save_input_output = SaveInputOutput(dir_path, 'NCHW')
 
-    def generate_layer_outputs(self, input_batch: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]):
+    def generate_layer_outputs(self, input_instance: Union[np.ndarray, List[np.ndarray], Tuple[np.ndarray]]):
         """
         This method captures output of every layer of a model & saves the inputs and corresponding layer-outputs to disk.
 
-        :param input_batch: Batch of inputs for which we want to obtain layer-outputs.
+        :param input_instance: Single input instance for which we want to obtain layer-outputs.
         :return: None
         """
-        logger.info("Generating layer-outputs for %d input instances", len(input_batch))
+        logger.info("Generating layer-outputs for input instance %d", self.save_input_output.input_cntr+1)
 
-        input_dict = create_input_dict(self.model, input_batch)
+        input_dict = create_input_dict(self.model, input_instance)
 
         layer_output_dict = self.layer_output.get_outputs(input_dict)
-        self.save_input_output.save(input_batch, layer_output_dict)
+        self.save_input_output.save(input_instance, layer_output_dict)
 
-        logger.info('Layer-outputs generated for %d input instances', len(input_batch))
+        logger.info('Layer-outputs generated for input instance %d', self.save_input_output.input_cntr)
 
 
 class LayerOutput:

--- a/TrainingExtensions/onnx/test/python/test_layer_output_utils.py
+++ b/TrainingExtensions/onnx/test/python/test_layer_output_utils.py
@@ -174,7 +174,8 @@ class TestLayerOutputUtil:
         # Generate layer-outputs
         layer_output_util = LayerOutputUtil(model=quantsim.model.model, dir_path=temp_dir_path)
         for input_batch in dummy_data_loader:
-            layer_output_util.generate_layer_outputs(input_batch.numpy())
+            for single_input in input_batch:
+                layer_output_util.generate_layer_outputs(single_input.unsqueeze(0).numpy())
 
         # Verify number of inputs
         assert data_count == len(os.listdir(os.path.join(temp_dir_path, 'inputs')))

--- a/TrainingExtensions/onnx/test/python/test_layer_output_utils.py
+++ b/TrainingExtensions/onnx/test/python/test_layer_output_utils.py
@@ -34,7 +34,7 @@
 #
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
-
+import copy
 import os
 import shutil
 
@@ -172,10 +172,13 @@ class TestLayerOutputUtil:
         temp_dir_path = os.path.join(temp_dir_path, 'temp_dir')
 
         # Generate layer-outputs
+        layer_out_dict_list = []
         layer_output_util = LayerOutputUtil(model=quantsim.model.model, dir_path=temp_dir_path)
         for input_batch in dummy_data_loader:
             for single_input in input_batch:
                 layer_output_util.generate_layer_outputs(single_input.unsqueeze(0).numpy())
+                layer_out_dict_list.append(copy.deepcopy(layer_output_util.layer_output.get_outputs(
+                    {"input": single_input.unsqueeze(0).numpy()})))
 
         # Verify number of inputs
         assert data_count == len(os.listdir(os.path.join(temp_dir_path, 'inputs')))
@@ -194,6 +197,16 @@ class TestLayerOutputUtil:
         session = QuantizationSimModel.build_session(quantsim.model.model, providers)
         input_dict = {'input': np.expand_dims(dummy_dataset.__getitem__(0).numpy(), axis=0)}
         assert np.array_equal(session.run(None, input_dict)[0], saved_last_layer_output)
+
+        # Ensure the saved outputs are with axis-transform
+        for idx, layer_out_dict in enumerate(layer_out_dict_list):
+            # Convert the layer output from NCHW to NHWC
+            layer_out = layer_out_dict['conv_output_3'].transpose(0, 2, 3, 1)
+
+            # Saved output should already be in NHWC format
+            saved_conv_output = np.fromfile(os.path.join(temp_dir_path, 'outputs', f'layer_outputs_{idx}',
+                                                         'conv_output_3.raw'), dtype=np.float32).reshape(layer_out.shape)
+            np.testing.assert_array_equal(layer_out, saved_conv_output)
 
         # Delete temp_dir
         shutil.rmtree(temp_dir_path, ignore_errors=False, onerror=None)

--- a/TrainingExtensions/tensorflow/test/python/test_keras_layer_outputs.py
+++ b/TrainingExtensions/tensorflow/test/python/test_keras_layer_outputs.py
@@ -129,7 +129,8 @@ class TestLayerOutputUtil:
         layer_output_util_obj = LayerOutputUtil(model=qs_obj.model, save_dir=save_dir)
         for batch_num, inp_batch in enumerate(dataloader):
             batch_x, _ = inp_batch
-            layer_output_util_obj.generate_layer_outputs(input_batch=batch_x)
+            for single_input in batch_x:
+                layer_output_util_obj.generate_layer_outputs(np.expand_dims(single_input, axis=0))
 
         # Verify number of inputs
         assert data_points == len(glob(save_dir+"/inputs/*.raw")) ## Check #Inputs

--- a/TrainingExtensions/torch/test/python/test_layer_output_utils.py
+++ b/TrainingExtensions/torch/test/python/test_layer_output_utils.py
@@ -51,7 +51,7 @@ from aimet_torch.v2.quantsim import QuantizationSimModel as QuantizationSimModel
 from aimet_torch.layer_output_utils import NamingScheme, LayerOutputUtil, LayerOutput
 from aimet_torch.utils import is_leaf_module
 from aimet_torch.onnx_utils import OnnxExportApiArgs
-from aimet.TrainingExtensions.torch.test.python.models import test_models
+from models import test_models
 
 
 def dummy_forward_pass(model: torch.nn.Module, input_batch: torch.Tensor):

--- a/TrainingExtensions/torch/test/python/test_layer_output_utils.py
+++ b/TrainingExtensions/torch/test/python/test_layer_output_utils.py
@@ -42,6 +42,7 @@ import torch
 import numpy as np
 from torch.utils.data import Dataset, DataLoader
 from torchvision import models
+import tempfile
 
 from aimet_torch.model_preparer import prepare_model
 from aimet_torch.model_validator.model_validator import ModelValidator
@@ -50,6 +51,7 @@ from aimet_torch.v2.quantsim import QuantizationSimModel as QuantizationSimModel
 from aimet_torch.layer_output_utils import NamingScheme, LayerOutputUtil, LayerOutput
 from aimet_torch.utils import is_leaf_module
 from aimet_torch.onnx_utils import OnnxExportApiArgs
+from aimet.TrainingExtensions.torch.test.python.models import test_models
 
 
 def dummy_forward_pass(model: torch.nn.Module, input_batch: torch.Tensor):
@@ -77,11 +79,14 @@ def get_original_model_artifacts():
     return model, layer_names, dummy_input
 
 
-def get_quantsim_artifacts(_QuantizationSimModel):
-    # Load resnet18 model
-    model = models.resnet18()
-    model.eval()
-    dummy_input = torch.rand(1, 3, 224, 224)
+def get_quantsim_artifacts(_QuantizationSimModel, model_and_input=None):
+    if model_and_input is not None:
+        model, dummy_input = model_and_input
+    else:
+        # Load resnet18 model
+        model = models.resnet18()
+        model.eval()
+        dummy_input = torch.rand(1, 3, 224, 224)
 
     # Prepare model for quantization simulation
     model = prepare_model(model)
@@ -254,3 +259,32 @@ class TestLayerOutputUtil:
 
         # Delete temp_dir
         shutil.rmtree(temp_dir_path, ignore_errors=False, onerror=None)
+
+    @pytest.mark.parametrize('_QuantizationSimModel', [QuantizationSimModelV1, QuantizationSimModelV2])
+    def test_layer_output_axis_transform(self, _QuantizationSimModel):
+        """ Test to ensure the layer outputs are saved with axis-transform """
+
+        model = test_models.ModelWithOneSplit().to(device='cpu')
+        input_shapes = (1, 1, 10, 10)
+        dummy_input = torch.randn(input_shapes)
+        qsim, layer_names, _ = get_quantsim_artifacts(_QuantizationSimModel, model_and_input=(model, dummy_input))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Generate layer-outputs
+            layer_output_util = LayerOutputUtil(model=qsim.model, dir_path=tmpdir)
+            for single_input in dummy_input:
+                layer_output_util.generate_layer_outputs(single_input.unsqueeze(0))
+
+            for conv_layer_name in layer_names:
+                # Output in NCHW format
+                layer_output_from_dict = layer_output_util.layer_output.layer_name_to_layer_output_dict[conv_layer_name]
+
+                # Convert from NCHW to NHWC
+                layer_output_from_dict = layer_output_from_dict.detach().permute(0, 2, 3, 1)
+
+                # Saved output should already be in NHWC format
+                saved_output = np.fromfile(tmpdir+f"/outputs/layer_outputs_0/{conv_layer_name}.raw",
+                                           dtype=np.float32).reshape(layer_output_from_dict.shape)
+                saved_output = torch.from_numpy(saved_output)
+
+                assert torch.equal(layer_output_from_dict, saved_output)

--- a/TrainingExtensions/torch/test/python/test_layer_output_utils.py
+++ b/TrainingExtensions/torch/test/python/test_layer_output_utils.py
@@ -231,7 +231,8 @@ class TestLayerOutputUtil:
         # Generate layer-outputs
         layer_output_util = LayerOutputUtil(model=quantsim.model, dir_path=temp_dir_path)
         for input_batch in dummy_data_loader:
-            layer_output_util.generate_layer_outputs(input_batch)
+            for single_input in input_batch:
+                layer_output_util.generate_layer_outputs(single_input.unsqueeze(0))
 
         # Verify number of inputs
         assert data_count == len(os.listdir(os.path.join(temp_dir_path, 'inputs')))


### PR DESCRIPTION
Fixes #3580 

Eliminate the detection of batch size from the intermediate output tensors, and consider these outputs as a single instance rather than multiple outputs.