### PR TITLE
Make onnx ConnectedGraph one-to-one with onnx model

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/connected_graph/connectedgraph_utils.py
+++ b/TrainingExtensions/common/src/python/aimet_common/connected_graph/connectedgraph_utils.py
@@ -54,7 +54,7 @@ def get_all_input_ops(conn_graph: ConnectedGraph) -> List[Op]:
     """
 
     all_ops = conn_graph.get_all_ops().values()
-    input_ops = [op for op in all_ops if not op.input_ops]
+    input_ops = []
     for op in all_ops:
         for item in op.inputs:
             if not item.producer and item.is_model_input:

--- a/TrainingExtensions/common/src/python/aimet_common/graph_searcher.py
+++ b/TrainingExtensions/common/src/python/aimet_common/graph_searcher.py
@@ -106,6 +106,8 @@ class GraphSearcher:
             # Still more to match
             if not op.output:
                 return None
+            if len(op.output_ops) > 1: # Can't match patterns with branches
+                return None
             for child_op in op.output.consumers:
                 matched_child_ops = self._match_pattern(child_op, pattern[1:], ignored_ops)
                 if matched_child_ops:

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -40,7 +40,7 @@
 """For constructing a uniform representation of the computational graph for an ONNX model,
 that is easy to navigate and stores information for the purpose of AIMET features.
 The representation graph consists of nodes that are either 'operation' or 'product';
-operations represent an operation that generates a tensor, while products represent
+operations represent a node that generates a tensor, while products represent
 the tensors that are either input to the model (input, constant or parameter) or the
 result of an operation. Furthermore the graph representation is bi-directional."""
 
@@ -190,8 +190,10 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
     def fill_op_product_graph(self):
         """
-        - DFS over the graph beginning with input op given as start_op_name
-        - Creates op/product graph
+        - Creates a product for all tensors (model inputs, constants/initializers, node outputs) in the onnx graph
+        - Creates an op for all nodes in the onnx graph
+        - Links products with their producer and consumer ops
+        - Identifies which products should be considered parameters
         """
 
         # Add products for all tensors in initializer

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -90,15 +90,7 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         self.model = model
         if isinstance(self.model, ONNXModel):
             self.model = self.model.model
-
-        # Maps output to consumer node
-        self._input_to_node = self._get_input_to_node()
-        self._output_to_node = self._get_output_to_node()
-
         self.fill_op_product_graph()
-        del self._input_to_node
-        del self._output_to_node
-
         self.starting_ops = list(self._get_starting_ops())
         # List of ops in the order they are traversed using the forward function
         self.ordered_ops = get_ordered_ops(self.starting_ops)
@@ -109,30 +101,6 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         :param name: Name of the module
         """
         return self._ops[name]
-
-    def _get_input_to_node(self):
-        """
-        Maps input names to nodes
-        """
-        input_to_node_dict = {}
-        for node in self.model.graph.node:
-            for input_name in node.input:
-                consumers = input_to_node_dict.get(input_name, [])
-                consumers.append(node)
-                input_to_node_dict[input_name] = consumers
-
-        return input_to_node_dict
-
-    def _get_output_to_node(self):
-        """
-        Maps output names to nodes
-        """
-        output_to_node_dict = {}
-        for node in self.model.graph.node:
-            for output_name in node.output:
-                output_to_node_dict[output_name] = node
-
-        return output_to_node_dict
 
     @staticmethod
     def _create_ir_op(node: NodeProto) -> Op:

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -224,10 +224,10 @@ class ConnectedGraph(AimetCommonConnectedGraph):
                 product.add_consumer(op)
                 product.tensor_dict[op] = inp # TODO: Delete Product.tensor_dict attribute
 
-            for output in node.output:
+            for idx, output in enumerate(node.output):
                 product = self._products[output]
                 # TODO: Make Op.output list of products to support multi-output ops
-                if op.output is None:
+                if idx == 0: # For backwards compatibility, op.output is always first product
                     op.output = product
                 product.producer = op
 

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/meta/connectedgraph.py
@@ -37,14 +37,14 @@
 #
 #  =============================================================================
 
-"""For constructing a uniform representation of the computational graph for a PyTorch model,
+"""For constructing a uniform representation of the computational graph for an ONNX model,
 that is easy to navigate and stores information for the purpose of AIMET features.
 The representation graph consists of nodes that are either 'operation' or 'product';
-operations represent a module or a function that generates a tensor, while products represent
+operations represent an operation that generates a tensor, while products represent
 the tensors that are either input to the model (input, constant or parameter) or the
 result of an operation. Furthermore the graph representation is bi-directional."""
 
-from typing import List, Union, Dict
+from typing import Union
 from onnxruntime.quantization.onnx_quantizer import ONNXModel
 import onnx
 from packaging import version  # pylint: disable=wrong-import-order
@@ -76,9 +76,11 @@ CONSTANT_TYPE = ['Constant', 'ConstantOfShape']
 
 class ConnectedGraph(AimetCommonConnectedGraph):
     """
