### PR TITLE
Remove invalid deprecation message in aimet_torch.v1

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -656,7 +656,6 @@ class QuantizationSimModel(_QuantizationSimModelBase):
 
 
 
-@deprecated("Use QuantizationSimModel.load_encodings instead.")
 def load_encodings_to_sim(quant_sim_model: _QuantizationSimModelBase, pytorch_encoding_path: str):
     """
     Loads the saved encodings to quant sim model. The encoding filename to load should end in _torch.encodings,

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -45,7 +45,6 @@ import torch
 
 from aimet_common.utils import AimetLogger
 from aimet_common.defs import QuantScheme, QuantizationDataType
-from aimet_common.utils import deprecated
 
 from aimet_torch.v1.qc_quantize_op import QcQuantizeStandAloneBase, QcQuantizeWrapper, QcQuantizeOpMode, \
     StaticGridQuantWrapper, LearnedGridQuantWrapper, NativeTorchQuantWrapper


### PR DESCRIPTION
Removed an invalid deprecation message in v1 quantsim API.
This method `load_encodings_to_sim()` does some major pre/post-processing on top of `sim.load_encodings`, so it can't be directly replaced with `sim.load_encodings` as the deprecation warning suggested.