### PR TITLE
Raise import error from when aimet_torch.v2 is the default API

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/qc_quantize_op.py
@@ -35,12 +35,14 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 """ Alias to legacy qc_quantize_op """
-from .utils import _get_default_api
+from .utils import _get_default_api, _warn_deprecated_in_v2, _deleted_module_import_error
+from .v1 import qc_quantize_op as _v1_api
 
 if _get_default_api() == "v1":
     from .v1.qc_quantize_op import * # pylint: disable=wildcard-import, unused-wildcard-import
-
-    from .utils import _warn_deprecated_in_v2
-    from .v1 import qc_quantize_op as _v1_qc_quantize_op
     _warn_deprecated_in_v2(__name__,
-                           v1_legacy_api=_v1_qc_quantize_op.__name__)
+                           v1_legacy_api=_v1_api.__name__)
+else:
+    raise _deleted_module_import_error(name=__name__,
+                                       since="2.0.0",
+                                       v1_legacy_api=_v1_api.__name__)

--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim_straight_through_grad.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim_straight_through_grad.py
@@ -35,12 +35,14 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 """ Alias to legacy quantsim_straight_through_grad """
-from .utils import _get_default_api
+from .utils import _get_default_api, _warn_deprecated_in_v2, _deleted_module_import_error
+from .v1 import quantsim_straight_through_grad as _v1_api
 
 if _get_default_api() == "v1":
     from .v1.quantsim_straight_through_grad import * # pylint: disable=wildcard-import, unused-wildcard-import
-
-    from .utils import _warn_deprecated_in_v2
-    from .v1 import quantsim_straight_through_grad as _v1_quantsim_straight_through_grad
     _warn_deprecated_in_v2(__name__,
-                           v1_legacy_api=_v1_quantsim_straight_through_grad.__name__)
+                           v1_legacy_api=_v1_api.__name__)
+else:
+    raise _deleted_module_import_error(name=__name__,
+                                       since="2.0.0",
+                                       v1_legacy_api=_v1_api.__name__)

--- a/TrainingExtensions/torch/src/python/aimet_torch/tensor_factory_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/tensor_factory_utils.py
@@ -35,12 +35,14 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 """ Alias to legacy tensor_factory_utils """
-from .utils import _get_default_api
+from .utils import _get_default_api, _warn_deprecated_in_v2, _deleted_module_import_error
+from .v1 import tensor_factory_utils as _v1_api
 
 if _get_default_api() == "v1":
     from .v1.tensor_factory_utils import * # pylint: disable=wildcard-import, unused-wildcard-import
-
-    from .utils import _warn_deprecated_in_v2
-    from .v1 import tensor_factory_utils as _v1_tensor_factory_utils
     _warn_deprecated_in_v2(__name__,
-                           v1_legacy_api=_v1_tensor_factory_utils.__name__)
+                           v1_legacy_api=_v1_api.__name__)
+else:
+    raise _deleted_module_import_error(name=__name__,
+                                       since="2.0.0",
+                                       v1_legacy_api=_v1_api.__name__)

--- a/TrainingExtensions/torch/src/python/aimet_torch/tensor_quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/tensor_quantizer.py
@@ -35,10 +35,14 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 """ Alias to legacy tensor_quantizer """
-from .v1.tensor_quantizer import * # pylint: disable=wildcard-import, unused-wildcard-import
+from .utils import _get_default_api, _warn_deprecated_in_v2, _deleted_module_import_error
+from .v1 import tensor_quantizer as _v1_api
 
-if __name__ != "__main__":
-    from .utils import _warn_deprecated_in_v2
-    from .v1 import tensor_quantizer as _v1_tensor_quantizer
+if _get_default_api() == "v1":
+    from .v1.tensor_quantizer import * # pylint: disable=wildcard-import, unused-wildcard-import
     _warn_deprecated_in_v2(__name__,
-                           v1_legacy_api=_v1_tensor_quantizer.__name__)
+                           v1_legacy_api=_v1_api.__name__)
+else:
+    raise _deleted_module_import_error(name=__name__,
+                                       since="2.0.0",
+                                       v1_legacy_api=_v1_api.__name__)

--- a/TrainingExtensions/torch/src/python/aimet_torch/torch_quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/torch_quantizer.py
@@ -35,12 +35,14 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 """ Alias to legacy torch_quantizer """
-from .utils import _get_default_api
+from .utils import _get_default_api, _warn_deprecated_in_v2, _deleted_module_import_error
+from .v1 import torch_quantizer as _v1_api
 
 if _get_default_api() == "v1":
     from .v1.torch_quantizer import * # pylint: disable=wildcard-import, unused-wildcard-import
-
-    from .utils import _warn_deprecated_in_v2
-    from .v1 import torch_quantizer as _v1_torch_quantizer
     _warn_deprecated_in_v2(__name__,
-                           v1_legacy_api=_v1_torch_quantizer.__name__)
+                           v1_legacy_api=_v1_api.__name__)
+else:
+    raise _deleted_module_import_error(name=__name__,
+                                       since="2.0.0",
+                                       v1_legacy_api=_v1_api.__name__)

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -1213,6 +1213,16 @@ def get_v1_quant_scheme_for_initialization(quant_scheme: QuantScheme) -> QuantSc
     return quant_scheme
 
 
+def _deleted_module_import_error(name: str, since: str, v1_legacy_api: str = None) -> ImportError:
+    msg = f"{name} module is deleted since aimet_torch=={since}."
+
+    if v1_legacy_api:
+        msg += f" If you must keep using the v1 legacy API for backwards-compatibility,"\
+               f" please import \"{v1_legacy_api}\" instead."
+
+    return ImportError(msg)
+
+
 def _warn_deprecated_in_v2(name: str, v1_legacy_api: str = None):
     msg = f"\"{name}\" will be deprecated soon in the later versions."
 


### PR DESCRIPTION
```pycon
>>> import aimet_torch.tensor_quantizer
ImportError: aimet_torch.tensor_quantizer module is deleted since aimet_torch==2.0.0.
If you must keep using the v1 legacy API for backwards-compatibility,
please import "aimet_torch.v1.tensor_quantizer" instead.
```