### PR TITLE
fix: fix wildcard import error with module-level __getattr__ function

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
@@ -1783,6 +1783,12 @@ __deleted_atttributes__ = {
 }
 
 def __getattr__(name: str):
-    if name in __deleted_atttributes__:
-        since = __deleted_atttributes__[name]
-        raise AttributeError(f"Attribute '{name}' was deleted from aimet_torch.onnx_utils since {since}")
+    try:
+        return globals()[name]
+    except KeyError as e:
+        if name in __deleted_atttributes__:
+            since = __deleted_atttributes__[name]
+            msg = f"Attribute '{name}' was deleted from aimet_torch.onnx_utils since {since}"
+        else:
+            msg = f"module '{__name__}' has no attribute '{name}'"
+        raise AttributeError(msg) from e

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -1329,5 +1329,11 @@ __migrated__ = {
 
 
 def __getattr__(name: str):
-    if _get_default_api() == "v2" and name in __migrated__:
-        raise ImportError(f'"{name}" has been moved to aimet_torch.v1.utils since aimet-torch==2.0.0')
+    try:
+        return globals()[name]
+    except KeyError as e:
+        if _get_default_api() == "v2" and name in __migrated__:
+            msg = f'"{name}" has been moved to aimet_torch.v1.utils since aimet-torch==2.0.0'
+        else:
+            msg = f"module '{__name__}' has no attribute '{name}'"
+        raise AttributeError(msg) from e


### PR DESCRIPTION
## Main changes
Recently I introduced some module-level `__getattr__` functions to provide more informative error messages regarding v1->v2 transition.
However, the current implementation has a bug where it fails to serve the wildcard import statements like `from aimet_torch.utils import *`
This PR fixes the bug