### PR TITLE
Always represent zero accurately in v1 histogram

### DIFF
--- a/ModelOptimizations/DlQuantization/src/math_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cpp
@@ -249,7 +249,7 @@ void InitializePdf(PDF& pdf, DTYPE min_val, DTYPE max_val, bool signed_vals)
     for (int i = 0; i < PDF_SIZE; ++i)
     {
         if (signed_vals)
-            pdf.xLeft[i] = min_val + i * bucket_size;
+            pdf.xLeft[i] = floor(min_val / bucket_size + i) * bucket_size;
         else
             pdf.xLeft[i] = i * bucket_size;
     }

--- a/ModelOptimizations/DlQuantization/test/TestPercentileEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestPercentileEncodingAnalyzer.cpp
@@ -300,7 +300,9 @@ TYPED_TEST(TestPercentileEncodingAnalyzer, Symmetric_Percentile100)
     absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
     absoluteMin = -absoluteMax;
 
-    EXPECT_LT(encoding.max, absoluteMax);
+    size_t PDF_SIZE = 512;
+    double HISTOGRAM_BUCKET_SIZE = 3 * (absoluteMax - absoluteMin) / PDF_SIZE;
+    EXPECT_LT(encoding.max, absoluteMax + PDF_SIZE);
 
     EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
     EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);

--- a/ModelOptimizations/DlQuantization/test/TestTensorQuantizer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestTensorQuantizer.cpp
@@ -123,14 +123,18 @@ TEST_F(TestTensorQuantizer, SanityTestCpu)
                                             encoding.min, encoding.max, 8, false);
 
     std::cout << "Encoding min=" << encoding.min << ", max=" << encoding.max << std::endl;
-    EXPECT_NEAR(encoding.min, -6.52711, 0.001);
-    EXPECT_NEAR(encoding.max, 8.88412, 0.001);
+    double MAX = 8.88412;
+    double MIN = -6.52711;
+    size_t PDF_SIZE = 512;
+    double HISTOGRAM_BUCKET_SIZE = 3 * (MAX - MIN) / PDF_SIZE;
+    EXPECT_NEAR(encoding.min, MIN, HISTOGRAM_BUCKET_SIZE);
+    EXPECT_NEAR(encoding.max, MAX, HISTOGRAM_BUCKET_SIZE);
 
     std::cout << "input-data=" << inputTensor.data()[0] << ", quantized-data=" << quantizedTensor.data()[0]
               << std::endl;
 
     EXPECT_NE(inputTensor.data()[0], quantizedTensor.data()[0]);
-    EXPECT_NEAR(quantizedTensor.data()[0], 5.0162, 0.001);
+    EXPECT_NEAR(quantizedTensor.data()[0], 5.0162, HISTOGRAM_BUCKET_SIZE);
 }
 
 TEST_F(TestTensorQuantizer, SanityTestComputeEncodingFromDataAsymmetricTFEnhanced)
@@ -140,8 +144,12 @@ TEST_F(TestTensorQuantizer, SanityTestComputeEncodingFromDataAsymmetricTFEnhance
     TfEncoding encoding {};
     enhancedTensorQuant->computeEncodingFromData(8, paramTensor.data(), tensorCount, encoding,
                                                  ComputationMode::COMP_MODE_CPU, false, false, false);
-    EXPECT_NEAR(encoding.min, -6.527, 0.001);
-    EXPECT_NEAR(encoding.max, 8.884, 0.001);
+    double MAX = 8.88412;
+    double MIN = -6.52711;
+    size_t PDF_SIZE = 512;
+    double HISTOGRAM_BUCKET_SIZE = 3 * (MAX - MIN) / PDF_SIZE;
+    EXPECT_NEAR(encoding.min, MIN, HISTOGRAM_BUCKET_SIZE);
+    EXPECT_NEAR(encoding.max, MAX, HISTOGRAM_BUCKET_SIZE);
 }
 
 TEST_F(TestTensorQuantizer, SanityTestComputeEncodingFromDataSymmetricTF)
@@ -599,13 +607,17 @@ TEST_F(TestTensorQuantizer, SanityTestGpu)
                                        quantTensorBlob.getDataPtrOnDevice(), encoding.min, encoding.max, 8, true);
 
     std::cout << "Encoding min=" << encoding.min << ", max=" << encoding.max << std::endl;
