### PR TITLE
Handle variadic functions properly in error message code examples

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -238,8 +238,6 @@ class BaseQuantizationMixin(abc.ABC):
 
     @classmethod
     def _generate_code_example(cls, module_cls) -> str:
-        mixin_clsname = cls.__name__
-        module_clsname = module_cls.__name__
         forward_fn_signature = inspect.signature(module_cls.forward)
         _, *forward_fn_args = list(forward_fn_signature.parameters.values())
         ret_type = forward_fn_signature.return_annotation
@@ -310,8 +308,8 @@ class BaseQuantizationMixin(abc.ABC):
         ]
 
         return '\n'.join([
-            f'@{mixin_clsname}.implements({module_clsname})',
-            f'class Quantized{module_clsname}({mixin_clsname}, {module_clsname}):',
+            f'@{cls.__name__}.implements({module_cls.__name__})',
+            f'class Quantized{module_cls.__name__}({cls.__name__}, {module_cls.__name__}):',
              '    def __quant_init__(self):',
              '        super().__quant_init__()',
              '',

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -241,22 +241,39 @@ class BaseQuantizationMixin(abc.ABC):
         mixin_clsname = cls.__name__
         module_clsname = module_cls.__name__
         forward_fn_signature = inspect.signature(module_cls.forward)
-        _, *forward_fn_args = list(forward_fn_signature.parameters.keys())
+        _, *forward_fn_args = list(forward_fn_signature.parameters.values())
         ret_type = forward_fn_signature.return_annotation
 
         if ret_type == inspect.Parameter.empty:
             # if return annotation is unspecified, assume torch.Tensor as return type
             ret_type = torch.Tensor
 
-        _declare_input_quantizers = [
-            f'self.input_quantizers = torch.nn.ModuleList({[None for _ in forward_fn_args]})',
+        positional_or_keyword_args = [
+            arg for arg in forward_fn_args
+            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD)
         ]
-        _quantize_inputs = []
-        for i, varname in enumerate(forward_fn_args):
-            _quantize_inputs += [
-                f"if self.input_quantizers[{i}]:",
-                f"    {varname} = self.input_quantizers[{i}]({varname})\n",
+        if positional_or_keyword_args != forward_fn_args:
+            # Module takes variable number of inputs (*args and/or **kwargs)
+            # In this case, only the user knows the proper number of input quantizers
+            _declare_input_quantizers = [
+                'self.input_quantizers = torch.nn.ModuleList(',
+                "    # <TODO: Declare the number of input quantizers here>",
+                ')',
             ]
+            _quantize_inputs = [
+                "# <TODO: Quantize inputs as necessary>\n",
+            ]
+        else:
+            _declare_input_quantizers = [
+                f'self.input_quantizers = torch.nn.ModuleList({[None for _ in positional_or_keyword_args]})',
+            ]
+            _quantize_inputs = []
+            for i, arg in enumerate(positional_or_keyword_args):
+                _quantize_inputs += [
+                    f"if self.input_quantizers[{i}]:",
+                    f"    {arg.name} = self.input_quantizers[{i}]({arg.name})\n",
+                ]
 
         if ret_type == torch.Tensor:
             _declare_output_quantizers = [
@@ -276,6 +293,22 @@ class BaseQuantizationMixin(abc.ABC):
                 "# <TODO: Quantize `ret` as necessary>\n",
             ]
 
+        def format_arg(arg: inspect.Parameter):
+            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                return arg.name
+            if arg.kind == inspect.Parameter.VAR_POSITIONAL:
+                return f"*{arg.name}"
+            if arg.kind == inspect.Parameter.KEYWORD_ONLY:
+                return f"{arg.name}={arg.name}"
+            if arg.kind == inspect.Parameter.VAR_KEYWORD:
+                return f"**{arg.name}"
+            raise RuntimeError
+
+        _call_super_forward = [
+            f'ret = super().forward({", ".join([format_arg(arg) for arg in forward_fn_args])})',
+        ]
+
         return '\n'.join([
             f'@{mixin_clsname}.implements({module_clsname})',
             f'class Quantized{module_clsname}({mixin_clsname}, {module_clsname}):',
@@ -292,11 +325,11 @@ class BaseQuantizationMixin(abc.ABC):
 
              '        # Run forward with quantized inputs and parameters',
              '        with self._patch_quantized_parameters():',
-            f'            ret = super().forward({", ".join(forward_fn_args)})',
+          *(f'            {line}' for line in _call_super_forward),
              '',
              '        # Quantize output tensors',
           *(f'        {line}' for line in _quantize_outputs),
-             '',
+
              '        return ret',
         ])
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -244,54 +244,61 @@ class BaseQuantizationMixin(abc.ABC):
         _, *forward_fn_args = list(forward_fn_signature.parameters.keys())
         ret_type = forward_fn_signature.return_annotation
 
-        if ret_type == inspect._empty: # pylint: disable=protected-access
+        if ret_type == inspect.Parameter.empty:
             # if return annotation is unspecified, assume torch.Tensor as return type
             ret_type = torch.Tensor
 
-        _quantize_inputs = "\n\n".join([
-f"""
-        if self.input_quantizers[{i}]:
-            {varname} = self.input_quantizers[{i}]({varname})
-""".strip('\n')
-            for i, varname in enumerate(forward_fn_args)
+        _declare_input_quantizers = [
+            f'self.input_quantizers = torch.nn.ModuleList({[None for _ in forward_fn_args]})',
+        ]
+        _quantize_inputs = []
+        for i, varname in enumerate(forward_fn_args):
+            _quantize_inputs += [
+                f"if self.input_quantizers[{i}]:",
+                f"    {varname} = self.input_quantizers[{i}]({varname})\n",
+            ]
+
+        if ret_type == torch.Tensor:
+            _declare_output_quantizers = [
+                'self.output_quantizers = torch.nn.ModuleList([None])',
+            ]
+            _quantize_outputs = [
+                "if self.output_quantizers[0]:",
+                "    ret = self.output_quantizers[0](ret)\n",
+            ]
+        else:
+            _declare_output_quantizers = [
+                "self.output_quantizers = torch.nn.ModuleList(",
+                "    # <TODO: Declare the number of output quantizers here>",
+                ")",
+            ]
+            _quantize_outputs = [
+                "# <TODO: Quantize `ret` as necessary>\n",
+            ]
+
+        return '\n'.join([
+            f'@{mixin_clsname}.implements({module_clsname})',
+            f'class Quantized{module_clsname}({mixin_clsname}, {module_clsname}):',
+             '    def __quant_init__(self):',
+             '        super().__quant_init__()',
+             '',
+             '        # Declare the number of input/output quantizers',
+          *(f'        {line}' for line in _declare_input_quantizers),
+          *(f'        {line}' for line in _declare_output_quantizers),
+             '',
+            f'    def forward{forward_fn_signature}:',
+             '        # Quantize input tensors',
+          *(f'        {line}' for line in _quantize_inputs),
+
+             '        # Run forward with quantized inputs and parameters',
+             '        with self._patch_quantized_parameters():',
+            f'            ret = super().forward({", ".join(forward_fn_args)})',
+             '',
+             '        # Quantize output tensors',
+          *(f'        {line}' for line in _quantize_outputs),
+             '',
+             '        return ret',
         ])
-
-        _quantize_outputs = \
-"""
-        if self.output_quantizers[0]:
-            ret = self.output_quantizers[0](ret)
-""".strip('\n') \
-        if ret_type == torch.Tensor else \
-"""
-        # <TODO: Quantize `ret` as necessary>
-""".strip('\n')
-
-        return \
-f"""
-@{mixin_clsname}.implements({module_clsname})
-class Quantized{module_clsname}({mixin_clsname}, {module_clsname}):
-    def __quant_init__(self):
-        super().__quant_init__()
-
-        # Declare the number of input/output quantizers
-        self.input_quantizers = torch.nn.ModuleList({[None for _ in forward_fn_args]})
-        self.output_quantizers = torch.nn.ModuleList({
-            [None] if ret_type == torch.Tensor else "<TODO: declare the number of output quantizers here>"
-        })
-
-    def forward{forward_fn_signature}:
-        # Quantize input tensors
-{_quantize_inputs}
-
-        # Run forward with quantized inputs and parameters
-        with self._patch_quantized_parameters():
-            ret = super().forward({", ".join(forward_fn_args)})
-
-        # Quantize output tensors
-{_quantize_outputs}
-
-        return ret
-""".strip('\n')
 
     @classmethod
     def from_module(cls, module: nn.Module):

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -1059,6 +1059,8 @@ def test_default_kernels(module_factory, input_factory):
     # transformers.models.llama.modeling_llama.LlamaRotaryEmbedding, # requires latest transformer
     # transformers.models.llama.modeling_llama.LlamaRMSNorm, # requires latest transformer
     torch.nn.Linear,
+    custom.Multiply,
+    custom.MatMul,
 ])
 def test_code_example(module_cls):
     """


### PR DESCRIPTION
## Problem
There was a bug in the codegen function which didn't work with modules that take variadic arguments.

For example like this:
(**Note how input quantization and super().forward is getting done incorrectly**)
```pycon
>>> class MyModule(torch.nn.Module):
...     def forward(self, *args, **kwargs):
...         ...
...
>>> _ = QuantizationSimModel(MyModule(), ())

RuntimeError: The quantized module definition of <class '__main__.MyModule'> is not registered.
Please register the quantized module definition of <class '__main__.MyModule'> using `@QuantizationMixin.implements(MyModule)` decorator.

For example:

@QuantizationMixin.implements(MyModule)
class QuantizedMyModule(QuantizationMixin, MyModule):
    def __quant_init__(self):
        super().__quant_init__()

        # Declare the number of input/output quantizers
        self.input_quantizers = torch.nn.ModuleList([None, None])
        self.output_quantizers = torch.nn.ModuleList([None])

    def forward(self, *args, **kwargs):
        # Quantize input tensors
        if self.input_quantizers[0]:
            args = self.input_quantizers[0](args)

        if self.input_quantizers[1]:
            kwargs = self.input_quantizers[1](kwargs)

        # Run forward with quantized inputs and parameters
        with self._patch_quantized_parameters():
            ret = super().forward(args, kwargs)

        # Quantize output tensors
        if self.output_quantizers[0]:
            ret = self.output_quantizers[0](ret)

        return ret


For more details, please refer to the official API reference:
https://quic.github.io/aimet-pages/releases/latest/apiref/torch/generated/aimet_torch.nn.QuantizationMixin.html#aimet_torch.nn.QuantizationMixin.implements
``` 

## Main Changes
Added some extra check to generate correct code examples with variadic functions.
Given `MyModule` defined as above, now the code example will look like this:
```
For example:

@QuantizationMixin.implements(MyModule)
class QuantizedMyModule(QuantizationMixin, MyModule):
    def __quant_init__(self):
        super().__quant_init__()

        # Declare the number of input/output quantizers
        self.input_quantizers = torch.nn.ModuleList(
            # <TODO: Declare the number of input quantizers here>
        )
        self.output_quantizers = torch.nn.ModuleList([None])

    def forward(self, *args, **kwargs):
        # Quantize input tensors
        # <TODO: Quantize inputs as necessary>

        # Run forward with quantized inputs and parameters
        with self._patch_quantized_parameters():
            ret = super().forward(*args, **kwargs)

        # Quantize output tensors
        if self.output_quantizers[0]:
            ret = self.output_quantizers[0](ret)

        return ret
```