### PR TITLE
Edit feature guide > sequential MSE

### DIFF
--- a/Docs/featureguide/seq_mse.rst
+++ b/Docs/featureguide/seq_mse.rst
@@ -11,11 +11,12 @@ Sequential MSE (SeqMSE) is a method that searches for optimal quantization encod
 (i.e. per layer) such that the difference between the original output activation and the
 corresponding quantization-aware output activation is minimized.
 
-Since SeqMSE is search-based rather than learning-based, it possesses several advantages:
+Since SeqMSE is search-based rather than learning-based, it has several advantages:
 
-- It requires only a small amount of calibration data,
-- It approximates the global minimum without getting trapped in local minima, and
-- It is robust to overfitting.
+- It requires only a small amount of calibration data
+- It approximates the global minimum without getting trapped in local minima
+- It is robust to overfitting
+
 
 Workflow
 ========
@@ -25,11 +26,12 @@ Prerequisites
 
 To use Seq MSE, you must:
 
+- Use PyTorch or ONNX. Sequential MSE does not support TensorFlow models
 - Load a pre-trained model
-- Create a training or validation dataloader for the model.
+- Create a training or validation dataloader for the model
 
-Code example
-------------
+Procedure
+---------
 
 Setup
 ~~~~~
@@ -50,10 +52,20 @@ Setup
             :start-after: # Prepare the dataloader
             :end-before: # End of dataloader
 
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        tbd.
+
 Step 1
 ~~~~~~
 
-Create QuantizationSimModel object (simulate quantization through AIMET's QuantSim).
+Use AIMET's :ref:`quantization simulation<quantsim-index>` to create a QuantSimModel object.
 
 .. tab-set::
     :sync-group: platform
@@ -65,10 +77,22 @@ Create QuantizationSimModel object (simulate quantization through AIMET's QuantS
             :language: python
             :start-after: # Create Quantization Simulation Model
             :end-before: # End of QuantizationSimModel
+
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        tbd.
+
+
 Step 2
 ~~~~~~
 
-Apply Seq MSE to decide optimal quantization encodings for parameters of supported layer(s)/operation(s).
+Apply SeqMSE to decide optimal quantization encodings for parameters of supported layers and operations.
 
 .. tab-set::
     :sync-group: platform
@@ -81,10 +105,20 @@ Apply Seq MSE to decide optimal quantization encodings for parameters of support
             :start-after: # Apply Seq MSE
             :end-before: # End of Seq MSE
 
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        tbd.
+
 Step 3
 ~~~~~~
 
-Compute encodings for all activations and remaining parameters of uninitialized layer(s)/operations(s).
+Apply SeqMSE to compute encodings for remaining parameters of uninitialized layers and operations.
 
 .. tab-set::
     :sync-group: platform
@@ -96,6 +130,16 @@ Compute encodings for all activations and remaining parameters of uninitialized 
             :language: python
             :start-after: # Calibration callback
             :end-before: # End of compute_encodings
+
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        tbd.
 
 Step 4
 ~~~~~~
@@ -113,10 +157,20 @@ Evaluate the quantized model using :class:`ImageClassificationEvaluator`.
             :start-after: # Evaluation
             :end-before: # End of evaluation
 
-Step 4
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        tbd.
+
+Step 5
 ~~~~~~
 
-If resulted quantized accuracy is satisfactory, export the model.
+If the resulting quantized accuracy is satisfactory, export the model.
 
 .. tab-set::
     :sync-group: platform
@@ -140,3 +194,16 @@ API
 
         .. include:: ../apiref/torch/seq_mse.rst
             :start-after: # start-after
+
+    .. tab-item:: TensorFlow
+        :sync: tf
+
+        Not supported.
+
+    .. tab-item:: ONNX
+        :sync: onnx
+
+        .. include:: ../apiref/onnx/seq_mse.rst
+            :start-after: # start-after
+
+


### PR DESCRIPTION
Torch API seems to be missing. Should be updated in a separate PR.

No API exists for TF, so I assume it's not supported. I assume this technique *is* supported for ONNX because an API exists for it. If either of these assumptions is wrong, we need to update the SeqMSE page to reflect this.