-    EXPECT_NEAR(encoding.min, -6.52711, 0.001);
-    EXPECT_NEAR(encoding.max, 8.88412, 0.001);
+    double MAX = 8.88412;
+    double MIN = -6.52711;
+    size_t PDF_SIZE = 512;
+    double HISTOGRAM_BUCKET_SIZE = 3 * (MAX - MIN) / PDF_SIZE;
+    EXPECT_NEAR(encoding.min, MIN, HISTOGRAM_BUCKET_SIZE);
+    EXPECT_NEAR(encoding.max, MAX, HISTOGRAM_BUCKET_SIZE);
 
     std::cout << "input-data=" << inputTensorBlob.getDataPtrOnCpu()[0]
               << ", quantized-data=" << quantTensorBlob.getDataPtrOnCpu()[0] << std::endl;
     EXPECT_NE(inputTensorBlob.getDataPtrOnCpu()[0], quantTensorBlob.getDataPtrOnCpu()[0]);
-    EXPECT_NEAR(quantTensorBlob.getDataPtrOnCpu()[0], 5.0162, 0.001);
+    EXPECT_NEAR(quantTensorBlob.getDataPtrOnCpu()[0], 5.0162, HISTOGRAM_BUCKET_SIZE);
 }
 
 #endif

--- a/ModelOptimizations/DlQuantization/test/TestTfEnhancedEncodingAnalyzer.cpp
+++ b/ModelOptimizations/DlQuantization/test/TestTfEnhancedEncodingAnalyzer.cpp
@@ -336,8 +336,10 @@ TYPED_TEST(TestTfEnhancedEncodingAnalyzer, SymmetricUnsigned)
     absoluteMax = std::max(std::abs(absoluteMax), std::abs(absoluteMin));
     absoluteMin = -absoluteMax;
 
+    size_t PDF_SIZE = 512;
+    double HISTOGRAM_BUCKET_SIZE = 3 * (absoluteMax - absoluteMin) / PDF_SIZE;
     EXPECT_EQ(encoding.min, 0);
-    EXPECT_NEAR(encoding.max, absoluteMax, 0.015);
+    EXPECT_NEAR(encoding.max, absoluteMax, 0.015 + HISTOGRAM_BUCKET_SIZE);
 
     EXPECT_FLOAT_EQ(encoding.delta, (encoding.max - encoding.min) / 255);
     EXPECT_FLOAT_EQ(encoding.offset, encoding.min / encoding.delta);

--- a/TrainingExtensions/tensorflow/test/python/test_adaround_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/test_adaround_keras.py
@@ -248,8 +248,8 @@ def test_compute_output_with_adarounded_weights():
 
     hard_recons_error, soft_recons_error = AdaroundOptimizer._eval_recons_err_metrics(conv_wrapper, None, inp_tensor,
                                                                                       out_tensor)
-    assert np.isclose(hard_recons_error, 0.6102066, atol=1e-4)
-    assert np.isclose(soft_recons_error, 0.6107949, atol=1e-4)
+    assert np.isclose(hard_recons_error, 0.61097431182861, atol=1e-4)
+    assert np.isclose(soft_recons_error, 0.61089688539505, atol=1e-4)
 
 
 # Adaround wrapper tests

--- a/TrainingExtensions/torch/test/python/v1/test_adaround_optimizer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_adaround_optimizer.py
@@ -150,8 +150,8 @@ class TestAdaroundOptimizer(unittest.TestCase):
                                                                                      out_data)
 
         print(recons_err_hard, recons_err_soft)
-        self.assertAlmostEqual(recons_err_hard, 0.610206663608551, places=3)
-        self.assertAlmostEqual(recons_err_soft, 0.6107949018478394, places=3)
+        self.assertAlmostEqual(recons_err_hard, 0.61097431182861, places=3)
+        self.assertAlmostEqual(recons_err_soft, 0.61089688539505, places=3)
 
     @pytest.mark.cuda
     def test_compute_output_with_adarounded_weights(self):

--- a/TrainingExtensions/torch/test/python/v1/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantizer.py
@@ -2134,7 +2134,7 @@ class TestQuantizationSimStaticGrad:
         tensor[0, 0, 0, 0] = 1000
         sim.model.conv2.output_quantizers[0].update_encoding_stats(tensor)
         sim.model.conv2.output_quantizers[0].compute_encoding()
-        assert sim.model.conv2.output_quantizers[0].encoding.max < 1.0
+        assert sim.model.conv2.output_quantizers[0].encoding.max < 1.1
 
         sim.model.conv2.output_quantizers[0].quant_scheme = QuantScheme.post_training_tf
         tensor = torch.rand(1, 10, 24, 24)


### PR DESCRIPTION
The current V1 histogram fails to represent zero accurately.
This means it fails to discriminate signed vs. unsigned, and hence fails to properly generate the so-called "unsigned symmetric" encoding.
Therefore in this PR, I made v1 histogram always represent zero accurately.