### PR TITLE
refactor: reduce v1 imports in quantsim code

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/quantsim_config/builder.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/quantsim_config/builder.py
@@ -125,6 +125,12 @@ class LazyQuantizeWrapper(torch.nn.Module, ABC): # pylint: disable=too-many-inst
 
         self.supported_kernels = {}
 
+    def get_original_module(self):
+        """
+        Returns the floating point version of quantized module
+        """
+        return self._module_to_wrap
+
     def enable_per_channel_quantization(self):
         """
         Changes all parameter quantizers (if any) to per-channel mode.

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
@@ -176,6 +176,9 @@ class QcQuantizeRecurrent(torch.nn.Module):
         # to be sub-optimal.
         self._reorder_initial_h_c_stats_update = QcQuantizeRecurrent._is_initial_h_c_stats_update_reordered()
 
+    def get_original_module(self):
+        return self.module_to_quantize
+
     @staticmethod
     def _is_initial_h_c_stats_update_reordered() -> bool:
         """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
@@ -177,6 +177,7 @@ class QcQuantizeRecurrent(torch.nn.Module):
         self._reorder_initial_h_c_stats_update = QcQuantizeRecurrent._is_initial_h_c_stats_update_reordered()
 
     def get_original_module(self):
+        self.update_params()
         return self.module_to_quantize
 
     @staticmethod

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_recurrent.py
@@ -119,7 +119,7 @@ class PackedSequenceInfo:
         return self._sorted_sequence_lens
 
 
-class QcQuantizeRecurrent(torch.nn.Module):
+class QcQuantizeRecurrent(torch.nn.Module): # pylint: disable=too-many-public-methods
     """
     Learns Min and Max for Encodings of Enabled quantizers for a recurrent layer
     """
@@ -177,6 +177,9 @@ class QcQuantizeRecurrent(torch.nn.Module):
         self._reorder_initial_h_c_stats_update = QcQuantizeRecurrent._is_initial_h_c_stats_update_reordered()
 
     def get_original_module(self):
+        """
+        Returns the floating point version of quantized module
+        """
         self.update_params()
         return self.module_to_quantize
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -1918,7 +1918,7 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
             if not utils.is_leaf_module(module_ref):
                 QuantizationSimModel._replace_quantization_wrapper_with_native_torch_quantization_nodes(module_ref, device)
 
-    # pylint: disable=protected-access, too-many-branches, too-many-locals
+    # pylint: disable=protected-access, too-many-branches, too-many-locals, import-outside-toplevel
     def _apply_exception_rules(self):
         """
         Apply exception rules to specific op. For example, a rule can override high bitwidth to Embedding module

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -1926,17 +1926,8 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
         """
         Apply exception rules to specific op. For example, a rule can override high bitwidth to Embedding module
         """
-        module_to_quant_wrapper = {}
-        for _, wrapper in self.quant_wrappers():
-            if isinstance(wrapper, LazyQuantizeWrapper):
-                original_module = wrapper._module_to_wrap
-            elif isinstance(wrapper, QcQuantizeRecurrent):
-                original_module = wrapper.module_to_quantize
-            else:
-                continue
-            module_to_quant_wrapper[original_module] = wrapper
-
-        for original_module, wrapper in module_to_quant_wrapper.items():
+        for wrapper in self.qmodules():
+            original_module = wrapper.get_original_module()
 
             if isinstance(original_module, torch.nn.Embedding):
                 if self._hw_version not in {'V73', 'V75', 'V79'}:
@@ -1967,8 +1958,8 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
                 first_input_op = op.inputs[0].producer if (not first_input_quantizer.enabled) else None
                 second_input_op = op.inputs[1].producer if (not second_input_quantizer.enabled) else None
 
-                target_quantizer_for_first_input = self._get_target_quantizer(first_input_quantizer, first_input_op, module_to_quant_wrapper)
-                target_quantizer_for_second_input = self._get_target_quantizer(second_input_quantizer, second_input_op, module_to_quant_wrapper)
+                target_quantizer_for_first_input = self._get_target_quantizer(first_input_quantizer, first_input_op)
+                target_quantizer_for_second_input = self._get_target_quantizer(second_input_quantizer, second_input_op)
 
                 # We don't need to apply exception rule when both first and second inputs are FP quantization
                 if (
@@ -2003,25 +1994,19 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
                         target_quantizer_for_second_input.use_symmetric_encodings = True
                         target_quantizer_for_first_input.bitwidth = 16
 
-    def _get_target_quantizer(self,
-                              input_quantizer: _QuantizerProtocol,
-                              input_op: Op,
-                              module_to_quant_wrapper: Dict[torch.nn.Module, _QuantizedModuleProtocol]) -> _QuantizerProtocol:
+    def _get_target_quantizer(self, input_quantizer: _QuantizerProtocol, input_op: Op) -> _QuantizerProtocol:
         """
         Returns input quantizer if enabled otherwise returns closest enabled parent output quantizer.
 
         :param input_quantizer: Input quantizer
         :param input_op: Input Op
