### PR TITLE
Remove save/load_checkpoint from v2 quantsim api reference

### DIFF
--- a/Docs/apiref/torch/quantsim.rst
+++ b/Docs/apiref/torch/quantsim.rst
@@ -10,12 +10,6 @@ aimet_torch.quantsim
 .. autoclass:: aimet_torch.QuantizationSimModel
    :members: compute_encodings, export
 
-**The following APIs can be used to save and restore the quantized model**
-
-.. automethod:: aimet_torch.quantsim.save_checkpoint
-
-.. automethod:: aimet_torch.quantsim.load_checkpoint
-
 **Quant Scheme Enum**
 
 .. autoclass:: aimet_common.defs.QuantScheme


### PR DESCRIPTION
`save/load_checkpoint` is deprecated

https://github.com/quic/aimet/blob/623f639e237c549143c24aa9f7d03154b469420b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py#L1745-L1757