### PR TITLE
Remove excessive graph nodes iteration during ConnectedGraph construction

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -46,6 +46,7 @@ import copy
 from collections import defaultdict
 from types import SimpleNamespace
 import inspect
+import itertools
 from typing import Tuple, Union, List, Dict, Type, Optional, Iterator
 import torch
 
@@ -1353,12 +1354,10 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         if is_torch_nn_leaf_module(module):
             return False
 
-        try:
-            aten_node = next(self._find_aten_nodes_in_forward_pass(trace))
-        except StopIteration:
-            aten_node = None
+        aten_nodes = list(itertools.islice(self._find_aten_nodes_in_forward_pass(trace), 2))
 
-        if not aten_node and is_leaf_module(module):
+        if len(aten_nodes) <= 1 and is_leaf_module(module):
+            # Custom leaf module
             return False
 
         if isinstance(module, (self._aimet_defined_modules, *aimet_torch.utils.modules_to_treat_as_leaf)):

--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -46,7 +46,7 @@ import copy
 from collections import defaultdict
 from types import SimpleNamespace
 import inspect
-import itertools
+from itertools import islice
 from typing import Tuple, Union, List, Dict, Type, Optional, Iterator
 import torch
 
@@ -413,16 +413,18 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             # functional operations e.g. cat, size etc
             else:
                 try:
-                    aten_node = next(self._find_aten_nodes_in_forward_pass(trace))
+                    is_elementwise = bool(elementwise_info) and \
+                                     node == next(self._find_aten_nodes_in_forward_pass(trace))
                 except StopIteration:
-                    aten_node = None
+                    is_elementwise = False
 
-                if elementwise_info and node == aten_node:
+                if is_elementwise:
                     # Aten op that corresponds to the elementwise op
-                    op_type = self.get_op_type(type(elementwise_info[1]))
+                    residing_module, op_module = elementwise_info
+                    op_type = self.get_op_type(type(op_module))
                     op = self._create_new_multi_output_op(op_type,
-                                                          residing_module=elementwise_info[0],
-                                                          op_module=elementwise_info[1])
+                                                          residing_module=residing_module,
+                                                          op_module=op_module)
                 else:
                     op_type = self._get_functional_node_type(node)
                     op = self._create_new_multi_output_op(op_type, residing_module=model)
@@ -1354,13 +1356,15 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         if is_torch_nn_leaf_module(module):
             return False
 
-        aten_nodes = list(itertools.islice(self._find_aten_nodes_in_forward_pass(trace), 2))
-
-        if len(aten_nodes) <= 1 and is_leaf_module(module):
-            # Custom leaf module
+        if isinstance(module, (self._aimet_defined_modules, *aimet_torch.utils.modules_to_treat_as_leaf)):
             return False
 
-        if isinstance(module, (self._aimet_defined_modules, *aimet_torch.utils.modules_to_treat_as_leaf)):
+        is_custom_leaf_module = is_leaf_module(module) and \
+            len(tuple(
+                islice(self._find_aten_nodes_in_forward_pass(trace), 2)
+            )) <= 1
+
+        if is_custom_leaf_module:
             return False
 
         return True

--- a/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/meta/connectedgraph.py
@@ -46,7 +46,7 @@ import copy
 from collections import defaultdict
 from types import SimpleNamespace
 import inspect
-from typing import Tuple, Union, List, Dict, Type, Optional
+from typing import Tuple, Union, List, Dict, Type, Optional, Iterator
 import torch
 
 from aimet_common.connected_graph.connectedgraph_utils import CG_SPLIT
@@ -58,7 +58,7 @@ from aimet_common.utils import AimetLogger
 import aimet_torch._base.nn.modules.custom as aimet_modules
 from aimet_torch.meta.operation import Op
 from aimet_torch.utils import is_leaf_module, run_hook_for_layers_with_given_input, in_eval_mode, \
-    is_torch_nn_leaf_module, is_custom_leaf_module, get_torch_tensortype_shape
+    is_torch_nn_leaf_module, get_torch_tensortype_shape
 from aimet_torch import onnx_utils
 import aimet_torch.utils
 
@@ -411,8 +411,12 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
             # functional operations e.g. cat, size etc
             else:
-                aten_nodes = self._find_aten_nodes_in_forward_pass(trace)
-                if elementwise_info and node == aten_nodes[0]:
+                try:
+                    aten_node = next(self._find_aten_nodes_in_forward_pass(trace))
+                except StopIteration:
+                    aten_node = None
+
+                if elementwise_info and node == aten_node:
                     # Aten op that corresponds to the elementwise op
                     op_type = self.get_op_type(type(elementwise_info[1]))
                     op = self._create_new_multi_output_op(op_type,
@@ -569,9 +573,12 @@ class ConnectedGraph(AimetCommonConnectedGraph):
             # For elementwise ops, we need to parse the callmethod interior, but want to retain information about the
             # elementwise op's residing module and torch module
             if self._is_multi_input_op_to_parse(subgraph_model):
-                aten_nodes = self._find_aten_nodes_in_forward_pass(subgraph_trace)
-                assert len(aten_nodes) <= 1
-                if len(aten_nodes) == 1:
+                try:
+                    aten_node = next(self._find_aten_nodes_in_forward_pass(subgraph_trace))
+                except StopIteration:
+                    aten_node = None
+
+                if aten_node:
                     elementwise_info = (residing_module, node_name_to_module[input_name])
                 else:
                     # This is an elementwise op that does not actually perform aten operations inside.
@@ -1343,13 +1350,21 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         if isinstance(module, BaseQuantizationMixin):
             return self._is_recursive_parsing_needed(module.get_original_module(), trace)
 
-        recursive_parsing_needed = True
-        if is_torch_nn_leaf_module(module) or \
-                is_custom_leaf_module(module, self._find_aten_nodes_in_forward_pass(trace)) or \
-                isinstance(module, (self._aimet_defined_modules, tuple(aimet_torch.utils.modules_to_treat_as_leaf))):
-            recursive_parsing_needed = False
+        if is_torch_nn_leaf_module(module):
+            return False
 
-        return recursive_parsing_needed
+        try:
+            aten_node = next(self._find_aten_nodes_in_forward_pass(trace))
+        except StopIteration:
+            aten_node = None
+
+        if not aten_node and is_leaf_module(module):
+            return False
+
+        if isinstance(module, (self._aimet_defined_modules, *aimet_torch.utils.modules_to_treat_as_leaf)):
+            return False
+
+        return True
 
     @staticmethod
     def _is_multi_input_op_to_parse(module: torch.nn.Module):
@@ -1408,7 +1423,7 @@ class ConnectedGraph(AimetCommonConnectedGraph):
 
     @staticmethod
     def _find_aten_nodes_in_forward_pass(trace: Union[torch.jit.TopLevelTracedModule, torch.jit.TracedModule]) \
-            -> List[torch._C.Node]:
+            -> Iterator[torch._C.Node]:
         """
         Find all the valid nodes in forward pass for given trace of model or submodule.
         Three possible outcomes:
@@ -1420,13 +1435,14 @@ class ConnectedGraph(AimetCommonConnectedGraph):
         :return: List of trace graph nodes if node.kind() starts with "aten::".
         """
         # pylint: disable=protected-access
-        nodes = []
         try:
-            nodes = [node for node in trace.graph.nodes() if "aten::" in node.kind() and
-                     ConnectedGraph._parse_op_type(node) not in ConnectedGraph.passthrough_graph_nodes]
+            nodes = trace.graph.nodes()
         except RuntimeError:
-            pass
-        return nodes
+            return
+
+        for node in nodes:
+            if "aten::" in node.kind() and ConnectedGraph._parse_op_type(node) not in ConnectedGraph.passthrough_graph_nodes:
+                yield node
 
     @staticmethod
     def _get_functional_node_type(node: torch._C.Node) -> str:

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -529,16 +529,17 @@ def is_leaf_module(module):
     :return:
         True if the module is a leaf, False otherwise
     """
-    module_list = list(module.modules())
+    try:
+        _ = next(module.children())
+    except StopIteration:
+        has_child = False
+    else:
+        has_child = True
 
     # pylint: disable=unidiomatic-typecheck
-    ret = bool(len(module_list) == 1) or type(module) in modules_to_treat_as_leaf
-
-    if ret:
-        return ret
-
-    return CustomSparseConv3DLayer is not None and\
-           isinstance(module, CustomSparseConv3DLayer)
+    return not has_child or \
+           type(module) in modules_to_treat_as_leaf or\
+           (CustomSparseConv3DLayer is not None and isinstance(module, CustomSparseConv3DLayer))
 
 
 def get_input_shape_batch_size(data_loader):
@@ -893,18 +894,6 @@ def is_torch_nn_leaf_module(module: torch.nn.Module) -> bool:
     if is_leaf_module(module) and is_torch_nn_module(module):
         torch_nn_leaf_module = True
     return torch_nn_leaf_module
-
-
-def is_custom_leaf_module(module: torch.nn.Module, nodes: List[torch._C.Node]) -> bool:
-    """
-    Given PyTorch module, determine whether the module is leaf module and has not more than one aten node(s).
-
-    :param module: PyTorch module.
-    :param nodes: List of trace graph nodes if node.kind() starts with "aten::".
-    :return: True if module is custom leaf module, False otherwise.
-    """
-    # pylint: disable=protected-access
-    return is_leaf_module(module) and len(nodes) <= 1
 
 
 def get_torch_tensortype_shape(torch_graph_output: torch._C.TensorType) -> Union[None, List[int]]:

--- a/TrainingExtensions/torch/test/python/test_connectedgraph.py
+++ b/TrainingExtensions/torch/test/python/test_connectedgraph.py
@@ -791,37 +791,37 @@ class TestConnectedGraphUtils(unittest.TestCase):
         # 1) aimet_modules.Add()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.Add(), dummy_input)
-        nodes =  ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes =  list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 2) aimet_modules.Subtract()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.Subtract(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 3) aimet_modules.Multiply()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.Multiply(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 4) aimet_modules.Divide()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.Divide(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 5) aimet_modules.MatMul()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.MatMul(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 6) aimet_modules.Concat()
         dummy_input = (torch.randn(1, 3, 4, 4), torch.randn(1, 3, 4, 4))
         trace = torch.jit.trace(aimet_modules.Concat(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
     @pytest.mark.cuda
@@ -836,7 +836,7 @@ class TestConnectedGraphUtils(unittest.TestCase):
 
         dummy_input = torch.randn(1, 3, 4, 4)
         trace = torch.jit.trace(CustomModule().cuda(), dummy_input.cuda())
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         # mulitply, softplus and relu ops.
         # detach is considered as passthrough op.
         assert len(nodes) == 3
@@ -854,7 +854,7 @@ class TestConnectedGraphUtils(unittest.TestCase):
         dummy_bias = torch.randn((32,))
         dummy_input = (dummy_input, dummy_weight, dummy_bias)
         trace = torch.jit.trace(CustomModule(), dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
     def test_find_nodes_in_forward_pass_for_torch_nn_module(self):
@@ -865,21 +865,21 @@ class TestConnectedGraphUtils(unittest.TestCase):
         conv = torch.nn.Conv2d(3, 3, 2).eval()
         print(conv.__class__)
         trace = torch.jit.trace(conv, dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 2) ReLU
         dummy_input = torch.randn(1, 3, 4, 4)
         relu = torch.nn.ReLU(inplace=True).eval()
         trace = torch.jit.trace(relu, dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
         # 3) BatchNorm2d
         dummy_input = torch.randn(1, 3, 4, 4)
         bn = torch.nn.BatchNorm2d(3).eval()
         trace = torch.jit.trace(bn, dummy_input)
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(trace))
         assert len(nodes) == 1
 
     def test_find_nodes_in_forward_pass_for_unused_module(self):
@@ -909,12 +909,12 @@ class TestConnectedGraphUtils(unittest.TestCase):
 
         # Conv2 is unused in forward pass.
         conv2_trace = getattr(trace, "conv2")
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(conv2_trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(conv2_trace))
         assert len(nodes) == 0
 
         # Conv1 and Conv3 are used in forward pass.
         conv1_trace = getattr(trace, "conv1")
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(conv1_trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(conv1_trace))
         assert len(nodes) == 1
 
     def test_find_nodes_in_forward_pass_for_undefined_graph(self):
@@ -927,7 +927,7 @@ class TestConnectedGraphUtils(unittest.TestCase):
 
         inner_seq_trace = getattr(trace, "inner_seq")
         bn_trace = getattr(inner_seq_trace, "1")
-        nodes = ConnectedGraph._find_aten_nodes_in_forward_pass(bn_trace)
+        nodes = list(ConnectedGraph._find_aten_nodes_in_forward_pass(bn_trace))
         assert len(nodes) == 0
 
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Main Changes
Optimized `ConnectedGraph.__init__`

### Benchmarks
* model: Unet + LoRA (1.3B parameters) (thanks @quic-mangal)
* GPU: RTX 2080

|                                                                            |     current     |   this PR    |
|----------------------------------------------------|------------|------------|
| `QuantizationSimModel.__init__`                        |    ~138s    |    **~28s**  |
| └ `ConnectedGraph.__init__`                              |    ~133s    |    **~23s**   |
| &nbsp;&nbsp;&nbsp;&nbsp;└ `torch.jit.trace`  |    ~20s      |    ~20s     |
| &nbsp;&nbsp;&nbsp;&nbsp;└ `<others>`        |    ~113s    |    **~3s**  |