-        :param module_to_quant_wrapper: Dict of module to quant wrapper
         :return: Target quantizer
         """
         target_quantizer = None
         if input_quantizer.enabled:
             target_quantizer = input_quantizer
         elif input_op:
-            closest_producer_wrapper = self._get_closest_producer_wrapper(
-                input_op, module_to_quant_wrapper
-            )
+            closest_producer_wrapper = self._get_closest_producer_wrapper(input_op)
             if closest_producer_wrapper:
                 target_quantizer = closest_producer_wrapper.output_quantizers[0] \
                         if closest_producer_wrapper.output_quantizers[0] else closest_producer_wrapper.input_quantizers[0]
@@ -2031,28 +2016,20 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
         return target_quantizer
 
 
-    def _get_closest_producer_wrapper(self,
-                                      op: Op,
-                                      module_to_quant_wrapper: Dict[torch.nn.Module, QcQuantizeWrapper]) -> \
-            Optional[QcQuantizeWrapper]:
+    def _get_closest_producer_wrapper(self, op: Op) -> Optional[_QuantizedModuleProtocol]:
         """
         Find the closest producer QcQuantizeWrapper and return it
 
         :param op: Target operation
-        :param module_to_quant_wrapper: Module to Wrapper dictionary
         :return: QcQuantizerWrapper if exists else None
         """
-        def get_quant_wrapper() -> Optional[QcQuantizeWrapper]:
-            module = op.get_module()
-            return module_to_quant_wrapper.get(module) if module else None
-
-        wrapper = get_quant_wrapper()
+        wrapper = self._get_qmodule(op)
         if wrapper:
             if wrapper.output_quantizers[0].enabled or wrapper.input_quantizers[0].enabled:
                 return wrapper
 
             if len(op.input_ops) == 1:
-                return self._get_closest_producer_wrapper(op.input_ops[0], module_to_quant_wrapper)
+                return self._get_closest_producer_wrapper(op.input_ops[0])
 
             logger.warning("A wrapper of %s with output quantization disabled has no input or more than one input "
                            "exists. It's ambiguous to find the nearest producer in this case", str(op.get_module()))
@@ -2066,7 +2043,21 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
             logger.warning("Multiple input ops exist, traversal to find closest producer is performed based on the "
                            "first input")
 
-        return self._get_closest_producer_wrapper(op.input_ops[0], module_to_quant_wrapper)
+        return self._get_closest_producer_wrapper(op.input_ops[0])
+
+    def _get_qmodule(self, op: Op) -> Optional[_QuantizedModuleProtocol]:
+        orig_module = op.get_module()
+        if not orig_module:
+            return None
+
+        full_name = self.connected_graph._module_to_name[orig_module] # pylint: disable=protected-access
+        _, *module_names = full_name.split('.')
+
+        if not module_names:
+            return None
+
+        module_name = '.'.join(module_names)
+        return utils.get_named_module(self.model, module_name)
 
     @staticmethod
     def save_model_with_embedded_quantization_nodes(sim_model, path: str, filename_prefix: str, dummy_input: Union[torch.Tensor, Tuple],

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -1926,7 +1926,12 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
         """
         Apply exception rules to specific op. For example, a rule can override high bitwidth to Embedding module
         """
+        from aimet_torch.v2.nn import BaseQuantizationMixin
+
         for wrapper in self.qmodules():
+            if isinstance(wrapper, BaseQuantizationMixin):
+                continue
+
             original_module = wrapper.get_original_module()
 
             if isinstance(original_module, torch.nn.Embedding):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -66,7 +66,7 @@ from aimet_torch.v1.nn.modules.custom import MatMul
 from aimet_torch.quantsim_config.quantsim_config import QuantSimConfigurator
 from aimet_torch.v1.qc_quantize_op import QcQuantizeStandAloneBase, QcQuantizeWrapper, QcQuantizeOpMode, \
     StaticGridQuantWrapper, LearnedGridQuantWrapper, NativeTorchQuantWrapper, QUANTIZER_TYPE_INPUT, QUANTIZER_TYPE_OUTPUT
-from aimet_torch.v1.tensor_quantizer import initialize_learned_grid_quantizer_attributes, TensorQuantizer
+from aimet_torch.v1.tensor_quantizer import initialize_learned_grid_quantizer_attributes
 from aimet_torch.v1.qc_quantize_op import get_encoding_by_quantizer as _get_encoding_by_quantizer
 from aimet_torch import torchscript_utils, utils, onnx_utils
 from aimet_torch.v1.utils import create_encoding_dict
@@ -2003,7 +2003,10 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
                         target_quantizer_for_second_input.use_symmetric_encodings = True
                         target_quantizer_for_first_input.bitwidth = 16
 
-    def _get_target_quantizer(self, input_quantizer: TensorQuantizer, input_op: Op, module_to_quant_wrapper: Dict[torch.nn.Module, QcQuantizeWrapper]) -> TensorQuantizer:
+    def _get_target_quantizer(self,
+                              input_quantizer: _QuantizerProtocol,
+                              input_op: Op,
+                              module_to_quant_wrapper: Dict[torch.nn.Module, _QuantizedModuleProtocol]) -> _QuantizerProtocol:
         """
         Returns input quantizer if enabled otherwise returns closest enabled parent output quantizer.
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -1430,13 +1430,10 @@ class QuantizationSimModel(_QuantizationSimModelInterface):
 
             # If modules is in the exclude list, remove the wrapper
             if module_ref in list_of_modules_to_exclude:
