### PR TITLE
Restore aimet-torch-cpu variant in PR job

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -199,8 +199,8 @@ jobs:
               TEST_DIR="$TEST_DIR ./TrainingExtensions/torch/test"
           fi
           TEST_ARGS=""
-          if [ "${{ matrix.VER_CUDA }}" != "" ] ; then
-              TEST_ARGS="$TEST_ARGS -m cuda"
+          if [ "${{ matrix.VER_CUDA }}" == "" ] ; then
+              TEST_ARGS="$TEST_ARGS -m \"not cuda\""
           fi
           ./.conda/bin/conda run --live-stream --name "${{ matrix.id }}" python3 -m pytest $TEST_ARGS  $TEST_DIR
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Torch variants
         run: |
           VALUE=$(echo "${VALUE:-"{}"}" | jq -c '.include += [
+              { "VER_PYTHON":"3.10", "VER_TENSORFLOW":"",       "VER_TORCH":"2.1.2", "VER_ONNX":"",        "VER_CUDA":"" },
               { "VER_PYTHON":"3.10", "VER_TENSORFLOW":"",       "VER_TORCH":"2.1.2", "VER_ONNX":"",        "VER_CUDA":"12.1.1" }
             ]')
           echo "VALUE=$VALUE" >> $GITHUB_ENV

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -185,6 +185,8 @@ jobs:
           onnx$([ -n "${{ matrix.VER_ONNX }}" ] && echo "==${{ matrix.VER_ONNX }}") \
           " > /tmp/constraints.txt
 
+          export PIP_EXTRA_INDEX_URL="https://download.pytorch.org/whl/$(echo "${{ matrix.VER_CUDA }}" | awk -F'.' '{print ($1!="")? "cu"$1$2 : "cpu"}')"
+
           curl -o ./conda.sh -L 'https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh'
           bash ./conda.sh -u -b -p ./.conda
           sudo apt update -qq && sudo apt install -y g++ # deepspeed compiles cuda kernels

--- a/Jenkins/fast-release/Dockerfile.ci
+++ b/Jenkins/fast-release/Dockerfile.ci
@@ -76,4 +76,3 @@ ENV PYTHONPYCACHEPREFIX=/tmp
 
 ENTRYPOINT ["/bin/bash", "--login", "-c", "${0#--} \"$@\""]
 CMD ["/bin/bash"]
-


### PR DESCRIPTION
## Context
In #3741, @quic-emironov has made somewhat-major behavioral changes as follows:
1. Removed aimet-torch-cpu variant
2. aimet-\*-gpu variants **only** run cuda test cases (the ones marked as `@pytest.mark.cuda`), and aimet-\*-cpu variants only run non-cuda test cases.

These behavioral differences between the old PR jobs (in Jenkins) and the new PR jobs (in GitHub Action) is making us hesitant to completely replace Jenkins with GitHub Action.

## Main Changes
Restored the old behaviors where aimet-*-gpu tests both cuda and non-cuda test cases so that everyone feels safer about transitioning our PR jobs' infrastructure from Jenkins to GitHub Action completely.