### PR TITLE
Batch unknown module error messages in one exception

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -61,6 +61,131 @@ def _no_op(in_tensor):
     return in_tensor
 
 
+class UnkownModuleError(RuntimeError):
+    """
+    Exception thrown when an unknown module is encountered
+    whose quantized definition isn't registered using @QuantizationMixin.implements().
+    """
+    module_cls: Type[torch.nn.Module]
+    mixin_cls: Type['BaseQuantizationMixin']
+    api_reference_url = "https://quic.github.io/aimet-pages/releases/" \
+                        "latest/apiref/torch/generated/" \
+                        "aimet_torch.nn.QuantizationMixin.html#aimet_torch.nn.QuantizationMixin.implements"
+
+    def __init__(self, module_cls: Type[torch.nn.Module], mixin_cls: Type['BaseQuantizationMixin']):
+        self.module_cls = module_cls
+        self.mixin_cls = mixin_cls
+        msg = self.generate_err_msg()
+        super().__init__(msg)
+
+    def generate_err_msg(self) -> str:
+        """ Generate error message """
+        module_cls = self.module_cls
+        mixin_cls = self.mixin_cls
+        code_example = self.generate_code_example()
+
+        return f'The quantized module definition of {module_cls} is not registered. ' \
+               f'Please register the quantized module definition of {module_cls} ' \
+               f'using `@{mixin_cls.__name__}.implements({module_cls.__name__})` decorator.\n\n' \
+               f"For example:\n\n{code_example}\n\n" \
+               f"For more details, please refer to the official API reference:\n{self.api_reference_url}"
+
+    def generate_code_example(self) -> str:
+        """ Generate code example """
+        module_cls = self.module_cls
+        mixin_cls = self.mixin_cls
+
+        forward_fn_signature = inspect.signature(module_cls.forward)
+        _, *forward_fn_args = list(forward_fn_signature.parameters.values())
+        ret_type = forward_fn_signature.return_annotation
+
+        if ret_type == inspect.Parameter.empty:
+            # if return annotation is unspecified, assume torch.Tensor as return type
+            ret_type = torch.Tensor
+
+        positional_or_keyword_args = [
+            arg for arg in forward_fn_args
+            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD)
+        ]
+        if positional_or_keyword_args != forward_fn_args:
+            # Module takes variable number of inputs (*args and/or **kwargs)
+            # In this case, only the user knows the proper number of input quantizers
+            _declare_input_quantizers = [
+                'self.input_quantizers = torch.nn.ModuleList(',
+                "    # <TODO: Declare the number of input quantizers here>",
+                ')',
+            ]
+            _quantize_inputs = [
+                "# <TODO: Quantize inputs as necessary>\n",
+            ]
+        else:
+            _declare_input_quantizers = [
+                f'self.input_quantizers = torch.nn.ModuleList({[None for _ in positional_or_keyword_args]})',
+            ]
+            _quantize_inputs = []
+            for i, arg in enumerate(positional_or_keyword_args):
+                _quantize_inputs += [
+                    f"if self.input_quantizers[{i}]:",
+                    f"    {arg.name} = self.input_quantizers[{i}]({arg.name})\n",
+                ]
+
+        if ret_type == torch.Tensor:
+            _declare_output_quantizers = [
+                'self.output_quantizers = torch.nn.ModuleList([None])',
+            ]
+            _quantize_outputs = [
+                "if self.output_quantizers[0]:",
+                "    ret = self.output_quantizers[0](ret)\n",
+            ]
+        else:
+            _declare_output_quantizers = [
+                "self.output_quantizers = torch.nn.ModuleList(",
+                "    # <TODO: Declare the number of output quantizers here>",
+                ")",
+            ]
+            _quantize_outputs = [
+                "# <TODO: Quantize `ret` as necessary>\n",
+            ]
+
+        def format_arg(arg: inspect.Parameter):
+            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
+                            inspect.Parameter.POSITIONAL_OR_KEYWORD):
+                return arg.name
+            if arg.kind == inspect.Parameter.VAR_POSITIONAL:
+                return f"*{arg.name}"
+            if arg.kind == inspect.Parameter.KEYWORD_ONLY:
+                return f"{arg.name}={arg.name}"
+            if arg.kind == inspect.Parameter.VAR_KEYWORD:
+                return f"**{arg.name}"
+            raise RuntimeError
+
+        return '\n'.join([
+            f'@{mixin_cls.__name__}.implements({module_cls.__name__})',
+            f'class Quantized{module_cls.__name__}({mixin_cls.__name__}, {module_cls.__name__}):',
+             '    def __quant_init__(self):',
+             '        super().__quant_init__()',
+             '',
+             '        # Declare the number of input/output quantizers',
+          *(f'        {line}' for line in _declare_input_quantizers),
+          *(f'        {line}' for line in _declare_output_quantizers),
+             '',
+            f'    def forward{forward_fn_signature}:',
+             '        # Quantize input tensors',
+          *(f'        {line}' for line in _quantize_inputs),
+
+             '        # Run forward with quantized inputs and parameters',
+             '        with self._patch_quantized_parameters():',
+            f'            ret = super().forward({", ".join([format_arg(arg) for arg in forward_fn_args])})',
+             '',
+             '        # Quantize output tensors',
+          *(f'        {line}' for line in _quantize_outputs),
+
+             '        return ret',
+        ])
+
+
+
 class BaseQuantizationMixin(abc.ABC):
     """Mixin that implements quantization on top of regular pytorch modules.
 
@@ -237,101 +362,6 @@ class BaseQuantizationMixin(abc.ABC):
         return wrapper
 
     @classmethod
-    def _generate_code_example(cls, module_cls) -> str:
-        forward_fn_signature = inspect.signature(module_cls.forward)
-        _, *forward_fn_args = list(forward_fn_signature.parameters.values())
-        ret_type = forward_fn_signature.return_annotation
-
-        if ret_type == inspect.Parameter.empty:
-            # if return annotation is unspecified, assume torch.Tensor as return type
-            ret_type = torch.Tensor
-
-        positional_or_keyword_args = [
-            arg for arg in forward_fn_args
-            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
-                            inspect.Parameter.POSITIONAL_OR_KEYWORD)
-        ]
-        if positional_or_keyword_args != forward_fn_args:
-            # Module takes variable number of inputs (*args and/or **kwargs)
-            # In this case, only the user knows the proper number of input quantizers
-            _declare_input_quantizers = [
-                'self.input_quantizers = torch.nn.ModuleList(',
-                "    # <TODO: Declare the number of input quantizers here>",
-                ')',
-            ]
-            _quantize_inputs = [
-                "# <TODO: Quantize inputs as necessary>\n",
-            ]
-        else:
-            _declare_input_quantizers = [
-                f'self.input_quantizers = torch.nn.ModuleList({[None for _ in positional_or_keyword_args]})',
-            ]
-            _quantize_inputs = []
-            for i, arg in enumerate(positional_or_keyword_args):
-                _quantize_inputs += [
-                    f"if self.input_quantizers[{i}]:",
-                    f"    {arg.name} = self.input_quantizers[{i}]({arg.name})\n",
-                ]
-
-        if ret_type == torch.Tensor:
-            _declare_output_quantizers = [
-                'self.output_quantizers = torch.nn.ModuleList([None])',
-            ]
-            _quantize_outputs = [
-                "if self.output_quantizers[0]:",
-                "    ret = self.output_quantizers[0](ret)\n",
-            ]
-        else:
-            _declare_output_quantizers = [
-                "self.output_quantizers = torch.nn.ModuleList(",
-                "    # <TODO: Declare the number of output quantizers here>",
-                ")",
-            ]
-            _quantize_outputs = [
-                "# <TODO: Quantize `ret` as necessary>\n",
-            ]
-
-        def format_arg(arg: inspect.Parameter):
-            if arg.kind in (inspect.Parameter.POSITIONAL_ONLY,
-                            inspect.Parameter.POSITIONAL_OR_KEYWORD):
-                return arg.name
-            if arg.kind == inspect.Parameter.VAR_POSITIONAL:
-                return f"*{arg.name}"
-            if arg.kind == inspect.Parameter.KEYWORD_ONLY:
-                return f"{arg.name}={arg.name}"
-            if arg.kind == inspect.Parameter.VAR_KEYWORD:
-                return f"**{arg.name}"
-            raise RuntimeError
-
-        _call_super_forward = [
-            f'ret = super().forward({", ".join([format_arg(arg) for arg in forward_fn_args])})',
-        ]
-
-        return '\n'.join([
-            f'@{cls.__name__}.implements({module_cls.__name__})',
-            f'class Quantized{module_cls.__name__}({cls.__name__}, {module_cls.__name__}):',
-             '    def __quant_init__(self):',
-             '        super().__quant_init__()',
-             '',
-             '        # Declare the number of input/output quantizers',
-          *(f'        {line}' for line in _declare_input_quantizers),
-          *(f'        {line}' for line in _declare_output_quantizers),
-             '',
-            f'    def forward{forward_fn_signature}:',
-             '        # Quantize input tensors',
-          *(f'        {line}' for line in _quantize_inputs),
-
-             '        # Run forward with quantized inputs and parameters',
-             '        with self._patch_quantized_parameters():',
-          *(f'            {line}' for line in _call_super_forward),
-             '',
-             '        # Quantize output tensors',
-          *(f'        {line}' for line in _quantize_outputs),
-
-             '        return ret',
-        ])
-
-    @classmethod
     def from_module(cls, module: nn.Module):
         r"""Create an instance of quantized module from a regular module instance.
 