-    For construction of a graph that connects operations together (
-    either module or functional) as producers and consumers of tensors.
-    Note that the graph has two kinds of nodes: operations and products."""
+    For construction of a graph that connects operations together as producers and consumers of tensors.
+    Note that the graph has two kinds of nodes: operations and products.
+
+    Operations represent the nodes in an onnx model, while products represent the tensors.
+    """
 
     def __init__(self, model: ModelProto):
         """
@@ -90,31 +92,16 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             self.model = self.model.model
 
         # Maps output to consumer node
-        self._input_to_node = {}
-        self._get_input_to_node()
-        self._unnamed_op = 0
-
-        self.starting_ops = []
-        self._branch_count = 0
-
-        # Counts number of constant inputs there are in the graph
-        self._constant_count = 0
-        self._constant_nodes_to_output = self._create_set_of_constant_nodes()
+        self._input_to_node = self._get_input_to_node()
+        self._output_to_node = self._get_output_to_node()
 
         self.fill_op_product_graph()
+        del self._input_to_node
+        del self._output_to_node
+
+        self.starting_ops = list(self._get_starting_ops())
         # List of ops in the order they are traversed using the forward function
         self.ordered_ops = get_ordered_ops(self.starting_ops)
-
-    def _create_set_of_constant_nodes(self) -> Dict:
-        constant_nodes = {}
-        for node in self.model.graph.node:
-            if node.op_type in CONSTANT_TYPE:
-                for output in node.output:
-                    if node.name in constant_nodes:
-                        constant_nodes[node.name].append(output)
-                    else:
-                        constant_nodes[node.name] = [output]
-        return constant_nodes
 
     def get_op_from_module_name(self, name: str) -> Op:
         """
@@ -127,62 +114,25 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         """
         Maps input names to nodes
         """
+        input_to_node_dict = {}
         for node in self.model.graph.node:
             for input_name in node.input:
-                if input_name in self._input_to_node:
-                    self._input_to_node[input_name].append(node)
-                else:
-                    self._input_to_node[input_name] = [node]
+                consumers = input_to_node_dict.get(input_name, [])
+                consumers.append(node)
+                input_to_node_dict[input_name] = consumers
 
-    # pylint: disable=too-many-branches
-    def _get_input_ops(self) -> List:
-        """ Gets list of names of starting nodes"""
+        return input_to_node_dict
 
-        def check_if_node_has_predecessor(node):
-            for input_name in node.input:
-                if input_name in output_names:
-                    return True
-            return False
-
-        output_names = {}
-        input_tensors_names = []
+    def _get_output_to_node(self):
+        """
+        Maps output names to nodes
+        """
+        output_to_node_dict = {}
         for node in self.model.graph.node:
-            for node_output in node.output:
-                output_names[node_output] = node
+            for output_name in node.output:
+                output_to_node_dict[output_name] = node
 
-        # Capture constant tensors associated to a node that has only contant tensor inputs and are not in the form of a constant node.
-        for node in self.model.graph.node:
-            if node.op_type != 'Identity' and node.op_type not in OPS_WITH_PARAMS and not check_if_node_has_predecessor(node):
-                for input_name in node.input:
-                    if input_name not in output_names:
-                        input_tensors_names.append(input_name)
-
-        # Capture model input tensors.
-        for tensor in self.model.graph.input:
-            if tensor.name not in input_tensors_names and tensor.name in self._input_to_node:
-                input_tensors_names.append(tensor.name)
-
-        # Capture nodes having all the inputs as constant tensors and these constants are coming from a constant node.
-        input_ops = []
-        for node in self.model.graph.node:
-            flag = True
-            if node.op_type == 'Constant':
-                continue
-            for input_name in node.input:
-                if input_name in output_names and output_names[input_name].op_type == 'Constant':
-                    continue
-                flag = False
-                break
-            if flag and node not in input_ops:
-                input_ops.append(node)
-
-        for input_tensor_name in input_tensors_names:
-            if input_tensor_name in self._input_to_node:
-                for node in self._input_to_node[input_tensor_name]:
-                    if node not in input_ops:
-                        input_ops.append(node)
-
-        return input_ops
+        return output_to_node_dict
 
     @staticmethod
     def _create_ir_op(node: NodeProto) -> Op:
@@ -205,342 +155,98 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
         return op
 
-    def _add_children_ops_to_op_queue(self, node: NodeProto, op_queue: List):
-        """
-        Utility function for adding all children of op to self._op_queue
-        :param node: node whose children will be added to op_queue
-        :param op_queue: Queue for performing dfs
-        """
-        for output_tensor in node.output:
-            if output_tensor in self._input_to_node:
-                for child_node in self._input_to_node[output_tensor]:
-                    op_queue.append((child_node, node, output_tensor))
-
-    def _process_starting_ops(self, op_queue: List):
-        """
-        Processes input ops
-        :param op_queue: Queue for performing dfs
-        """
-        input_ops = self._get_input_ops()
-        for node in input_ops:
-            if not node.name:
-                node.name = str(node.op_type) + '_unnamed_' + str(self._unnamed_op)
-                self._unnamed_op += 1
-            node_name = node.name
-            if node_name not in self._ops:
-                op = self._create_ir_op(node)
-                self._ops[node_name] = op
-                self._add_children_ops_to_op_queue(node, op_queue)
-                self.starting_ops.append(op)
-            for index, input_tensor_name in enumerate(node.input):
-                if self.check_if_param(node, index):
-                    continue
-                if self.check_if_const(input_tensor_name):
-                    op = self._ops[node.name]
-                    self._create_constant_product(op, input_tensor_name)
-                else:
-                    self._create_and_link_product_for_inputs(node_name, input_tensor_name)
+    def _get_starting_ops(self):
+        for op in self._ops.values():
+            if not op.input_ops:
+                yield op
 
     @staticmethod
-    def check_if_param(node: NodeProto, index: int) -> bool:
-        """
-        Checks if given tensor is a param
-
-        :param node: ONNX node
-        :param index: input index we are looking at
-        """
-        if node.op_type in ['Gemm', 'Conv', 'ConvTranspose'] and index in [WEIGHT_INDEX, BIAS_INDEX]:
-            return True
-        if node.op_type == 'MatMul' and index == WEIGHT_INDEX:
-            return True
-        if node.op_type == 'BatchNormalization' and index in [WEIGHT_INDEX, BIAS_INDEX, RUNNING_VAR_INDEX, RUNNING_MEAN_INDEX]:
-            return True
-        if node.op_type in ['RNN', 'LSTM', 'GRU'] and index != INPUT_INDEX:
-            return True
-
-        return False
-
-    def check_if_const(self, input_tensor_name: str) -> bool:
-        """
-        Checks if given tensor is a constant
-
-        :param input_tensor_name: input tensor name we are looking at
-        """
-        for output_names in self._constant_nodes_to_output.values():
-            if input_tensor_name in output_names:
-                return True
-        return False
-
-    def _create_and_link_product_for_inputs(self, consumer_node_name: str, input_tensor_name: str):
+    def _create_product_for_inputs(input_value_info: onnx.ValueInfoProto):
         """
         Create products between input and op consuming the input
         """
