### PR TITLE
Throw runtime error if QuantizationSimModel takes untraceable input

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -1835,7 +1835,7 @@ def _assert_jit_traceable(model, dummy_input):
 
     try:
         untraceable_obj = next(
-            x for x in tree_flatten(dummy_input) if not isinstance(x, torch.Tensor)
+            x for x in tree_flatten(dummy_input)[0] if not isinstance(x, torch.Tensor)
         )
     except StopIteration:
         return

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -61,6 +61,7 @@ from typing import (
 )
 
 import torch
+from torch.utils._pytree import tree_iter
 import onnx
 from packaging import version  # pylint: disable=wrong-import-order
 from safetensors.numpy import save_file as save_safetensor_file
@@ -279,6 +280,10 @@ class _QuantizationSimModelBase(_QuantizationSimModelInterface):
         # Perform sanity checks on inputs
         validate_quantsim_inputs(quant_scheme, rounding_mode, default_output_bw, default_param_bw,
                                  default_data_type)
+
+        # Assert dummy input is traceable by torch.jit.trace
+        _assert_jit_traceable(type(model), dummy_input)
+
         # save some parameters
         if in_place:
             self.model = model
@@ -1803,3 +1808,56 @@ def check_accumulator_overflow(model: torch.nn.Module, quant_bw: int, accum_bw: 
                     most_accum_range_used_layer, most_accum_range_used * 100)
 
     return most_accum_range_used_layer, most_accum_range_used
+
+
+def _assert_jit_traceable(model_cls, dummy_input):
+    try:
+        from transformers import Cache, DynamicCache, EncoderDecoderCache # pylint: disable=import-outside-toplevel
+    except ImportError:
+        # Dummy definition in case transformers package doesn't exist
+        Cache = type('Cache', (), {})
+        DynamicCache = type('DynamicCache', (), {})
+        EncoderDecoderCache = type('EncoderDecoderCache', (), {})
+
+    try:
+        untraceable_obj = next(
+            x for x in tree_iter(dummy_input) if not isinstance(x, torch.Tensor)
+        )
+    except StopIteration:
+        return
+
+    msg = "QuantizationSimModel can only take a tensor or tuple, list, or dict of tensors as input; "\
+         f"Got {type(untraceable_obj)}."
+
+    if not isinstance(untraceable_obj, Cache):
+        raise RuntimeError(msg)
+
+    cache_cls = type(untraceable_obj)
+    parent_clsname = model_cls.__name__
+    new_clsname = f"My{parent_clsname}"
+
+    msg += '\n'.join([
+         " If the model is from HuggingFace transformers that takes Cache object as input, "\
+        "consider defining a subclass that only takes tensors instead of Cache.\n",
+
+         "For example:\n\n",
+    ])
+
+    if cache_cls in (DynamicCache, EncoderDecoderCache):
+        msg += '\n'.join([
+            f"class {new_clsname}({parent_clsname}):",
+             "    def forward(self, ..., past_key_values: List[Tuple[Tensor, Tensor]] = None, ...):",
+            f"        # Create {cache_cls.__name__} object from nested tuple of tensors `past_key_values`",
+            f"        past_key_values = {cache_cls.__name__}.from_legacy_cache(past_key_values)",
+             "        return super().forward(..., past_key_values, ...)",
+         ])
+    else:
+        msg += '\n'.join([
+            f"class {new_clsname}({parent_clsname}):",
+             "    def forward(self, ..., past_key_values: List[Tuple[Tensor, Tensor]] = None, ...):",
+            f"        # TODO: Create {cache_cls.__name__} object from nested tuple of tensors `past_key_values`",
+            f"        past_key_values: {cache_cls.__name__} = ...",
+             "        return super().forward(..., past_key_values, ...)",
+         ])
+
+    raise RuntimeError(msg)

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -282,7 +282,7 @@ class _QuantizationSimModelBase(_QuantizationSimModelInterface):
                                  default_data_type)
 
         # Assert dummy input is traceable by torch.jit.trace