@@ -346,17 +376,7 @@ class BaseQuantizationMixin(abc.ABC):
         qtzn_module_cls = cls.cls_to_qcls.get(module_cls, None)
 
         if not qtzn_module_cls:
-            api_reference_url = "https://quic.github.io/aimet-pages/releases/" \
-                                "latest/apiref/torch/generated/" \
-                                "aimet_torch.nn.QuantizationMixin.html#aimet_torch.nn.QuantizationMixin.implements"
-
-            raise RuntimeError(
-                f'The quantized module definition of {module_cls} is not registered. '
-                f'Please register the quantized module definition of {module_cls} '
-                f'using `@{cls.__name__}.implements({module_cls.__name__})` decorator.\n\n'
-                f"For example:\n\n{cls._generate_code_example(module_cls)}\n\n"
-                f"For more details, please refer to the official API reference:\n{api_reference_url}"
-            )
+            raise UnkownModuleError(module_cls, cls)
 
         qtzn_module = cls.__new__(qtzn_module_cls)
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -61,7 +61,7 @@ def _no_op(in_tensor):
     return in_tensor
 
 
-class UnkownModuleError(RuntimeError):
+class UnknownModuleError(RuntimeError):
     """
     Exception thrown when an unknown module is encountered
     whose quantized definition isn't registered using @QuantizationMixin.implements().
@@ -376,7 +376,7 @@ class BaseQuantizationMixin(abc.ABC):
         qtzn_module_cls = cls.cls_to_qcls.get(module_cls, None)
 
         if not qtzn_module_cls:
-            raise UnkownModuleError(module_cls, cls)
+            raise UnknownModuleError(module_cls, cls)
 
         qtzn_module = cls.__new__(qtzn_module_cls)
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -62,7 +62,7 @@ from aimet_torch._base.quantsim import (
     _QuantizedModuleProtocol,
 )
 from aimet_torch.v2 import nn as aimet_nn
-from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin, UnkownModuleError
+from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin, UnknownModuleError
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
 from aimet_torch.v2._builder import _V2LazyQuantizeWrapper
 from aimet_torch.v2.quantization.base import QuantizerBase
@@ -112,11 +112,11 @@ def _convert_to_qmodel(model: torch.nn.Module):
             try:
                 qmodule = QuantizationMixin.from_module(module)
                 module = qmodule
-            except UnkownModuleError as e:
+            except UnknownModuleError as e:
                 try:
                     qmodule = _legacy_impl.FakeQuantizationMixin.from_module(module)
                     module = qmodule
-                except UnkownModuleError:
+                except UnknownModuleError:
                     pass
 
                 if not qmodule and not tuple(module.children()):
@@ -127,7 +127,7 @@ def _convert_to_qmodel(model: torch.nn.Module):
 
         return module
 
-    exceptions: List[UnkownModuleError] = []
+    exceptions: List[UnknownModuleError] = []
     model = _convert_to_qmodule(model)
 
     if not exceptions:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -137,20 +137,25 @@ def _convert_to_qmodel(model: torch.nn.Module):
         raise exceptions[0]
 
     # Multiple unknown modules found. Batch all error messages in one exception
+    e = exceptions[0]
     msg = '\n'.join([
         'Quantized module definitions of the following modules are not registered: [',
         *(f'    {e.module_cls},' for e in exceptions),
-        ']\n',
+        ']',
     ])
 
-    # Only print code example of the first exception
-    e = exceptions[0]
-    msg += f'Please register the quantized module definition of the modules listed above ' \
-           f'using `@{e.mixin_cls.__name__}.implements({e.module_cls.__name__})` decorator.\n\n' \
-           f"For example:\n\n{e.generate_code_example()}\n\n" \
-           f"For more details, please refer to the official API reference:\n{e.api_reference_url}"
+    raise RuntimeError('\n\n'.join([
+        msg,
 
-    raise RuntimeError(msg)
+        'Please register the quantized module definition of the modules listed above ' \
+        f'using `@{e.mixin_cls.__name__}.implements()` decorator.',
+
+        "For example:",
+
+        *(e.generate_code_example() for e in exceptions),
+
+       f"For more details, please refer to the official API reference:\n{e.api_reference_url}"
+    ]))
 
 
 class QuantizationSimModel(_QuantizationSimModelBase):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -37,7 +37,7 @@
 """ Top level API for performing quantization simulation of a pytorch model """
 
 import copy
-from typing import Union, Tuple, Optional, Sequence, TypeVar, Any, Callable, overload
+from typing import Union, Tuple, Optional, Sequence, TypeVar, Any, Callable, overload, List
 import warnings
 import itertools
 import io
@@ -62,7 +62,7 @@ from aimet_torch._base.quantsim import (
     _QuantizedModuleProtocol,
 )
 from aimet_torch.v2 import nn as aimet_nn
-from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin
+from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin, UnkownModuleError
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
 from aimet_torch.v2._builder import _V2LazyQuantizeWrapper
 from aimet_torch.v2.quantization.base import QuantizerBase
@@ -101,29 +101,56 @@ class _NOT_SPECIFIED:
     pass
 
 
-def _convert_to_qmodule(module: torch.nn.Module):
+def _convert_to_qmodel(model: torch.nn.Module):
     """
     Helper function to convert all modules to quantized aimet.nn modules.
     """
-    if not isinstance(module, (*quantized_modules, *unquantizable_modules, *containers)):
-        qmodule = None
-        try:
-            qmodule = QuantizationMixin.from_module(module)
-            module = qmodule
-        except RuntimeError as e:
+
+    def _convert_to_qmodule(module: torch.nn.Module):
+        if not isinstance(module, (*quantized_modules, *unquantizable_modules, *containers)):
+            qmodule = None
             try:
-                qmodule = _legacy_impl.FakeQuantizationMixin.from_module(module)
+                qmodule = QuantizationMixin.from_module(module)
                 module = qmodule
-            except RuntimeError:
-                pass
+            except UnkownModuleError as e:
+                try:
+                    qmodule = _legacy_impl.FakeQuantizationMixin.from_module(module)
+                    module = qmodule
+                except UnkownModuleError:
+                    pass
 
-            if not qmodule and not tuple(module.children()):
-                raise e # pylint: disable=raise-missing-from
+                if not qmodule and not tuple(module.children()):
+                    exceptions.append(e)
 
-    for name, child in module.named_children():
-        setattr(module, name, _convert_to_qmodule(child))
+        for name, child in module.named_children():
+            setattr(module, name, _convert_to_qmodule(child))
 
-    return module
+        return module
+
+    exceptions: List[UnkownModuleError] = []
+    model = _convert_to_qmodule(model)
+
+    if not exceptions:
+        return model
+
+    if len(exceptions) == 1:
+        raise exceptions[0]
+
+    # Multiple unknown modules found. Batch all error messages in one exception
+    msg = '\n'.join([
+        'Quantized module definitions of the following modules are not registered: [',
+        *(f'    {e.module_cls},' for e in exceptions),
+        ']\n',
+    ])
+
+    # Only print code example of the first exception
+    e = exceptions[0]
+    msg += f'Please register the quantized module definition of the modules listed above ' \
+           f'using `@{e.mixin_cls.__name__}.implements({e.module_cls.__name__})` decorator.\n\n' \
+           f"For example:\n\n{e.generate_code_example()}\n\n" \
+           f"For more details, please refer to the official API reference:\n{e.api_reference_url}"
+
+    raise RuntimeError(msg)
 
 
 class QuantizationSimModel(_QuantizationSimModelBase):
@@ -253,7 +280,7 @@ class QuantizationSimModel(_QuantizationSimModelBase):
             model = copy.deepcopy(model)
             in_place = True
 
-        model = _convert_to_qmodule(model)
+        model = _convert_to_qmodel(model)
 
         with _register_zero3_forward_hooks(model, use_dummy_params=True):
             # NOTE: Register for the model is pre-partitioned by deepspeed zero3 or zero3-offload.

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -66,6 +66,7 @@ from aimet_torch.v2.nn import (
     QuantizedSoftmax,
     QuantizedLayerNorm,
     QuantizedGroupNorm,
+    UnknownModuleError,
 )
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
 from aimet_torch.v2.nn.true_quant import _dispatch, _dispatch_table
@@ -1068,7 +1069,7 @@ def test_code_example(module_cls):
     When: Generate code example with _generate_code_example
     Then: The generated code should be parseable by python interpreter
     """