+        shape = [dim.dim_value for dim in input_value_info.type.tensor_type.shape.dim]
+        product = Product(input_value_info.name, shape)
+        product.is_const = False
+        product.is_model_input = True
+        return product
 
-        assert input_tensor_name, "No inputs present in the model"
+    def _create_product_for_activations(self, producer: onnx.NodeProto, tensor_name: str):
+        if producer.op_type == "Constant":
+            return self._create_constant_product(tensor_name, producer.attribute[0].t.dims)
+        return Product(tensor_name, None)
 
-        if input_tensor_name + '_to_' + consumer_node_name in self._products:
-            logger.debug("%s already exists", input_tensor_name + '_to_' + consumer_node_name)
-        else:
-            # TODO: figure out a way to add tensor shape. Adding the shape as None for now
-            product = Product(input_tensor_name + '_to_' + consumer_node_name, None)
-            # add product to self._products dictionary
-            self._products[input_tensor_name + '_to_' + consumer_node_name] = product
-            logger.debug("Created new product " + input_tensor_name + '_to_' + consumer_node_name)
-            product.is_model_input = True
-
-            consumer_op = self._ops[consumer_node_name]
-            product.tensor_dict[consumer_op] = input_tensor_name
-
-            # Link parent op, product, and current op
-            # Fill in input, output, producer, consumer params as appropriate.
-            consumer_op.add_input(product)
-            product.add_consumer(consumer_op)
-
-    def _create_op_if_not_exists(self, node: NodeProto):
-        """ Creates a CG op for a node"""
-        if node.name not in self._ops:
-            op = self._create_ir_op(node)
-            self._ops[node.name] = op
-            logger.debug("Created new op: %s ", node.name)
-        else:
-            logger.debug("Op %s already exists", node.name)
-
-    def _create_and_link_product_if_not_exists(self, child_node: NodeProto, parent_node: NodeProto,
-                                               connecting_tensor_name: str):
-        """ Create and link new product if it does not yet exist """
-        parent_module_name = parent_node.name
-        child_node_name = child_node.name
-        if parent_module_name + '_to_' + child_node_name in self._products:
-            logger.debug("%s already exists", parent_module_name + '_to_' + child_node_name)
-        else:
-            # TODO: figure out a way to add tensor shape. Adding the shape as None for now
-            product = Product(parent_module_name + '_to_' + child_node_name, None)
-            # add product to self._products dictionary
-            self._products[parent_module_name + '_to_' + child_node_name] = product
-            logger.debug("Created new product " + parent_module_name + '_to_' + child_node_name)
-
-            current_op = self._ops[child_node_name]
-            parent_op = self._ops[parent_module_name]
-
-            # find Tensor that corresponds to this product
-            if connecting_tensor_name is None:
-                logger.error("Could not find corresponding tensor between %s and %s",
-                             parent_module_name,
-                             child_node_name)
-                assert False
-            product.tensor_dict[current_op] = connecting_tensor_name
-
-            # Link parent op, product, and current op
-            # Fill in input, output, producer, consumer params as appropriate.
-            current_op.add_input(product)
-            product.producer = parent_op
-            product.add_consumer(current_op)
-            parent_op.output = product
-
-    def _create_link_for_output_product(self, output_tensor_name: str, producer_node_name: str):
-        """ Creates link between nodes and outputs of the model """
-        product_name = producer_node_name + '_to_' + output_tensor_name
-        if product_name in self._products:
-            logger.debug("%s already exists", product_name)
-        else:
-            # TODO: figure out a way to add tensor shape. Adding the shape as None for now
-            product = Product(product_name, None)
-            # add product to self._products dictionary
-            self._products[product_name] = product
-            logger.debug("Created new product %s", product_name)
-
-            producer_op = self._ops[producer_node_name]
-            product.tensor_dict[producer_node_name] = output_tensor_name
-
-            # Link producer op, product, and current tensor
-            producer_op.output = product
-            product.producer = producer_op
-
-    def _create_output_products(self):
-        """ Create products between last node and output """
-        for output in self.model.graph.output:
-            for node in self.model.graph.node:
-                if output.name in node.output:
-                    self._create_link_for_output_product(output.name, node.name)
-
-    def fill_op_product_graph(self):
-        """
-        - DFS over the graph beginning with input op given as start_op_name
-        - Creates op/product graph
-        """
-        visited_ops = set()
-        op_queue = []
-        self._process_starting_ops(op_queue)
-        # op_queue is treated as a stack, containing operations to traverse. Elements are tuple
-        # - Index 0 contains the node to visit.
-        # - Index 1 contains the parent node.
-        while op_queue:
-            child_node, parent_node, connecting_tensor_name = op_queue.pop()
-            if not child_node.name:
-                child_node.name = str(child_node.op_type) + '_unnamed_' + str(self._unnamed_op)
-                self._unnamed_op += 1
-            # new module, create op/product and link to parent
-            if child_node.name != parent_node.name:
-                self._create_op_if_not_exists(child_node)
-                self._create_and_link_product_if_not_exists(child_node, parent_node, connecting_tensor_name)
-
-                # add children to op_queue if not visited
-                if child_node.name not in visited_ops:
-                    self._add_children_ops_to_op_queue(child_node, op_queue)
-                    visited_ops.add(child_node.name)
-                    logger.debug("visited op: %s", child_node.name)
-
-        # Add output products
-        self._create_output_products()
-
-        # Add parameter products during postprocess
-        logger.debug("finished initial pass, num_products is %s", len(self._products))
-        self._create_param_products()
-
-        # Identify places where branch Ops need to be inserted
-        self._branch_ops_processing()
-
-        # Create constant products
-        self._create_constant_products_for_model()
-
-    def _create_constant_products_for_model(self):
-        """ Create constant products for all ops in the model """
-        for node in self.model.graph.node:
-            if node.op_type == 'Constant':
-                for output in node.output:
-                    if output in self._input_to_node:
-                        for op in self._input_to_node[output]:
-                            op_name = op.name
-                            cg_op = self._ops[op_name]
-                            self._create_constant_product(cg_op, output)
-
-    def _create_constant_product(self, consumer, connecting_tensor_name):
+    @staticmethod
+    def _create_constant_product(name, dims):
         """
         Create constant product
 
         :param consumer: Consumer of the product
         :param connecting_tensor_name: tensor that connects consumer and constant op
         """
