### PR TITLE
Remove platform tag from aimet_torch pip package

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/_deps.pyi
+++ b/TrainingExtensions/common/src/python/aimet_common/_deps.pyi
@@ -36,4 +36,5 @@
 # =============================================================================
 from typing import Optional
 
+python_abi: str
 torch: Optional[str]

--- a/TrainingExtensions/common/src/python/aimet_common/_gen.py
+++ b/TrainingExtensions/common/src/python/aimet_common/_gen.py
@@ -45,16 +45,6 @@ def main(output_dir):
     except ImportError:
         torch = None
 
-    try:
-        import tensorflow as tf
-    except ImportError:
-        tf = None
-
-    try:
-        import onnx
-    except ImportError:
-        onnx = None
-
     _template = os.path.join(os.path.dirname(__file__), "_deps.pyi")
 
     with open(_template) as f:
@@ -64,7 +54,7 @@ def main(output_dir):
         ]
 
     content = [
-        # f"platform = '{...}'",
+        f"python_abi = '{sysconfig.get_config_var('SOABI')}'",
         "torch = "      + (f"'{torch.__version__}'" if torch else "None"),
         # "tensorflow = " + (f"'{tf.__version__}'" if tf else "None"),
         # "onnx = "       + (f"'{onnx.__version__}'" if onnx else "None"),

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
@@ -41,6 +41,8 @@
 # see https://packaging.python.org/en/latest/guides/packaging-namespace-packages
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
 
+import sysconfig
+
 import torch as _torch
 from aimet_common import _deps
 
@@ -71,6 +73,18 @@ def _is_torch_compatible(current: str, required: str):
 def _check_requirements():
     reasons = []
 
+    # Check Python ABI.
+    # The format of python_abi depends on the current platform.
+    # In GNU Linux, it's "{python}-{version}-{arch}-{platform}", where
+    #   * python = cpython | ...
+    #   * version = 36 | 37 | 38 | 39 | 310 | ...
+    #   * arch = x86_64 | aarch64 | ...
+    #   * platform = linux-gnu
+    python_abi = sysconfig.get_config_var('SOABI')
+    if python_abi != _deps.python_abi:
+        reasons.append(f"  * Python: {_deps.python_abi} (currently you have {python_abi})")
+
+    # Check PyTorch ABI.
     if not _is_torch_compatible(_torch.__version__, _deps.torch):
         major, minor, patch = _deps.torch.split(".")
         _, cuda = patch.split("+")

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/__init__.py
@@ -67,7 +67,7 @@ def _is_torch_compatible(current: str, required: str):
     cuda, = cuda
     required_cuda, = required_cuda
 
-    return cuda == required_cuda or cuda == "cpu"
+    return cuda in (required_cuda, "cpu")
 
 
 def _check_requirements():

--- a/packaging/convert_wheel_format.sh
+++ b/packaging/convert_wheel_format.sh
@@ -80,4 +80,12 @@ glibc_min_ver=$(echo "${glibc_ver_list_sorted}" | awk '{print $1;}' | tr '.' '_'
 echo "glibc_min_ver = ${glibc_min_ver}"
 
 # Rename the package wheel files to conform to manylinux format for PyPi
-wheel tags --platform-tag="manylinux_${glibc_min_ver}_x86_64" --remove ${WHEEL_DIR}/*.whl
+whlfile_name=$(find ${WHEEL_DIR}/*.whl | head -n 1)
+if [[ $whlfile_name =~ aimet_torch.+ ]]; then
+    # aimet_torch supports all platform by default,
+    # and only optionally asserts certain platform when importing aimet_torch.v1
+    tags="--abi-tag=none --platform-tag=any"
+else
+    tags="--platform-tag=manylinux_${glibc_min_ver}_x86_64"
+fi
+wheel tags ${tags} --remove $whlfile_name


### PR DESCRIPTION
## Main Changes
* Removed platform tag from aimet_torch pip package. **Now you can install aimet_torch in all platform (arm64, MacOS, etc)**
* However, importing aimet_torch.v1 will still assert certain platform (currently x86_64 + manylinux)

## Example
```pycon
>>> import sys; sys.version
'3.8.20 (default, Sep  7 2024, 18:35:08) \n[GCC **11.4.0]'**
>>> import torch; torch.__version__
'2.2.2+cu121'
>>> import aimet_torch.v1
ImportError: aimet_torch.v1 package requires following environment:
  * Python: cpython-310-x86_64-linux-gnu (currently you have cpython-38-x86_64-linux-gnu)
  * torch==2.1.*+cu118 (currently you have torch==2.2.2+cu121)
```