-    src_code = QuantizationMixin._generate_code_example(module_cls)
+    src_code = UnknownModuleError(module_cls, QuantizationMixin).generate_code_example()
     try:
         ast.parse(src_code)
     except SyntaxError as e:


### PR DESCRIPTION
## Problem
Another pain point found by @quic-ykota.
It's painful for the users when the model contains too many unknown custom modules because QuantizationSimModel will only complain about one unknown module at a time.
As a result, the users will have to repeat N times of trial-and-errors only to identify the modules that are missing the quantized definitions for.

## Solution
Batched error messages in single exception.
Given three unknown modules `MyModule1`, `MyModule2`, and `MytModule3`, the new error message will now look like this:
```
RuntimeError: Quantized module definitions of the following modules are not registered: [
    <class '__main__.MyModule1'>,
    <class '__main__.MyModule2'>,
    <class '__main__.MyModule3'>,
]

Please register the quantized module definition of the modules listed above using `@QuantizationMixin.implements()` decorator.

For example:

@QuantizationMixin.implements(MyModule1)
class QuantizedMyModule1(QuantizationMixin, MyModule1):
    def __quant_init__(self):
        super().__quant_init__()

        # Declare the number of input/output quantizers
        self.input_quantizers = torch.nn.ModuleList([None])
        self.output_quantizers = torch.nn.ModuleList([None])

    def forward(self, x):
        # Quantize input tensors
        if self.input_quantizers[0]:
            x = self.input_quantizers[0](x)

        # Run forward with quantized inputs and parameters
        with self._patch_quantized_parameters():
            ret = super().forward(x)

        # Quantize output tensors
        if self.output_quantizers[0]:
            ret = self.output_quantizers[0](ret)

        return ret

@QuantizationMixin.implements(MyModule2)
class QuantizedMyModule2(QuantizationMixin, MyModule2):
    def __quant_init__(self):
        super().__quant_init__()

        # Declare the number of input/output quantizers
        self.input_quantizers = torch.nn.ModuleList([None])
        self.output_quantizers = torch.nn.ModuleList([None])

    def forward(self, x):
        # Quantize input tensors
        if self.input_quantizers[0]:
            x = self.input_quantizers[0](x)

        # Run forward with quantized inputs and parameters
        with self._patch_quantized_parameters():
            ret = super().forward(x)

        # Quantize output tensors
        if self.output_quantizers[0]:
            ret = self.output_quantizers[0](ret)

        return ret

@QuantizationMixin.implements(MyModule3)
class QuantizedMyModule3(QuantizationMixin, MyModule3):
    def __quant_init__(self):
        super().__quant_init__()

        # Declare the number of input/output quantizers
        self.input_quantizers = torch.nn.ModuleList([None])
        self.output_quantizers = torch.nn.ModuleList([None])

    def forward(self, x):
        # Quantize input tensors
        if self.input_quantizers[0]:
            x = self.input_quantizers[0](x)

        # Run forward with quantized inputs and parameters
        with self._patch_quantized_parameters():
            ret = super().forward(x)

        # Quantize output tensors
        if self.output_quantizers[0]:
            ret = self.output_quantizers[0](ret)

        return ret

For more details, please refer to the official API reference:
https://quic.github.io/aimet-pages/releases/latest/apiref/torch/generated/aimet_torch.nn.QuantizationMixin.html#aimet_torch.nn.QuantizationMixin.implements
```