-        product_name = f'constant_{connecting_tensor_name}' + '_to_' + consumer.name
-        if product_name not in self._products:
-            product = Product(product_name, None)
-            # add product to self._products dictionary
-            self._products[product_name] = product
-            logger.debug("Created new product %s", product_name)
+        product = Product(name, dims)
+        product.is_const = True
+        return product
 
-            product.tensor_dict[consumer] = product_name
+    def fill_op_product_graph(self):
+        """
+        - DFS over the graph beginning with input op given as start_op_name
+        - Creates op/product graph
+        """
 
-            product.is_const = True
+        # Add products for all tensors in initializer
+        for tensor in self.model.graph.initializer:
+            self._products[tensor.name] = self._create_constant_product(tensor.name, tensor.dims)
 
-            self._constant_count += 1
+        # Add products for all model inputs
+        for input_info in self.model.graph.input:
+            self._products[input_info.name] = self._create_product_for_inputs(input_info)
 
-            # Link parent op, product, and current op
-            # Fill in input, output, producer, consumer params as appropriate.
-            consumer.add_input(product)
-            product.add_consumer(consumer)
+        # Create products for all intermediate tensors
+        for node in self.model.graph.node:
+            for output in node.output:
+                self._products[output] = self._create_product_for_activations(node, output)
 
-    def _branch_ops_processing(self):
-        """ Identify places in the op/product graph where branch ops need to be inserted, and create them """
+        # Create ops and link with products
+        for node in self.model.graph.node:
+            if node.op_type == "Constant":
+                continue
 
-        # Dictionary that will map producers (ops) to products
-        # Ops that map to multiple products will be ones to create branch ops for
-        product_producer_dict = dict()
-        for product in self._products.values():
-            if product.producer is not None:
-                if product.producer not in product_producer_dict:
-                    product_producer_dict[product.producer] = [product]
-                else:
-                    product_producer_dict[product.producer].append(product)
+            op = self._create_ir_op(node)
+            self._ops[node.name] = op
+            for inp in node.input:
+                if not inp:
+                    continue # Empty string indicates omitted optional input
+                product = self._products[inp]
+                op.add_input(product)
+                product.add_consumer(op)
+                product.tensor_dict[op] = inp # TODO: Delete Product.tensor_dict attribute
 
-        for op in product_producer_dict:
-            if len(product_producer_dict[op]) > 1:
-                # check if this has an input node
-                is_model_input = False
-                for product in product_producer_dict[op]:
-                    if product.is_model_input:
-                        is_model_input = True
-                # Create branch op directly under op
-                branch_op = self._create_branch_op()
-                # Create product to link op and branch_op
-                self._link_previous_op_to_branch_op(op, branch_op)
-                # Create product to link branch op with multiple children modules
-                self._link_branch_op_to_multiple_ops(branch_op, product_producer_dict[op], is_model_input)
+            for output in node.output:
+                product = self._products[output]
+                # TODO: Make Op.output list of products to support multi-output ops
+                if op.output is None:
+                    op.output = product
+                product.producer = op
 
-    def _create_branch_op(self):
-        """ Create a new branch op in self._ops """
+        # TODO: Move this process outside of ConnectedGraph altogether
+        self._identify_param_products()
 
-        op = Op(name='branch_' + str(self._branch_count), output_shape=None,
-                dotted_name='branch_' + str(self._branch_count),
-                is_anonymous=True,
-                op_type='branch')
-        self._ops[op.name] = op
-        self._branch_count += 1
-        return op
+    def _identify_param_products(self):
+        """ Identify products which are parameters of select modules """
 