-        _assert_jit_traceable(type(model), dummy_input)
+        _assert_jit_traceable(model, dummy_input)
 
         # save some parameters
         if in_place:
@@ -1810,14 +1810,28 @@ def check_accumulator_overflow(model: torch.nn.Module, quant_bw: int, accum_bw: 
     return most_accum_range_used_layer, most_accum_range_used
 
 
-def _assert_jit_traceable(model_cls, dummy_input):
+def _assert_jit_traceable(model, dummy_input):
     try:
-        from transformers import Cache, DynamicCache, EncoderDecoderCache # pylint: disable=import-outside-toplevel
+        from transformers import ( # pylint: disable=import-outside-toplevel
+            PreTrainedModel,
+            Cache,
+            DynamicCache,
+            EncoderDecoderCache
+        )
     except ImportError:
         # Dummy definition in case transformers package doesn't exist
+        PreTrainedModel = type('PreTrainedModel', (), {})
         Cache = type('Cache', (), {})
         DynamicCache = type('DynamicCache', (), {})
         EncoderDecoderCache = type('EncoderDecoderCache', (), {})
+
+    if isinstance(model, PreTrainedModel) and model.config.use_return_dict:
+        msg = ' '.join([
+            "QuantizationSimModel only supports models that return a tensor or tuple, list, or dict of tensors",
+            "If the model is from HuggingFace transformers,",
+            "it is required to set ``model.config.return_dict=False``",
+        ])
+        raise RuntimeError(msg)
 
     try:
         untraceable_obj = next(
@@ -1833,7 +1847,7 @@ def _assert_jit_traceable(model_cls, dummy_input):
         raise RuntimeError(msg)
 
     cache_cls = type(untraceable_obj)
-    parent_clsname = model_cls.__name__
+    parent_clsname = type(model).__name__
     new_clsname = f"My{parent_clsname}"
 
     msg += '\n'.join([
@@ -1849,7 +1863,8 @@ def _assert_jit_traceable(model_cls, dummy_input):
              "    def forward(self, ..., past_key_values: List[Tuple[Tensor, Tensor]] = None, ...):",
             f"        # Create {cache_cls.__name__} object from nested tuple of tensors `past_key_values`",
             f"        past_key_values = {cache_cls.__name__}.from_legacy_cache(past_key_values)",
-             "        return super().forward(..., past_key_values, ...)",
+             "        ..., new_past_key_values, ... =  super().forward(..., past_key_values, ...)",
+             "        return (..., new_past_key_values.to_legacy_cache(), ...)",
          ])
     else:
         msg += '\n'.join([
@@ -1857,7 +1872,12 @@ def _assert_jit_traceable(model_cls, dummy_input):
              "    def forward(self, ..., past_key_values: List[Tuple[Tensor, Tensor]] = None, ...):",
             f"        # TODO: Create {cache_cls.__name__} object from nested tuple of tensors `past_key_values`",
             f"        past_key_values: {cache_cls.__name__} = ...",
-             "        return super().forward(..., past_key_values, ...)",
+             "",
+             "        ..., new_past_key_values, ... =  super().forward(..., past_key_values, ...)",
+             "",
+            f"        # TODO: Create nested tuple of tensors from a {cache_cls.__name__} object `new_past_key_values`",
+            f"        new_past_key_values: List[Tuple[Tensor, Tensor]] = ...",
+             "        return (..., new_past_key_values.to_legacy_cache(), ...)",
          ])
 
     raise RuntimeError(msg)

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -61,7 +61,7 @@ from typing import (
 )
 
 import torch
-from torch.utils._pytree import tree_iter
+from torch.utils._pytree import tree_flatten
 import onnx
 from packaging import version  # pylint: disable=wrong-import-order
 from safetensors.numpy import save_file as save_safetensor_file
@@ -1821,7 +1821,7 @@ def _assert_jit_traceable(model_cls, dummy_input):
 
     try:
         untraceable_obj = next(
-            x for x in tree_iter(dummy_input) if not isinstance(x, torch.Tensor)
+            x for x in tree_flatten(dummy_input) if not isinstance(x, torch.Tensor)
         )
     except StopIteration:
         return

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -1876,7 +1876,7 @@ def _assert_jit_traceable(model, dummy_input):
              "        ..., new_past_key_values, ... =  super().forward(..., past_key_values, ...)",
              "",
             f"        # TODO: Create nested tuple of tensors from a {cache_cls.__name__} object `new_past_key_values`",
-            f"        new_past_key_values: List[Tuple[Tensor, Tensor]] = ...",
+             "        new_past_key_values: List[Tuple[Tensor, Tensor]] = ...",
              "        return (..., new_past_key_values.to_legacy_cache(), ...)",
          ])
 


