### PR TITLE
Fix histogram bug in libpymo

### DIFF
--- a/ModelOptimizations/DlQuantization/src/math_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cpp
@@ -391,7 +391,7 @@ void GetHistogram_cpu(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], 
     {
         // Map a floating point number to the appropriate bucket.
         int index =
-            is_signed ? round(data[i] / bucket_size - pdf_offset) : round(std::abs(data[i]) / bucket_size - pdf_offset);
+            is_signed ? floor(data[i] / bucket_size - pdf_offset) : floor(std::abs(data[i]) / bucket_size - pdf_offset);
 
         // Add to histogram, if inside the histogram range.
         if (index >= 0 && index < PDF_SIZE)

--- a/ModelOptimizations/DlQuantization/src/math_functions.cu
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cu
@@ -174,8 +174,8 @@ __global__ static void histogramCountKernel(const DTYPE* data,
     {
         // Map a floating point number to the appropriate bucket.
         int index = is_signed ?
-                    round(data[i] / bucket_size - histogram_offset) :
-                    round(abs(data[i]) / bucket_size - histogram_offset);
+                    floor(data[i] / bucket_size - histogram_offset) :
+                    floor(abs(data[i]) / bucket_size - histogram_offset);
 
         // Add to histogram, if inside the histogram range.
         if (index >= 0 && index < PDF_SIZE)


### PR DESCRIPTION
There was a subtle bug in v1 histogram which causes catastrophic accuracy drop in efficientnet under tf-enhanced.
This PR fixes the bug; Now v1 tf-enhanced produces normal accuracy (~77%) as in v2.