-    def _link_previous_op_to_branch_op(self, original_op: Op, branch_op: Op):
-        """ Link the original op to the new branch op by creating a product """
-
-        product = Product(original_op.name + '_to_' + branch_op.name, None)
-        product.producer = original_op
-        product.add_consumer(branch_op)
-        original_op.output = product
-        branch_op.add_input(product)
-        self._products[product.name] = product
-
-    def _link_branch_op_to_multiple_ops(self, branch_op: Op, product_list: list,
-                                        is_model_input: bool = False):
-        """ Create new product with multiple consumers, linking branch op with children ops"""
-
-        branch_op_product = Product(branch_op.name + '_to_' + 'multiple_ops', branch_op.output_shape)
-        branch_op_product.is_model_input = is_model_input
-        branch_op_product.producer = branch_op
-        branch_op.output = branch_op_product
-
-        # For each product from original op to multiple children, we must:
-        # 1: Add each child op as a consumer of the new branch_op_product
-        # 2: Append the old product's corresponding Tensor to the new branch op product's tensor_list
-        # 3: Add new branch_op_product as input for each child op
-        # 4: Remove product from original op to child in child's inputs
-        # 5: Remove product from self._products
-        for product in product_list:
-            assert len(product.consumers) <= 1
-
-            if len(product.consumers) == 1:
-                # item 1
-                branch_op_product.add_consumer(product.consumers[0])
-                # item 2
-                assert len(product.tensor_dict.keys()) == 1
-                branch_op_product.tensor_dict[product.consumers[0]] = product.tensor_dict[product.consumers[0]]
-                # items 3 and 4
-                # replace the old product with the new branch product, in the same index as the old product
-                index = product.consumers[0].inputs.index(product)
-                product.consumers[0].inputs[index] = branch_op_product
-                # item 5
-                del self._products[product.name]
-            else:
-                for output in self.model.graph.output:
-                    if product.name.startswith(output.name + '_to_') or \
-                        product.name.endswith('_to_' + output.name) or \
-                        product.name == output.name:
-                        del self._products[product.name]
-
-        self._products[branch_op_product.name] = branch_op_product
-
-    def _create_param_products(self):
-        """ Create products for parameters of select modules """
-
-        def create_and_connect_product(param_name: str, product_shape: List, my_op: Op,
-                                       param_tensor: TensorProto, product_type: Union[str, None]):
+        def set_as_param(param_tensor: TensorProto, my_op: Op, product_type: Union[str, None]):
             """ Create product with given name, shape, and corresponding tensor.  Connect product to my_op. """
-
-            product = Product(param_name, product_shape)
+            param_name = param_tensor.name
+            product_shape = param_tensor.dims
+            product = self._products[param_name]
+            product.shape = product_shape
             product.is_parm = True
-            product.add_consumer(my_op)
+            my_op.add_param(param_name, product, product_type)
+            # TODO: Delete Product.tensor_dict, Product.tensor attributes
             product.tensor_dict[my_op] = param_tensor
             product.tensor = param_tensor
-            my_op.add_input(product)
-            self._products[product.name] = product
-            my_op.add_param(param_name, product, product_type)
+            product.is_const = False # Backward compatibility
 
         def create_weight_bias_params(my_op: Op):
             """ Create products for conv2d, dense, depthwise conv2d, and similar """
@@ -548,11 +254,11 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
             weight_tensor = ParamUtils.get_param(self.model, op, WEIGHT_INDEX)
             if weight_tensor:
-                create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight')
+                set_as_param(weight_tensor, my_op, 'weight')
 
             bias_tensor = ParamUtils.get_param(self.model, op, BIAS_INDEX)
             if bias_tensor:
-                create_and_connect_product(bias_tensor.name, bias_tensor.dims, my_op, bias_tensor, 'bias')
+                set_as_param(bias_tensor, my_op, 'bias')
 
         def create_matmul_params(my_op: Op):
             """
@@ -563,7 +269,7 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             op = my_op.get_module()
             weight_tensor, _ = retrieve_constant_input(op, self.model, WEIGHT_INDEX)
             if weight_tensor:
-                create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight')
+                set_as_param(weight_tensor, my_op, 'weight')
 
         def create_recurrent_type_params(my_op: Op):
             """
@@ -574,11 +280,11 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             op = my_op.get_module()
             weight_tensor = ParamUtils.get_param(self.model, op, WEIGHT_INDEX)
             if weight_tensor:
-                create_and_connect_product(weight_tensor.name, weight_tensor.dims, my_op, weight_tensor, 'weight_x')
+                set_as_param(weight_tensor, my_op, 'weight_x')
 
             recurrent_weight_tensor = ParamUtils.get_param(self.model, op, RECURRENT_WEIGHT_INDEX)
             if recurrent_weight_tensor:
-                create_and_connect_product(recurrent_weight_tensor.name, recurrent_weight_tensor.dims, my_op, recurrent_weight_tensor, 'weight_r')
+                set_as_param(recurrent_weight_tensor, my_op, 'weight_r')
 
         def create_batchnorm_params(my_op: Op):
             """ Create products for fusedbatchnorm """
@@ -586,19 +292,19 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
             gamma_tensor = ParamUtils.get_param(self.model, op, WEIGHT_INDEX)
             if gamma_tensor:
-                create_and_connect_product(gamma_tensor.name, gamma_tensor.dims, my_op, gamma_tensor, 'weight')
+                set_as_param(gamma_tensor, my_op, 'weight')
 
             beta_tensor = ParamUtils.get_param(self.model, op, BIAS_INDEX)
             if beta_tensor:
-                create_and_connect_product(beta_tensor.name, beta_tensor.dims, my_op, beta_tensor, 'bias')
+                set_as_param(beta_tensor, my_op, 'bias')
 
             moving_mean_tensor = ParamUtils.get_param(self.model, op, RUNNING_MEAN_INDEX)
             if moving_mean_tensor:
-                create_and_connect_product(moving_mean_tensor.name, moving_mean_tensor.dims, my_op, moving_mean_tensor, "running_mean")
+                set_as_param(moving_mean_tensor, my_op, "running_mean")
 
             moving_variance_tensor = ParamUtils.get_param(self.model, op, RUNNING_VAR_INDEX)
             if moving_variance_tensor:
-                create_and_connect_product(moving_variance_tensor.name, moving_variance_tensor.dims, my_op, moving_variance_tensor, "running_var")
+                set_as_param(moving_variance_tensor, my_op, "running_var")
 
         def handle_default(my_op: Op):
             """ Handler for other modules """

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim_config/quantsim_config.py
@@ -158,13 +158,15 @@ class QuantSimConfigurator(AimetCommonQuantSimConfigurator):
                 continue
             op_to_quantizers[node.name] = OpToQuantizers()
             for input_product in node.input:
-                self._populate_input_and_param_quantizer(op_to_quantizers[node.name], input_product)
+                self._populate_input_quantizer(op_to_quantizers[node.name], input_product)
             for output_product in node.output:
                 self._populate_output_quantizer(op_to_quantizers[node.name], output_product)
+            for name, _ in op.parameters.items():
+                op_to_quantizers[node.name].parameter_quantizers.append((name, self._quant_ops_dict[name]))
 
         return op_to_quantizers
 
-    def _populate_input_and_param_quantizer(self, op_to_quantizers: OpToQuantizers, input_product: str):
+    def _populate_input_quantizer(self, op_to_quantizers: OpToQuantizers, input_product: str):
         """
         Populate input and param quantizer for an op
         """
@@ -174,8 +176,6 @@ class QuantSimConfigurator(AimetCommonQuantSimConfigurator):
             return
         if product_name in self._activation_names:
             op_to_quantizers.input_quantizers.append(self._quant_ops_dict[product_name])
-        else:
-            op_to_quantizers.parameter_quantizers.append((product_name, self._quant_ops_dict[product_name]))
 
     def _populate_output_quantizer(self, op_to_quantizers: OpToQuantizers, output_product: str):
         """

--- a/TrainingExtensions/onnx/test/python/models/models_for_tests.py
+++ b/TrainingExtensions/onnx/test/python/models/models_for_tests.py
@@ -2672,34 +2672,6 @@ def matmul_with_constant_first_input():
     onnx.checker.check_model(model, True)
     return model
 
-def matmul_with_constant_second_input():
-    model = helper.make_model(
-        graph=helper.make_graph(
-            name="MatMulModel",
-            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10])],
-            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 10])],
-            initializer=[
-                numpy_helper.from_array(np.random.randn(1, 10).astype('float32'), name='matmul.weight'),
-                numpy_helper.from_array(np.array([1]).astype('int64'), name='axes')
-            ],
-            nodes=[
-                helper.make_node(
-                    "Unsqueeze",
-                    inputs=["model_input", "axes"],
-                    outputs=["matmul_input"],
-                ),
-                helper.make_node(
-                    "MatMul",
-                    inputs=["matmul_input", "matmul.weight"],
-                    outputs=["model_output"],
-                    name="matmul"
-                )
-            ]
-        )
-    )
-    onnx.checker.check_model(model, True)
-    return model
-
 def conv_with_weight_identity_input():
     model = helper.make_model(
         graph=helper.make_graph(

--- a/TrainingExtensions/onnx/test/python/models/models_for_tests.py
+++ b/TrainingExtensions/onnx/test/python/models/models_for_tests.py
@@ -2643,3 +2643,86 @@ def shared_stat_batchnorm_model():
     )
     onnx.checker.check_model(model, True)
     return model
+
+def matmul_with_constant_first_input():
+    model = helper.make_model(
+        graph=helper.make_graph(
+            name="MatMulModel",
+            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10])],
+            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 1])],
+            initializer=[
+                numpy_helper.from_array(np.random.randn(10, 10).astype('float32'), name='matmul.weight'),
+                numpy_helper.from_array(np.array([1]).astype('int64'), name='axes')
+            ],
+            nodes=[
+                helper.make_node(
+                    "Unsqueeze",
+                    inputs=["model_input", "axes"],
+                    outputs=["matmul_input"],
+                ),
+                helper.make_node(
+                    "MatMul",
+                    inputs=["matmul.weight", "matmul_input"],
+                    outputs=["model_output"],
+                    name="matmul"
+                )
+            ]
+        )
+    )
+    onnx.checker.check_model(model, True)
+    return model
+
+def matmul_with_constant_second_input():
+    model = helper.make_model(
+        graph=helper.make_graph(
+            name="MatMulModel",
+            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10])],
+            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 10])],
+            initializer=[
+                numpy_helper.from_array(np.random.randn(1, 10).astype('float32'), name='matmul.weight'),
+                numpy_helper.from_array(np.array([1]).astype('int64'), name='axes')
+            ],
+            nodes=[
+                helper.make_node(
+                    "Unsqueeze",
+                    inputs=["model_input", "axes"],
+                    outputs=["matmul_input"],
+                ),
+                helper.make_node(
+                    "MatMul",
+                    inputs=["matmul_input", "matmul.weight"],
+                    outputs=["model_output"],
+                    name="matmul"
+                )
+            ]
+        )
+    )
+    onnx.checker.check_model(model, True)
+    return model
+
+def conv_with_weight_identity_input():
+    model = helper.make_model(
+        graph=helper.make_graph(
+            name="IdentityConvModel",
+            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10, 10, 32, 32])],
+            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 10, 32, 32])],
+            initializer=[
+                numpy_helper.from_array(np.random.randn(10, 10, 1, 1).astype('float32'), name='identity.input'),
+            ],
+            nodes=[
+                helper.make_node(
+                    "Identity",
+                    inputs=["identity.input"],
+                    outputs=["conv.weight"],
+                ),
+                helper.make_node(
+                    "Conv",
+                    inputs=["model_input", "conv.weight"],
+                    outputs=["model_output"],
+                    name="conv"
+                )
+            ]
+        )
+    )
+    onnx.checker.check_model(model, True)
+    return model

--- a/TrainingExtensions/onnx/test/python/test_connected_graph.py
+++ b/TrainingExtensions/onnx/test/python/test_connected_graph.py
@@ -34,7 +34,8 @@
 #
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
-
+import itertools
+import pytest
 import torch
 from aimet_common.connected_graph.connectedgraph_utils import get_all_input_ops, get_all_ops_with_constant_inputs
 from aimet_onnx.meta.connectedgraph import ConnectedGraph, CONSTANT_TYPE
@@ -42,35 +43,73 @@ from models import models_for_tests
 
 
 class TestConnectedGraph:
-    def test_simple_model(self):
-        model = models_for_tests.build_dummy_model()
+
+    @pytest.mark.parametrize("model", (models_for_tests.build_dummy_model(),
+                                       models_for_tests.single_residual_model().model,
+                                       models_for_tests.multi_input_model().model,
+                                       models_for_tests.transposed_conv_model().model,
+                                       models_for_tests.concat_model().model,
+                                       models_for_tests.hierarchical_model().model,
+                                       models_for_tests.elementwise_op_model().model,
+                                       models_for_tests.instance_norm_model().model,
+                                       models_for_tests.layernorm_model(),
+                                       models_for_tests.matmul_with_constant_first_input()
+                                       ))
+    def test_model_representation(self, model):
+        """
+        Given: A ConnectedGraph constructed for a given model
+        Then: 1) All non-constant nodes should be represented as ops in the CG
+              2) All tensors should be represented as products in the CG
+        """
+        nodes = {node.name for node in model.graph.node if node.op_type != "Constant"}
+        tensors = {tensor for node in model.graph.node for tensor in itertools.chain(node.input, node.output) if tensor}
         cg = ConnectedGraph(model)
         ops = cg.get_all_ops()
-        assert len(ops) == 5
-        assert ['conv', 'relu', 'maxpool', 'flatten', 'fc'] == [op_name for op_name in ops]
+        assert ops.keys() == nodes
         products = cg.get_all_products()
-        assert len(products) == 10
-        assert ['input_to_conv', 'conv_to_relu', 'relu_to_maxpool', 'maxpool_to_flatten', 'flatten_to_fc', 'fc_to_output',
-                'conv_w', 'conv_b', 'fc_w', 'fc_b'] == [product for product in products]
+        assert products.keys() == tensors
+
+        for _, product in products.items():
+            for node in model.graph.node:
+                if node.op_type == "Constant":
+                    continue
+                """
+                When: A tensor is the output of a node
+                Then: The corresponding Op should be the product's producer
+                """
+                if product.name in node.output:
+                    assert node == product.producer.get_module()
+
+                """
+                When: A tensor is the input of a node
+                Then: The corresponding Op should appear in the product's consumers
+                """
+                if product.name in node.input:
+                    assert node in [op.get_module() for op in product.consumers]
+
+            """
+            When: A tensor is a model input
+            Then: The corresponding product should have product.is_model_input set to True
+            """
+            if product.name in {t.name for t in model.graph.input}:
+                assert product.is_model_input
+            else:
+                assert not product.is_model_input
 
     def test_single_residual_model(self):
         model = models_for_tests.single_residual_model()
         conn_graph = ConnectedGraph(model)
-        operator_names = {node.name for node in model.nodes() if node.op_type not in CONSTANT_TYPE and node.op_type != 'Identity'}
-        assert operator_names.issubset(conn_graph.get_all_ops().keys())
-        non_operators = conn_graph.get_all_ops().keys() - operator_names
-        assert len(non_operators) == conn_graph._branch_count
+        operator_names = {node.name for node in model.nodes() if node.op_type not in CONSTANT_TYPE}
+        assert operator_names == conn_graph.get_all_ops().keys()
 
-        nodes_with_outputs = [node for node in model.graph().node if node.output]
         model_weights = {node.input[1] for node in model.graph().node if node.op_type == "Conv"}
         products = conn_graph.get_all_products()
-        for node in nodes_with_outputs:
-            assert any(f"{node.name}" in prod for prod in products), f"{node.name}, {products}"
-        assert {f"{model.graph().node[0].name}_to_{model.graph().node[1].name}", f"{model.graph().node[-1].name}_to_output", * model_weights}.issubset({product for product in products})
+
+        for weight in model_weights:
+            assert products[weight].is_parm
 
         input_ops = get_all_input_ops(conn_graph)
         assert len(input_ops) == 1
-        assert conn_graph._branch_count == 1
         for op in conn_graph.ordered_ops:
             if op.type == "Gemm":
                 assert op.transposed_params
@@ -78,51 +117,18 @@ class TestConnectedGraph:
     def test_multi_inputs_model(self):
         model = models_for_tests.multi_input_model()
         conn_graph = ConnectedGraph(model)
-        assert len(conn_graph.get_all_ops()) == 15
-
-        products = conn_graph.get_all_products()
-        assert len(products) == 27
-        assert {'/conv1_a/Conv_to_/maxpool1_a/MaxPool', '/conv1_b/Conv_to_/maxpool1_b/MaxPool', '/conv2/Conv_to_/maxpool2/MaxPool'}.issubset(
-            {product for product in products})
-        assert {'conv1_a.weight', 'conv1_a.bias', 'conv1_b.weight'}.issubset({product for product in products})
         input_ops = get_all_input_ops(conn_graph)
         assert len(input_ops) == 2
-
-    def test_transposed_conv_model(self):
-        model = models_for_tests.transposed_conv_model()
-
-        activations = set()
-        for node in model.graph().node:
-            if node.op_type != "Identity":
-                activations.add(node.input[0])
-                activations.add(node.output[0])
-
-        conn_graph = ConnectedGraph(model)
-        assert len(conn_graph.get_all_ops()) == 5
-
-        products = conn_graph.get_all_products()
-        assert len(products) == len(activations) + len(model.graph().initializer)
-        assert {'bn1.weight',
-                'bn1.bias'}.issubset({product for product in products})
 
     def test_concat_model(self):
         model = models_for_tests.concat_model()
         conn_graph = ConnectedGraph(model)
         ops = conn_graph.get_all_ops()
-        assert len(ops) == 6
         assert len(ops['/Concat'].inputs) == 3
-        products = conn_graph.get_all_products()
-        assert len(products) == 17
-        assert conn_graph._branch_count == 0
 
     def test_hierarchical_model(self):
         model = models_for_tests.hierarchical_model()
         conn_graph = ConnectedGraph(model)
-        operator_names = {node.name for node in model.nodes() if node.op_type not in CONSTANT_TYPE and node.op_type != 'Identity'}
-        assert operator_names.issubset(conn_graph.get_all_ops().keys())
-        non_operators = conn_graph.get_all_ops().keys() - operator_names
-        assert len(non_operators) == conn_graph._branch_count
-        assert conn_graph._branch_count == 0
         ordered_ops = conn_graph.ordered_ops
         name_to_index = {}
         for index, op in enumerate(ordered_ops):
@@ -145,9 +151,12 @@ class TestConnectedGraph:
         model = models_for_tests._convert_to_onnx_no_fold(torch_model, torch.randn(input_shape))
 
         cg = ConnectedGraph(model)
-        assert cg.ordered_ops[4].type == 'Transpose'
-        assert cg.ordered_ops[5].type == 'MatMul'
-        assert 'fc2.weight' in cg.ordered_ops[5].parameters
+        for op in cg.ordered_ops:
+            if op.type == 'MatMul':
+                assert 'fc2.weight' in op.parameters
+                break
+        else:
+            assert False
 
     def test_constant_elementwise_inputs(self):
         """ Test that constant inputs to elementwise ops are identified correctly """
@@ -155,21 +164,28 @@ class TestConnectedGraph:
         cg = ConnectedGraph(model)
 
         assert len(get_all_ops_with_constant_inputs(cg)) == 2
+        for product in cg.ordered_ops[0].inputs:
+            if product.name == "input":
+                assert not product.is_const
+                assert product.is_model_input
+            else:
+                assert product.is_const
 
-        assert not cg.ordered_ops[0].inputs[0].is_const
-        assert cg.ordered_ops[0].inputs[1].is_const
-        assert cg.ordered_ops[1].inputs[0].is_model_input == False
-        assert not cg.ordered_ops[1].inputs[0].is_const
-        assert cg.ordered_ops[1].inputs[1].is_const
+        for product in cg.ordered_ops[1].inputs:
+            assert not product.is_model_input
+            if product.producer == cg.ordered_ops[0]:
+                assert not product.is_const
+            else:
+                assert product.is_const
 
     def test_instance_norm_model(self):
         model = models_for_tests.instance_norm_model()
         cg = ConnectedGraph(model)
-        assert cg.ordered_ops[1].type == 'InstanceNormalization'
+        assert cg.ordered_ops[-2].type == 'InstanceNormalization'
 
     def test_layer_norm_model(self):
         model = models_for_tests.layernorm_model()
         cg = ConnectedGraph(model)
-        layernorm_cg_op = cg.ordered_ops[2]
+        layernorm_cg_op = cg.ordered_ops[-1]
         assert layernorm_cg_op.type == 'LayerNormalization'
         assert ['layernorm.scale', 'layernorm.bias'] == list(layernorm_cg_op.parameters.keys())

--- a/TrainingExtensions/onnx/test/python/test_connected_graph.py
+++ b/TrainingExtensions/onnx/test/python/test_connected_graph.py
@@ -38,7 +38,8 @@ import itertools
 import pytest
 import torch
 from aimet_common.connected_graph.connectedgraph_utils import get_all_input_ops, get_all_ops_with_constant_inputs
-from aimet_onnx.meta.connectedgraph import ConnectedGraph, CONSTANT_TYPE
+from aimet_onnx.meta.connectedgraph import ConnectedGraph, CONSTANT_TYPE, OPS_WITH_PARAMS
+from aimet_onnx.utils import ParamUtils
 from models import models_for_tests
 
 
@@ -93,8 +94,34 @@ class TestConnectedGraph:
             """
             if product.name in {t.name for t in model.graph.input}:
                 assert product.is_model_input