-                if isinstance(module_ref, _QuantizedModuleProtocol):
+                if isinstance(module_ref, (_QuantizedModuleProtocol, QcQuantizeRecurrent)):
                     orig_module = module_ref.get_original_module()
                 elif isinstance(module_ref, QcQuantizeStandAloneBase):
                     orig_module = torch.nn.Identity()
-                elif isinstance(module_ref, QcQuantizeRecurrent):
-                    module_ref.update_params()
-                    orig_module = module_ref.module_to_quantize
                 else:
                     orig_module = None
 

--- a/TrainingExtensions/torch/test/python/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/test_quantizer.py
@@ -5196,11 +5196,8 @@ class TestQuantizationSimLearnedGrid:
         qsim.model.permute.output_quantizers[0].enabled = False
         qsim.compute_encodings(lambda m, _: m(dummy_input), None)
 
-        module_to_quant_wrapper = {}
-        for _, wrapper in qsim.quant_wrappers():
-            module_to_quant_wrapper[wrapper._module_to_wrap] = wrapper
         # Use connected graph op corresponding to reshape to test
-        closest_wrapper = qsim._get_closest_producer_wrapper(qsim.connected_graph.ordered_ops[1], module_to_quant_wrapper)
+        closest_wrapper = qsim._get_closest_producer_wrapper(qsim.connected_graph.ordered_ops[1])
         assert closest_wrapper == qsim.model.permute
 
 


### PR DESCRIPTION
The ultimate goal before 2.0 release is moving the common code to `_base.quantsim`.
However, currently it's impossible because quantsim.v1 imports too many v1-specific components

This PR removes some of the v1 dependencies to make the migration to _base easeir.
