### PR TITLE
Export QuantizationSimModel API in root package

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/__init__.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/__init__.py
@@ -40,3 +40,6 @@
 # For more information about explicit namespace packages,
 # see https://packaging.python.org/en/latest/guides/packaging-namespace-packages
 __path__ = __import__('pkgutil').extend_path(__path__, __name__)
+
+from .quantsim import QuantizationSimModel
+from . import nn


### PR DESCRIPTION
## Main Changes
Now you can import QuantizationSimModel from the root package
```pycon
>>> import aimet_torch
>>> aimet_torch.QuantizationSimModel
<class 'aimet_torch.v2.quantsim.quantsim.QuantizationSimModel'>
>>> aimet_torch.nn.QuantizedConv2d
<class 'aimet_torch.v2.nn.true_quant.QuantizedConv2d'>
```