### PR TITLE
Treat nullary torch.Tensor.type() as an attribute descriptor

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -90,12 +90,26 @@ class QuantizedTensorBase(torch.Tensor):
 
     encoding: EncodingBase
 
+    _attr_types = {
+        torch.dtype,
+        torch.device,
+        torch.layout,
+        torch.Size,
+        str,
+    }
+
     _attr_descriptors = {
-        torch.Tensor.dtype.__get__,
-        torch.Tensor.device.__get__,
-        torch.Tensor.layout.__get__,
-        torch.Tensor.shape.__get__,
-        torch.Tensor.size,
+        # attribute descriptor        attribute type
+        ( torch.Tensor.dtype.__get__,  torch.dtype),
+        ( torch.Tensor.device.__get__, torch.device),
+        ( torch.Tensor.layout.__get__, torch.layout),
+        ( torch.Tensor.shape.__get__,  torch.Size),
+        ( torch.Tensor.size,           torch.Size),
+        ( torch.Tensor.type,           str), # NOTE: Tensor.type is overloaded with two different specs:
+                                             #   1) Without argument: `tensor.type() -> str`;
+                                             #      should be considered a attribute descriptor
+                                             #   2) With arguments: `tensor.type(dtype) -> torch.Tensor`;
+                                             #      should be considered a typecasting operator
     }
 
     _cast_ops = {
@@ -310,7 +324,7 @@ class QuantizedTensorBase(torch.Tensor):
             return HANDLED_FUNCTIONS[func](*args, **kwargs)
         ret = super().__torch_function__(func, types, args, kwargs)
 
-        if func in cls._attr_descriptors:
+        if (func, type(ret)) in cls._attr_descriptors:
             return ret
 
         self, *_ = args

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -90,14 +90,6 @@ class QuantizedTensorBase(torch.Tensor):
 
     encoding: EncodingBase
 
-    _attr_types = {
-        torch.dtype,
-        torch.device,
-        torch.layout,
-        torch.Size,
-        str,
-    }
-
     _attr_descriptors = {
         # attribute descriptor        attribute type
         ( torch.Tensor.dtype.__get__,  torch.dtype),

--- a/TrainingExtensions/torch/test/python/v2/quantization/test_tensor.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/test_tensor.py
@@ -702,6 +702,7 @@ class TestQuantizedTensor:
             * layout
             * shape
             * size()
+            * type()
         Then: The attributes from both tensors should be value-equal and type-equal
         """
         tensor = torch.empty(10, 10)
@@ -721,3 +722,6 @@ class TestQuantizedTensor:
 
         assert tensor.size() == qtensor.size()
         assert type(tensor.size()) == type(qtensor.size())
+
+        assert tensor.type() == qtensor.type()
+        assert type(tensor.type()) == type(qtensor.type())


### PR DESCRIPTION
## Problem
[torch.Tensor.type](https://pytorch.org/docs/stable/generated/torch.Tensor.type.html) is overloaded with two vastly different behaviors as below:
1. `(self,) -> str` -- returns the dtype of `self`
2. `(self, dtype: torch.dtype) -> torch.Tensor` -- casts `self` into `dtype`

The first case should be considered a attribute descriptor; the second should be considered typecasting operator.
However, AIMET quantized tensor always treats `torch.Tensor.type()` as a typecasting operator

## Main Changes
Added an additional type check to identify whether `type()` was used as a attribute descriptor or a typecasting operator