+                assert not product.producer
             else:
                 assert not product.is_model_input
+
+            """
+            When: A tensor has no producer
+            Then: The tensor is either a model input, constant, or parameter
+            """
+            if not product.producer:
+                assert product.is_model_input or product.is_const or product.is_parm
+            else:
+                assert not (product.is_model_input or product.is_const or product.is_parm)
+
+        for op_name, op in ops.items():
+            node = op.get_module()
+            """
+            When: A tensor is input idx of node
+            Then: The tensor's product should be input idx of the corresponding op
+            """
+            for idx, tensor in enumerate(node.input):
+                assert op.inputs[idx] is products[tensor]
+
+            """
+            When: A tensor is output[0] of a node
+            Then: The tensor's product should be the corresponding op's output
+            """
+            if node.output:
+                assert op.output is products[node.output[0]]
 
     def test_single_residual_model(self):
         model = models_for_tests.single_residual_model()


### PR DESCRIPTION
## Motivation

Currently our onnx ConnectedGraph implementation uses some very complicated logic to populate a graph structure by performing DFS from the "starting ops" (determined by some complicated criteria) to the model outputs. This process inserts new ops to the graph at branches, and intentionally or unintentionally omits other ops from the representation, resulting in some headaches/bugs such as:
- Errors for unsimplified models due to ops not being found during DFS
- No guarantee whether a connectedgraph op exists in the onnx model (and vice-versa)
- ConnectedGraph op input orderings not correctly matching that of the onnx node
- ConnectedGraph ops missing some inputs for irregularly defined models (e.g., matmuls with constant first inputs)

## Main Changes

This PR makes the following changes to the onnx ConnectedGraph logic:

1) Remove all graph tracing
2) Make ConnectedGraph ops exactly match the onnx graph nodes*
3) Make ConnectedGraph products exactly match the onnx graph tensors
4) Remove "branch" ops from the connected graph
5) Use existing onnx model naming for ops/products

*Except "Constant" ops, which are really just tensors