### PR TITLE
Update aimet_torch QuantizationSimModel API reference

### DIFF
--- a/Docs/apiref/torch/quantsim.rst
+++ b/Docs/apiref/torch/quantsim.rst
@@ -7,21 +7,14 @@ aimet_torch.quantsim
 ..
   # start-after
 
-.. autoclass:: aimet_torch.quantsim.QuantizationSimModel
-
-**The following API can be used to Compute encodings for calibration:**
-
-.. automethod:: aimet_torch.quantsim.QuantizationSimModel.compute_encodings
+.. autoclass:: aimet_torch.QuantizationSimModel
+   :members: compute_encodings, export
 
 **The following APIs can be used to save and restore the quantized model**
 
 .. automethod:: aimet_torch.quantsim.save_checkpoint
 
 .. automethod:: aimet_torch.quantsim.load_checkpoint
-
-**The following API can be used to export the quantized model to target:**
-
-.. automethod:: aimet_torch.quantsim.QuantizationSimModel.export
 
 **Quant Scheme Enum**
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -181,9 +181,9 @@ class QuantizationSimModel(_QuantizationSimModelBase):
            Passing `rounding_mode` will throw runtime error in >=1.35.
 
         .. warning::
-           The default value of `quant_scheme` will change
+           The default value of `quant_scheme` has changed
            from `QuantScheme.post_training_tf_enhanced` to `QuantScheme.training_range_learning_with_tf_init`
-           in the future versions, and will be deprecated in the longer term.
+           since 2.0.0, and will be deprecated in the longer term.
 
         Args:
             model (torch.nn.Module): Model to simulate the quantized execution of


### PR DESCRIPTION
## Main Changes:
* Replaced :automethod: with :members: (6c1c7b61862b9af726fc66ac7ad23f1c21f00152)
* Updated warning message (f88a1016810583da18935931bb12aa6ff4322706)

#### Why :members: over :automethod:?
It's cleaner
![image](https://github.com/user-attachments/assets/bbacbe87-ab4f-47ba-9096-afc8ddc8d64f)
