### PR TITLE
test: insulate PyPI wheel package tests from other build artifacts

### DIFF
--- a/TrainingExtensions/common/test/CMakeLists.txt
+++ b/TrainingExtensions/common/test/CMakeLists.txt
@@ -37,7 +37,7 @@
 add_test(CommonTrainingExtensionTest
       ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR} --junitxml=${CMAKE_CURRENT_BINARY_DIR}/py_test_output.xml
       )
-if(DEFINED ENV{FAST_RELEASE})
+if(NOT DEFINED ENV{FAST_RELEASE})
     # When building PyPI wheel packages (aka FAST_RELEASE),
     # we only want to test the pure wheel package without relying on any other build artifacts
     set_property(TEST CommonTrainingExtensionTest

--- a/TrainingExtensions/common/test/CMakeLists.txt
+++ b/TrainingExtensions/common/test/CMakeLists.txt
@@ -37,5 +37,9 @@
 add_test(CommonTrainingExtensionTest
       ${Python3_EXECUTABLE} -m pytest ${CMAKE_CURRENT_SOURCE_DIR} --junitxml=${CMAKE_CURRENT_BINARY_DIR}/py_test_output.xml
       )
-set_property(TEST CommonTrainingExtensionTest
-      APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+if(DEFINED ENV{FAST_RELEASE})
+    # When building PyPI wheel packages (aka FAST_RELEASE),
+    # we only want to test the pure wheel package without relying on any other build artifacts
+    set_property(TEST CommonTrainingExtensionTest
+          APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+endif()

--- a/TrainingExtensions/onnx/test/CMakeLists.txt
+++ b/TrainingExtensions/onnx/test/CMakeLists.txt
@@ -48,8 +48,12 @@ endif (ENABLE_CUDA)
 
 add_subdirectory(python/models/customops)
 
-set_property(TEST OnnxTrainingExtensionTest
-      APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+if(NOT DEFINED ENV{FAST_RELEASE})
+    # When building PyPI wheel packages (aka FAST_RELEASE),
+    # we only want to test the pure wheel package without relying on any other build artifacts
+    set_property(TEST OnnxTrainingExtensionTest
+          APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+endif()
 
 if(DEFINED ENV{DEPENDENCY_DATA_PATH})
     set_property(TEST OnnxTrainingExtensionTest

--- a/TrainingExtensions/tensorflow/test/CMakeLists.txt
+++ b/TrainingExtensions/tensorflow/test/CMakeLists.txt
@@ -46,8 +46,12 @@ else (ENABLE_CUDA)
 
 endif (ENABLE_CUDA)
 
-set_property(TEST TfTrainingExtensionTest
-      APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+if(NOT DEFINED ENV{FAST_RELEASE})
+    # When building PyPI wheel packages (aka FAST_RELEASE),
+    # we only want to test the pure wheel package without relying on any other build artifacts
+    set_property(TEST TfTrainingExtensionTest
+          APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+endif()
 
 if(DEFINED ENV{DEPENDENCY_DATA_PATH})
 set_property(TEST TfTrainingExtensionTest

--- a/TrainingExtensions/torch/test/CMakeLists.txt
+++ b/TrainingExtensions/torch/test/CMakeLists.txt
@@ -46,8 +46,12 @@ else (ENABLE_CUDA)
 
 endif (ENABLE_CUDA)
 
-set_property(TEST TorchTrainingExtensionTest
-      APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+if(NOT DEFINED ENV{FAST_RELEASE})
+    # When building PyPI wheel packages (aka FAST_RELEASE),
+    # we only want to test the pure wheel package without relying on any other build artifacts
+    set_property(TEST TorchTrainingExtensionTest
+          APPEND PROPERTY ENVIRONMENT "${AIMET_PYTHONPATH}")
+endif()
 
 if(DEFINED ENV{DEPENDENCY_DATA_PATH})
 set_property(TEST TorchTrainingExtensionTest

--- a/TrainingExtensions/torch/test/python/experimental/__init__.py
+++ b/TrainingExtensions/torch/test/python/experimental/__init__.py
@@ -1,0 +1,36 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================

--- a/TrainingExtensions/torch/test/python/experimental/v2/__init__.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/__init__.py
@@ -1,0 +1,36 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================

--- a/TrainingExtensions/torch/test/python/experimental/v2/quantsim/__init__.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/quantsim/__init__.py
@@ -1,0 +1,36 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2024, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================

--- a/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_export_utils.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_export_utils.py
@@ -45,12 +45,12 @@ import tempfile
 
 import torch
 from aimet_common import quantsim
-from aimet_torch.examples.test_models import SingleResidualWithAvgPool
 from aimet_torch.experimental.v2.quantsim.export_utils import EncodingType
 from aimet_torch.v1.quantsim import QuantizationSimModel as QuantizationSimModelV1, QuantizationDataType
 from aimet_torch.v2.quantsim import QuantizationSimModel as QuantizationSimModelV2
 from aimet_torch.v2.quantization.base import QuantizerBase
 from aimet_torch.v2.quantization.affine.quantizer import QuantizeDequantize, GroupedBlockQuantizeDequantize
+from ....models.test_models import SingleResidualWithAvgPool
 
 @contextmanager
 def swap_encoding_version(version='1.0.0'):

--- a/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_quantsim_utils.py
+++ b/TrainingExtensions/torch/test/python/experimental/v2/quantsim/test_quantsim_utils.py
@@ -40,10 +40,10 @@ import json
 import os
 import torch
 import tempfile
-from aimet_torch.examples.test_models import SingleResidualWithAvgPool
 from aimet_torch.v2.quantsim import QuantizationSimModel
 from aimet_torch.v2.quantization.affine.backends.torch_builtins import quantize
 from aimet_torch.v2.experimental import clip_weights_to_7f7f
+from ....models.test_models import SingleResidualWithAvgPool
 
 def test_clip_weights_to_7f7f():
     torch.manual_seed(0)

--- a/TrainingExtensions/torch/test/python/v1/test_quantizer_groups.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantizer_groups.py
@@ -41,7 +41,6 @@ import torch
 from aimet_common.defs import QuantizationDataType
 from aimet_common.amp.quantizer_groups import reformat_supported_kernels
 from aimet_torch.batch_norm_fold import fold_all_batch_norms
-from aimet_torch.examples.test_models import SingleResidual, ConcatModel
 from aimet_torch.v1.quantsim import QuantizationSimModel
 from aimet_torch.amp.quantizer_groups import find_quantizer_group, find_op_groups, find_supported_candidates, \
     QuantizerGroup
@@ -82,7 +81,7 @@ class TestQuantizerGroups:
         assert len(op_groups['ModelWithOneSplit.conv1']) == 2
 
     def test_single_residual_network(self):
-        model = SingleResidual()
+        model = test_models.SingleResidual()
         input_shapes = (1, 3, 32, 32)
         device = utils.get_device(model)
         inp_tensor_list = utils.create_rand_tensors_given_shapes(input_shapes, device)
@@ -100,7 +99,7 @@ class TestQuantizerGroups:
         assert op_groups['SingleResidual.conv4'] == ['SingleResidual.ada']
 
     def test_concat_model(self):
-        model = ConcatModel()
+        model = test_models.ConcatModel()
         inp_shape_1 = (1, 3, 8, 8)
         inp_shape_2 = (1, 3, 8, 8)
         inp_shape_3 = (1, 3, 8, 8)

--- a/TrainingExtensions/torch/test/python/v1/test_weight_pad_utils.py
+++ b/TrainingExtensions/torch/test/python/v1/test_weight_pad_utils.py
@@ -45,13 +45,11 @@ from aimet_common import libpymo
 from onnx import numpy_helper
 
 from aimet_common.defs import QuantScheme, QuantizationDataType, MAP_ROUND_MODE_TO_PYMO
-from aimet_torch.examples.test_models import MultiInput
-
 from aimet_torch.v1.quantsim import QuantizationSimModel
 from aimet_torch.v1.tensor_quantizer import StaticGridPerTensorQuantizer, StaticGridPerChannelQuantizer
 from aimet_torch.weight_padding_utils import recompute_scale, recompute_encodings, weight_pad, WeightPaddingParams
 
-from ..models.test_models import TinyModel
+from ..models.test_models import TinyModel, MultiInput
 
 
 def evaluate(model: torch.nn.Module, dummy_input: torch.Tensor):

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_config_utils.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_config_utils.py
@@ -38,7 +38,6 @@
 
 import pytest
 import torch
-from aimet_torch.examples.test_models import SingleResidualWithAvgPool, TransposedConvModel
 from aimet_torch.v2.quantsim import QuantizationSimModel
 from aimet_torch.v2.quantsim.config_utils import set_activation_quantizers_to_float, \
     set_blockwise_quantization_for_weights, set_grouped_blockwise_quantization_for_weights
@@ -47,6 +46,8 @@ from aimet_torch.v2.quantization.affine import QuantizeDequantize, GroupedBlockQ
 from aimet_torch.v2.quantization.float import FloatQuantizeDequantize
 import aimet_torch.v2.nn as aimet_nn
 from aimet_torch.utils import get_device
+from ...models.test_models import SingleResidualWithAvgPool, TransposedConvModel
+
 
 devices = ['cpu']
 if torch.cuda.is_available():

--- a/TrainingExtensions/torch/test/python/v2/visualization_tools/test_quant_stats_visualization.py
+++ b/TrainingExtensions/torch/test/python/v2/visualization_tools/test_quant_stats_visualization.py
@@ -41,7 +41,6 @@ import os.path
 import torch
 from ...models.test_models import TinyModel
 from ...models.test_models import ModelWithUnusedMatmul
-from aimet_torch.examples.test_models import SingleResidualWithAvgPool
 from aimet_torch.v2.quantsim import QuantizationSimModel
 from aimet_torch.v1.quantsim import QuantScheme
 from aimet_torch.v2.visualization_tools import visualize_stats, visualize_advanced_stats


### PR DESCRIPTION
## Main Changes
Removed `PYTHONPATH` environment variable when testing pure PyPI wheel packages.
When running `make test` with `PYTHONPATH` set, it wouldn't test the actual wheel package but test with whatever is importable from `PYTHONPATH` on top.