### PR DESCRIPTION
## Problem
Since v4.47 (released Dec 2024), HuggingFace transformers stopped supporting [**legacy format**](https://huggingface.co/docs/transformers/en/kv_cache#legacy-cache-format) KV cache (=KV cache represented as nested tuple of tensors) and only supports [**Cache**](https://github.com/huggingface/transformers/blob/ec7afad60909dd97d998c1f14681812d69a15728/src/transformers/cache_utils.py#L27) objects (=custom nn.Module defined in transformers)

**This is/will be a major blocking issue for the GenAI notebooks since torch.jit.trace only allows Tensors as input, and therefore QuantizationSimModel can't be instantiated with the models utilizing KV cache.**

## Solutions
#### ❌ long term solution
The ultimate long-term solution would be thoroughly redesigning quantsim configurator such that it doesn't require or only optionally requires torch.jit.trace. However, it would be a huge long-term project.
Therefore, in this PR, @ashvkuma and I propose a passive short-term solution as below.

#### ✔️ short term solution (this PR)
A short term solution is throwing a runtime error with proper error messages that help the users adjust their models to be compatible with torch.jit tracing. Once this PR gets merged, the users will start to see error messages as below when they try to create QuantizationSimModel with transformers.Cache object as below:

```pycon
>>> model = LlamaForCausalLM.from_pretrained('huggyllama/llama-7b', config=config)
>>> dummy_input = (torch.randn(...), torch.randn(...), torch.randn(...), DynamicCache())
>>> _ = QuantizationSimModel(model, input)

Traceback (most recent call last):
  <...>

RuntimeError: QuantizationSimModel can only take a tensor or tuple, list, or dict of tensors as input; Got <class 'transformers.cache_utils.DynamicCache'>.
If the model is from HuggingFace transformers that takes Cache object as input, consider defining a subclass that only takes tensors instead of Cache.

For example:

class MyLlamaForCausalLM(LlamaForCausalLM):
    def forward(self, ..., past_key_values: List[Tuple[Tensor, Tensor]] = None, ...):
        # Create DynamicCache object from nested tuple of tensors `past_key_values`
        past_key_values = DynamicCache.from_legacy_cache(past_key_values)
        return super().forward(..., past_key_values, ...)
```

#### ❌ solutions that were discussed but rejected (+ why)
* Use dynamo tracing instead of torch.jit tracing
   1. Takes a huge amount of engineering effort
   2. Dynamo trace produces a dirty, verbose graph
* Let quantsim temporarily convert DynamicCache to legacy-format cache using [**to/from_legacy_cache()**](https://github.com/huggingface/transformers/blob/ec7afad60909dd97d998c1f14681812d69a15728/src/transformers/cache_utils.py#L460-L480) so DynamicCache will never be passed to torch.jit.trace
   1. KV cache inputs will be represented very differently in ConnectedGraph (nested tuple of tensors) and the actual model (transformers.Cache object), making it difficult/confusing to attach input quantizers properly for KV cache.
   2. We also had some concerns regarding sim.export() which is another API that heavily relies on torch.jit.trace.
   3. In general, it's not a good idea to silently modify the definition of the user model