### PR TITLE
Unpin PyTorch version

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -20,7 +20,7 @@ ignore=CVS,
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=
+ignore-patterns=.+\.pyi
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/ModelOptimizations/PyModelOptimizations/CMakeLists.txt
+++ b/ModelOptimizations/PyModelOptimizations/CMakeLists.txt
@@ -63,6 +63,8 @@ set_target_properties(PyModelOptimizations
          LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/artifacts/aimet_common/"
       )
 
+add_dependencies(PyModelOptimizations generate_deps)
+
 install(TARGETS PyModelOptimizations
         LIBRARY
         DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/aimet_common

--- a/TrainingExtensions/common/CMakeLists.txt
+++ b/TrainingExtensions/common/CMakeLists.txt
@@ -60,7 +60,11 @@ add_custom_target(generate_deps
             "${CMAKE_CURRENT_SOURCE_DIR}/src/python/aimet_common/_gen.py"
             --output-dir ${CMAKE_BINARY_DIR}/artifacts/aimet_common
 )
-
+install(DIRECTORY ${CMAKE_BINARY_DIR}/artifacts/aimet_common/
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/python/aimet_common
+        FILES_MATCHING
+        PATTERN "_deps.py"
+      )
 
 add_dependencies(whl_prep_ln whl_prep_ln_common)
 whl_add_whl_action_target(common)

--- a/TrainingExtensions/common/src/python/aimet_common/_deps.pyi
+++ b/TrainingExtensions/common/src/python/aimet_common/_deps.pyi
@@ -1,7 +1,8 @@
-#==============================================================================
+# -*- mode: python -*-
+# =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2018, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -32,35 +33,7 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 #  @@-COPYRIGHT-END-@@
-#==============================================================================
+# =============================================================================
+from typing import Optional
 
-add_subdirectory(src/python)
-
-if (ENABLE_TESTS)
-    add_subdirectory(test)
-endif()
-
-add_custom_target(whl_prep_cp_common DEPENDS
-    whl_prep_cp_common_DlCompression
-    whl_prep_cp_common_DlEqualization
-    whl_prep_cp_common_DlQuantization
-    whl_prep_cp_common_PyModelOptimizations
-)
-add_dependencies(whl_prep_cp whl_prep_cp_common)
-
-add_custom_target(whl_prep_ln_common DEPENDS
-    whl_prep_ln_common_DlCompression
-    whl_prep_ln_common_DlEqualization
-    whl_prep_ln_common_DlQuantization
-    whl_prep_ln_common_PyModelOptimizations
-)
-
-add_custom_target(generate_deps
-    COMMAND python3
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/python/aimet_common/_gen.py"
-            --output-dir ${CMAKE_BINARY_DIR}/artifacts/aimet_common
-)
-
-
-add_dependencies(whl_prep_ln whl_prep_ln_common)
-whl_add_whl_action_target(common)
+torch: Optional[str]

--- a/TrainingExtensions/common/src/python/aimet_common/_gen.py
+++ b/TrainingExtensions/common/src/python/aimet_common/_gen.py
@@ -1,7 +1,8 @@
-#==============================================================================
+# -*- mode: python -*-
+# =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2018, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -32,35 +33,50 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 #  @@-COPYRIGHT-END-@@
-#==============================================================================
-
-add_subdirectory(src/python)
-
-if (ENABLE_TESTS)
-    add_subdirectory(test)
-endif()
-
-add_custom_target(whl_prep_cp_common DEPENDS
-    whl_prep_cp_common_DlCompression
-    whl_prep_cp_common_DlEqualization
-    whl_prep_cp_common_DlQuantization
-    whl_prep_cp_common_PyModelOptimizations
-)
-add_dependencies(whl_prep_cp whl_prep_cp_common)
-
-add_custom_target(whl_prep_ln_common DEPENDS
-    whl_prep_ln_common_DlCompression
-    whl_prep_ln_common_DlEqualization
-    whl_prep_ln_common_DlQuantization
-    whl_prep_ln_common_PyModelOptimizations
-)
-
-add_custom_target(generate_deps
-    COMMAND python3
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/python/aimet_common/_gen.py"
-            --output-dir ${CMAKE_BINARY_DIR}/artifacts/aimet_common
-)
+# =============================================================================
+# pylint: disable=all
+import os
+import sysconfig
 
 
-add_dependencies(whl_prep_ln whl_prep_ln_common)
-whl_add_whl_action_target(common)
+def main(output_dir):
+    try:
+        import torch
+    except ImportError:
+        torch = None
+
+    try:
+        import tensorflow as tf
+    except ImportError:
+        tf = None
+
+    try:
+        import onnx
+    except ImportError:
+        onnx = None
+
+    _template = os.path.join(os.path.dirname(__file__), "_deps.pyi")
+
+    with open(_template) as f:
+        copyright_string = [
+            line.strip() for line in f.readlines()
+            if line.startswith('#')
+        ]
+
+    content = [
+        # f"platform = '{...}'",
+        "torch = "      + (f"'{torch.__version__}'" if torch else "None"),
+        # "tensorflow = " + (f"'{tf.__version__}'" if tf else "None"),
+        # "onnx = "       + (f"'{onnx.__version__}'" if onnx else "None"),
+        ""
+    ]
+
+    with open(os.path.join(output_dir, "_deps.py"), "w") as f:
+        f.write('\n'.join(copyright_string + content))
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output-dir", type=str)
+    args = parser.parse_args()
+    main(args.output_dir)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
@@ -46,19 +46,26 @@ from aimet_common import _deps
 
 
 def _is_torch_compatible(current: str, required: str):
-    major, minor, patch = current.split(".") # eg. 2.1.2+cu121
-    major_, minor_, patch_ = required.split(".")
+    # PyTorch version tag examples:
+    #   * 2.1.2+cu121
+    #   * 2.1.2+cpu
+    #   * 2.1.2
+    major, minor, patch = current.split(".")
+    required_major, required_minor, required_patch = required.split(".")
 
-    if (major, minor) != (major_, minor_):
+    if (major, minor) != (required_major, required_minor):
         return False
 
-    _, cuda = patch.split("+")
-    _, cuda_ = patch_.split("+")
+    _, *cuda = patch.split("+")
+    _, *required_cuda = required_patch.split("+")
 
-    if cuda != cuda_:
-        return False
+    if not cuda:
+        return True
 
-    return True
+    cuda, = cuda
+    required_cuda, = required_cuda
+
+    return cuda == required_cuda or cuda == "cpu"
 
 
 def _check_requirements():

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
@@ -1,7 +1,8 @@
-#==============================================================================
+# -*- mode: python -*-
+# =============================================================================
 #  @@-COPYRIGHT-START-@@
 #
-#  Copyright (c) 2018, Qualcomm Innovation Center, Inc. All rights reserved.
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
 #  modification, are permitted provided that the following conditions are met:
@@ -32,35 +33,49 @@
 #  SPDX-License-Identifier: BSD-3-Clause
 #
 #  @@-COPYRIGHT-END-@@
-#==============================================================================
+# =============================================================================
+# pylint: disable=missing-docstring
 
-add_subdirectory(src/python)
+# Declare explicit namespace package.
+# For more information about explicit namespace packages,
+# see https://packaging.python.org/en/latest/guides/packaging-namespace-packages
+__path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
-if (ENABLE_TESTS)
-    add_subdirectory(test)
-endif()
-
-add_custom_target(whl_prep_cp_common DEPENDS
-    whl_prep_cp_common_DlCompression
-    whl_prep_cp_common_DlEqualization
-    whl_prep_cp_common_DlQuantization
-    whl_prep_cp_common_PyModelOptimizations
-)
-add_dependencies(whl_prep_cp whl_prep_cp_common)
-
-add_custom_target(whl_prep_ln_common DEPENDS
-    whl_prep_ln_common_DlCompression
-    whl_prep_ln_common_DlEqualization
-    whl_prep_ln_common_DlQuantization
-    whl_prep_ln_common_PyModelOptimizations
-)
-
-add_custom_target(generate_deps
-    COMMAND python3
-            "${CMAKE_CURRENT_SOURCE_DIR}/src/python/aimet_common/_gen.py"
-            --output-dir ${CMAKE_BINARY_DIR}/artifacts/aimet_common
-)
+import torch as _torch
+from aimet_common import _deps
 
 
-add_dependencies(whl_prep_ln whl_prep_ln_common)
-whl_add_whl_action_target(common)
+def _is_torch_compatible(current: str, required: str):
+    major, minor, patch = current.split(".") # eg. 2.1.2+cu121
+    major_, minor_, patch_ = required.split(".")
+
+    if (major, minor) != (major_, minor_):
+        return False
+
+    _, cuda = patch.split("+")
+    _, cuda_ = patch_.split("+")
+
+    if cuda != cuda_:
+        return False
+
+    return True
+
+
+def _check_requirements():
+    reasons = []
+
+    if not _is_torch_compatible(_torch.__version__, _deps.torch):
+        major, minor, patch = _deps.torch.split(".")
+        _, cuda = patch.split("+")
+        reasons.append(f"  * torch=={major}.{minor}.*+{cuda} "
+                       f"(currently you have torch=={_torch.__version__})")
+
+    if reasons:
+        msg = "\n".join([
+            "aimet_torch.v1 package requires following environment:",
+            *reasons,
+        ])
+        raise ImportError(msg)
+
+
+_check_requirements()

--- a/packaging/dependencies/fast-release/torch-gpu/reqs_pip_torch_gpu.txt
+++ b/packaging/dependencies/fast-release/torch-gpu/reqs_pip_torch_gpu.txt
@@ -22,6 +22,6 @@ scikit-learn
 scipy
 setuptools
 tensorboard
-torch~=2.2.0
+torch
 torchvision
 tqdm


### PR DESCRIPTION
Added pytorch version check at aimet_torch.v1 import time.
## Main Changes
* **Unpiined pytorch version**
* Importing aimet_torch.v1 will throw import error immediately if you don't have the required pytorch version for libpymo

## Example
```pycon
>>> import torch
>>> torch.__version__
'2.2.0+cu121'
>>> import aimet_torch.v1
ImportError: aimet_torch.v1 package requires following environment:
  * torch==2.2.*+cu121 (currently you have torch==2.1.2+cu118)
```