### PR TITLE
Redefine symmetry as offset=-round((qmin + qmax) / 2)

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -437,7 +437,10 @@ class MinMaxQuantizer(AffineQuantizerBase): # pylint: disable=abstract-method
         dtype = dtype or torch.float32
 
         if self.symmetric:
-            offset = torch.zeros_like(self.min, requires_grad=False, dtype=dtype)
+            offset = torch.full_like(self.min,
+                                     fill_value=-round((self.qmin + self.qmax) / 2),
+                                     requires_grad=False,
+                                     dtype=dtype)
         else:
             offset = ste_round(self.min.to(dtype) / self.get_scale(dtype)) - self.qmin
 


### PR DESCRIPTION
## Problem Statement
Given an **unsigned asymmetric** quantizer, setting `quantizer.symmetric = True` only turns it into an **unsigned symmetric** quantizer.
This is problematic for three reasons
* Blindly setting symmetric=True often results in catastrophic accuracy drop
* It's a bit counter-intuitive that int8 qdq and uint8 qdq produces radically different outputs
* It's vastly different from v1 behavior where the users could set symmetric=True without thinking about int8 vs. uint8

## Proposal
I propose redefining symmetry as below:
`offset = -round((qmin+qmax) / 2)`

In a sense, this is a generalized version of the current definition of symmetry (`offset = 0`) because, with the new definition, floating point 0.0 will always line up with the midpoint of the integer grid -- 0 if int8, 128 if uint8.

This new definition has the following pros and cons

Pros:
* Setting quantizer.symmetric = True/False doesn't affect the qdq simulation accuracy.
* **For most users who NEVER use unsigned symmetric**, this is the most transparent solution (requires no user code change) to prevent catastrophic accuracy drop

Cons:
* The meaning of quantizer.signed and quantizer.symmetric slightly diverges from our day-to-day usage of "signed" and "symmetric".
Particularly, quantizer.signed = False  and quantizer.symmetric = True doesn't mean what we've been conventionally referring to as "unsigned symmetry".