### PR TITLE
Fix exception rules not searching all ops

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -606,7 +606,7 @@ class QuantizationSimModel:
         """
         Apply exception rules to specific op. For example, a rule can override high bitwidth to GroupNorm op.
         """
-        for op in self.connected_graph.ordered_ops:
+        for op in self.connected_graph.get_all_ops().values():
             input_quantizers, output_quantizers, param_quantizers = self.get_op_quantizers(op)
 
             if op.type == 'GroupNormalization':


### PR DESCRIPTION
Authored by @quic-mtuttle 

connected_graph.ordered_ops is populated via DFS and may not contain all ops in model. Short term fix is to just use connected_graph.get_all_ops() instead, longer term we should investigate how ordered_ops is populated and fix that