### PR TITLE
Unify replace_* util functions with replace_modules

### DIFF
--- a/Docs/legacy/torch_code_examples/post_training_techniques_examples.py
+++ b/Docs/legacy/torch_code_examples/post_training_techniques_examples.py
@@ -68,7 +68,9 @@ def cross_layer_equalization_manual():
     batch_norm_fold.fold_given_batch_norms(model, layer_list)
 
     # Replace any ReLU6 layers with ReLU
-    utils.replace_modules_of_type1_with_type2(model, torch.nn.ReLU6, torch.nn.ReLU)
+    utils.replace_modules(model,
+                          lambda module: isinstance(module, torch.nn.ReLU6),
+                          lambda _: torch.nn.ReLU())
 
     # Cross Layer Scaling
     # Create a list of consecutive conv layers to be equalized
@@ -115,7 +117,9 @@ def cross_layer_equalization_depthwise_layers():
     batch_norm_fold.fold_given_batch_norms(model, layer_list)
 
     # Replace any ReLU6 layers with ReLU
-    utils.replace_modules_of_type1_with_type2(model, torch.nn.ReLU6, torch.nn.ReLU)
+    utils.replace_modules(model,
+                          lambda module: isinstance(module, torch.nn.ReLU6),
+                          lambda _: torch.nn.ReLU())
 
     # Cross Layer Scaling
     # Create a list of consecutive conv layers to be equalized
@@ -144,7 +148,9 @@ def cross_layer_equalization_auto_step_by_step():
         bn_dict[conv_bn[0]] = conv_bn[1]
 
     # Replace any ReLU6 layers with ReLU
-    utils.replace_modules_of_type1_with_type2(model, torch.nn.ReLU6, torch.nn.ReLU)
+    utils.replace_modules(model,
+                          lambda module: isinstance(module, torch.nn.ReLU6),
+                          lambda _: torch.nn.ReLU())
 
     # Perform cross-layer scaling on applicable layer sets
     cls_set_info_list = cross_layer_equalization.CrossLayerScaling.scale_model(model, input_shape)

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/batch_norm_fold.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/batch_norm_fold.py
@@ -303,8 +303,10 @@ class BatchNormFoldBase(ABC):
         return stand_alone_bn_ops
 
     @staticmethod
-    def _delete_bn_from_model(model: torch.nn.Module, bn_layer_list: Iterable[BatchNormType]):
-        utils.replace_modules_with_instances_of_new_type(model, bn_layer_list, torch.nn.Identity)
+    def _delete_bn_from_model(model: torch.nn.Module, bn_layer_list: Iterable[torch.nn.Module]):
+        utils.replace_modules(model,
+                              lambda module: module in bn_layer_list,
+                              lambda _: torch.nn.Identity())
 
     @classmethod
     def _find_all_batch_norms_to_fold(cls, connected_graph: ConnectedGraph) -> Tuple[

--- a/TrainingExtensions/torch/src/python/aimet_torch/cross_layer_equalization.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/cross_layer_equalization.py
@@ -736,7 +736,9 @@ def equalize_bn_folded_model(model: torch.nn.Module,
 
         with place_model(model, torch.device('cpu')):
             # replace any ReLU6 layers with ReLU
-            utils.replace_modules_of_type1_with_type2(model, torch.nn.ReLU6, torch.nn.ReLU)
+            utils.replace_modules(model,
+                                  lambda module: isinstance(module, torch.nn.ReLU6),
+                                  lambda _: torch.nn.ReLU())
 
             # perform cross-layer scaling on applicable layer sets
             cls_set_info_list = CrossLayerScaling.scale_model(model, input_shapes, dummy_input=dummy_input)

--- a/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/model_preparer.py
@@ -137,7 +137,7 @@ import torch
 import torch.fx
 from aimet_common.utils import AimetLogger
 from aimet_torch.utils import in_eval_mode
-from aimet_torch.utils import replace_modules_of_type1_with_type2
+from aimet_torch.utils import replace_modules
 import aimet_torch._base.nn.modules.custom as aimet_modules
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.ModelPreparer)
@@ -561,7 +561,9 @@ def _prepare_traced_model(traced_model: torch.fx.GraphModule,
     _verify_traced_model(traced_model)
 
     # Replace SiLU with CustomSiLU
-    replace_modules_of_type1_with_type2(traced_model, torch.nn.SiLU, aimet_modules.CustomSiLU)
+    replace_modules(traced_model,
+                    lambda module: isinstance(module, torch.nn.SiLU),
+                    lambda _: aimet_modules.CustomSiLU())
 
 
 def _verify_traced_model(traced_model: torch.fx.GraphModule):

--- a/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
@@ -436,7 +436,9 @@ class OnnxSaver:
         """
         # Pre-processing pytorch model
         for dropout_type in aimet_torch.utils.DROPOUT_TYPES:
-            aimet_torch.utils.replace_modules_of_type1_with_type2(pytorch_model, dropout_type, torch.nn.Identity)
+            aimet_torch.utils.replace_modules(pytorch_model,
+                                              lambda module: isinstance(module, dropout_type),
+                                              lambda _: torch.nn.Identity())
 
         if EXPORT_TO_ONNX_DIRECT:
             cls._export_model_to_onnx(pytorch_model, dummy_input, onnx_model_path, is_conditional, onnx_export_args)

--- a/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
@@ -437,7 +437,7 @@ class OnnxSaver:
         # Pre-processing pytorch model
         for dropout_type in aimet_torch.utils.DROPOUT_TYPES:
             aimet_torch.utils.replace_modules(pytorch_model,
-                                              lambda module: isinstance(module, dropout_type),
+                                              lambda module: isinstance(module, dropout_type), # pylint: disable=cell-var-from-loop
                                               lambda _: torch.nn.Identity())
 
         if EXPORT_TO_ONNX_DIRECT:

--- a/TrainingExtensions/torch/src/python/aimet_torch/peft.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/peft.py
@@ -48,7 +48,7 @@ from safetensors import safe_open
 from peft.tuners.lora.layer import LoraLayer as PeftLoraLayer
 from peft.tuners.lora.layer import Conv2d as PeftConv2d
 
-from aimet_torch.utils import replace_module
+from aimet_torch.utils import replace_modules
 from aimet_torch._base.nn.modules.custom import Add, Multiply
 from aimet_torch.v2.quantsim import QuantizationSimModel
 from aimet_torch.v2.quantization.affine import QuantizeDequantize
@@ -121,9 +121,9 @@ def replace_lora_layers_with_quantizable_layers(model: torch.nn.Module):
 
     :param model: PEFT model
     """
-    replace_module(model,
-                   lambda module: isinstance(module, (PeftLoraLayer, PeftConv2d)),
-                   LoraLayer)
+    replace_modules(model,
+                    lambda module: isinstance(module, (PeftLoraLayer, PeftConv2d)),
+                    LoraLayer)
 
 
 class AdapterMetaData:

--- a/TrainingExtensions/torch/src/python/aimet_torch/peft.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/peft.py
@@ -48,7 +48,7 @@ from safetensors import safe_open
 from peft.tuners.lora.layer import LoraLayer as PeftLoraLayer
 from peft.tuners.lora.layer import Conv2d as PeftConv2d
 
-from aimet_torch.utils import replace_modules_of_type1_using_constructor
+from aimet_torch.utils import replace_module
 from aimet_torch._base.nn.modules.custom import Add, Multiply
 from aimet_torch.v2.quantsim import QuantizationSimModel
 from aimet_torch.v2.quantization.affine import QuantizeDequantize
@@ -121,8 +121,9 @@ def replace_lora_layers_with_quantizable_layers(model: torch.nn.Module):
 
     :param model: PEFT model
     """
-    replace_modules_of_type1_using_constructor(model, PeftLoraLayer, LoraLayer)
-    replace_modules_of_type1_using_constructor(model, PeftConv2d, LoraLayer)
+    replace_module(model,
+                   lambda module: isinstance(module, (PeftLoraLayer, PeftConv2d)),
+                   LoraLayer)
 
 
 class AdapterMetaData:

--- a/TrainingExtensions/torch/src/python/aimet_torch/transformers/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/transformers/utils.py
@@ -51,8 +51,9 @@ def get_quantizable_pt_transformer_model(model: torch.nn.Module):
     :return: updates model in-place, as necessary.
     """
     # auto replace PyTorch MHA in given transformer layer with quantizable MHA
-    utils.replace_modules_of_type1_using_constructor(model, torch.nn.MultiheadAttention,
-                                                     create_quantizable_multihead_attention)
+    utils.replace_modules(model,
+                          lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                          create_quantizable_multihead_attention)
 
     # auto replace functional activation with module for nn.Transformer layers
     prepare_pt_transformer_for_quantsim(model)

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -631,26 +631,6 @@ def replace_modules_of_type1_with_type2(model: torch.nn.Module,
             replace_modules_of_type1_with_type2(module_ref, type1, type2)
 
 
-def replace_modules_of_type1_using_constructor(model, type1, constructor):
-    """
-    Given a model, finds all modules of type type1 and replaces them with the module created with constructor
-    constructor should accept original module as an argument
-    :param model: Model to replace modules in
-    :param type1: Module type of modules to replace
-    :param constructor: Constructor of the new module
-    :return: None
-    """
-
-    for module_name, module_ref in model.named_children():
-        if isinstance(module_ref, type1):
-            setattr(model, module_name, constructor(module_ref))
-
-        children_module_list = list(module_ref.modules())
-        if len(children_module_list) != 1:
-            replace_modules_of_type1_using_constructor(module_ref, type1, constructor)
-
-
-
 def replace_modules(model: torch.nn.Module,
                     condition: Callable[[torch.nn.Module], bool],
                     factory: Callable[[torch.nn.Module], torch.nn.Module]):

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -610,30 +610,12 @@ def get_ordered_list_of_modules(model: torch.nn.Module,
     return list_modules
 
 
-def replace_modules_of_type1_with_type2(model: torch.nn.Module,
-                                        type1: type(torch.nn.Module), type2: type(torch.nn.Module)):
-    """
-    Given a model, finds all modules of type type1 and replaces them with instances of type2
-    Note: Since instances of type2 are instantiated using a default constructor (no parameters),
-    only certain module types e.g. torch.nn.ReLU can be used as type2
-    :param model: Model to replace modules in
-    :param type1: Module type of modules to replace
-    :param type2: Module type to instantiate to replace modules with
-    :return: None
-    """
-
-    for module_name, module_ref in model.named_children():
-        if isinstance(module_ref, type1):
-            setattr(model, module_name, type2())
-
-        children_module_list = list(module_ref.modules())
-        if len(children_module_list) != 1:
-            replace_modules_of_type1_with_type2(module_ref, type1, type2)
-
-
 def replace_modules(model: torch.nn.Module,
                     condition: Callable[[torch.nn.Module], bool],
                     factory: Callable[[torch.nn.Module], torch.nn.Module]):
+    """
+    Replace all modules that satisfy the given condition
+    """
     def fn(parent):
         for name, child in parent.named_children():
             if condition(child):

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -650,26 +650,16 @@ def replace_modules_of_type1_using_constructor(model, type1, constructor):
             replace_modules_of_type1_using_constructor(module_ref, type1, constructor)
 
 
-def replace_modules_with_instances_of_new_type(model: torch.nn.Module, modules_to_replace_list: List[torch.nn.Module],
-                                               new_type: type(torch.nn.Module)):
-    """
-    Given a model, replaces given modules with instances of new_type
-    Note: Since instances of new_type are instantiated using a default constructor (no parameters),
-    only certain module types e.g. torch.nn.ReLU can be used as new_type
-    :param model: Model to replace modules in
-    :param modules_to_replace_list: Modules to replace
-    :param new_type: Module type to instantiate to replace modules with
-    :return: None
-    """
 
-    for module_name, module_ref in model.named_children():
+def replace_modules(model: torch.nn.Module,
+                    condition: Callable[[torch.nn.Module], bool],
+                    factory: Callable[[torch.nn.Module], torch.nn.Module]):
+    def fn(parent):
+        for name, child in parent.named_children():
+            if condition(child):
+                setattr(parent, name, factory(child))
 
-        if module_ref in modules_to_replace_list:
-            setattr(model, module_name, new_type())
-
-        children_module_list = list(module_ref.modules())
-        if len(children_module_list) != 1:
-            replace_modules_with_instances_of_new_type(module_ref, modules_to_replace_list, new_type)
+    model.apply(fn)
 
 
 def create_rand_tensors_given_shapes(input_shape: Union[Tuple, List[Tuple]], device: torch.device) \

--- a/TrainingExtensions/torch/test/python/test_utils.py
+++ b/TrainingExtensions/torch/test/python/test_utils.py
@@ -94,8 +94,9 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
         model = torchvision.models.resnet18()
         model.eval()
 
-        utils.replace_modules_with_instances_of_new_type(model, [model.layer1[0].bn1, model.layer1[1].bn1],
-                                                         torch.nn.Identity)
+        utils.replace_modules(model,
+                              lambda module: module in [model.layer1[0].bn1, model.layer1[1].bn1],
+                              lambda _: torch.nn.Identity())
 
         # check - given modules have been replaced
         self.assertTrue(isinstance(model.layer1[0].bn1, torch.nn.Identity))

--- a/TrainingExtensions/torch/test/python/test_utils.py
+++ b/TrainingExtensions/torch/test/python/test_utils.py
@@ -79,7 +79,9 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
         model = torchvision.models.resnet18()
         model.eval()
 
-        utils.replace_modules_of_type1_with_type2(model, torch.nn.ReLU, torch.nn.ReLU6)
+        utils.replace_modules(model,
+                              lambda module: isinstance(module, torch.nn.ReLU),
+                              lambda _: torch.nn.ReLU6())
 
         # check - no ReLU modules left in the model anymore
         for module in model.modules():

--- a/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
@@ -626,10 +626,14 @@ class TestQuantizationSimTransformers(unittest.TestCase):
         # add in quantizable enc/dec
         prepare_pt_transformer_for_quantsim(transformer_model_2)
         utils.replace_modules(transformer_model_2.encoder,
-                              lambda module: isinstance(module, (nn.TransformerEncoderLayer,
-                                                                 nn.TransformerDecoderLayer,
-                                                                 nn.MultiheadAttention)),
+                              lambda module: isinstance(module, nn.TransformerEncoderLayer),
                               create_quantizable_transformer_encoder_layer)
+        utils.replace_modules(transformer_model_2.encoder,
+                              lambda module: isinstance(module, nn.TransformerDecoderLayer),
+                              create_quantizable_transformer_decoder_layer)
+        utils.replace_modules(transformer_model_2.encoder,
+                              lambda module: isinstance(module, nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
         transformer_model_2.eval()
         out_fp_2 = transformer_model_2(src=copy.deepcopy(src), tgt=copy.deepcopy(src))
         diff = out_fp_2 - out_fp

--- a/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
@@ -53,7 +53,7 @@ from aimet_common.defs import QuantScheme, QuantizationDataType
 from aimet_torch.meta.connectedgraph import ConnectedGraph
 from aimet_torch.transformers.activation import create_quantizable_transformer_encoder_layer, \
     create_quantizable_transformer_decoder_layer, create_quantizable_multihead_attention, QuantizableMultiheadAttention
-from aimet_torch.utils import create_rand_tensors_given_shapes, replace_modules_of_type1_using_constructor
+from aimet_torch.utils import create_rand_tensors_given_shapes
 from aimet_torch.meta import connectedgraph_utils
 from aimet_torch.v1.qc_quantize_op import StaticGridQuantWrapper, StaticGridPerTensorQuantizer
 from aimet_torch.v1.quantsim import QuantizationSimModel
@@ -502,8 +502,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
             self.assertTrue(isinstance(transformer_model.decoder.layers[i].self_attn, torch.nn.MultiheadAttention))
 
         # auto replace PyTorch MHA in given transformer layer with quantizable MHA
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         # validate replacement is done for both encoder and decoder
         for i in range(num_encoder_layers):
@@ -561,8 +562,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
         prepare_pt_transformer_for_quantsim(transformer_model)
 
         # auto replace PyTorch MHA in given transformer layer with quantizable MHA
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         ops_with_missing_modules = connectedgraph_utils.get_ops_with_missing_modules(transformer_model, (src, src))
 
@@ -612,8 +614,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
 
         # current method being followed
         prepare_pt_transformer_for_quantsim(transformer_model_1)
-        replace_modules_of_type1_using_constructor(transformer_model_1, torch.nn.MultiheadAttention,
-                                                   create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model_1,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
         transformer_model_1.eval()
         out_fp_1 = transformer_model_1(src=copy.deepcopy(src), tgt=copy.deepcopy(src))
         diff = out_fp_1 - out_fp
@@ -622,12 +625,11 @@ class TestQuantizationSimTransformers(unittest.TestCase):
 
         # add in quantizable enc/dec
         prepare_pt_transformer_for_quantsim(transformer_model_2)
-        replace_modules_of_type1_using_constructor(transformer_model_2.encoder, nn.TransformerEncoderLayer,
-                                                   create_quantizable_transformer_encoder_layer)
-        replace_modules_of_type1_using_constructor(transformer_model_2.decoder, nn.TransformerDecoderLayer,
-                                                   create_quantizable_transformer_decoder_layer)
-        replace_modules_of_type1_using_constructor(transformer_model_2, torch.nn.MultiheadAttention,
-                                                   create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model_2.encoder,
+                              lambda module: isinstance(module, (nn.TransformerEncoderLayer,
+                                                                 nn.TransformerDecoderLayer,
+                                                                 nn.MultiheadAttention)),
+                              create_quantizable_transformer_encoder_layer)
         transformer_model_2.eval()
         out_fp_2 = transformer_model_2(src=copy.deepcopy(src), tgt=copy.deepcopy(src))
         diff = out_fp_2 - out_fp
@@ -663,8 +665,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
         model = MhaModel().eval()
         aimet_torch.utils.modules_to_treat_as_leaf = [torch.nn.MultiheadAttention, QuantizableMultiheadAttention]
 
-        utils.replace_modules_of_type1_using_constructor(model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         aimet_sim = QuantizationSimModel(model, dummy_input=copy.deepcopy(dummy_input), quant_scheme='tf')
 
@@ -749,8 +752,9 @@ def test_mha_as_leaf_module(replace_with_q_mha):
     aimet_torch.utils.modules_to_treat_as_leaf = []
 
     if replace_with_q_mha:
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
     cg_0 = ConnectedGraph(transformer_model, model_input=dummy_input)
 

--- a/TrainingExtensions/torch/test/python/v1/test_sparse_conv.py
+++ b/TrainingExtensions/torch/test/python/v1/test_sparse_conv.py
@@ -227,10 +227,11 @@ class TestSparseConv(unittest.TestCase):
 
         sequential_model = SequentialModel()
 
-        from aimet_torch.utils import replace_modules_of_type1_using_constructor
+        from aimet_torch.utils import replace_modules
         from aimet_torch.custom.custom_modules import create_quantizable_sparse_sequential, QuantizableSparseSequential
-        replace_modules_of_type1_using_constructor(sequential_model, spconv.SparseSequential,
-                                                   create_quantizable_sparse_sequential)
+        replace_modules(sequential_model,
+                        lambda module: isinstance(module, spconv.SparseSequential),
+                        create_quantizable_sparse_sequential)
         self.assertTrue(isinstance(sequential_model.seq, QuantizableSparseSequential))
 
         sim = QuantizationSimModel(sequential_model, dummy_input)

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_transformers.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_transformers.py
@@ -52,7 +52,7 @@ from aimet_common.defs import QuantScheme, QuantizationDataType
 from aimet_torch.meta.connectedgraph import ConnectedGraph
 from aimet_torch.transformers.activation import create_quantizable_transformer_encoder_layer, \
     create_quantizable_transformer_decoder_layer, create_quantizable_multihead_attention, QuantizableMultiheadAttention
-from aimet_torch.utils import create_rand_tensors_given_shapes, replace_modules_of_type1_using_constructor
+from aimet_torch.utils import create_rand_tensors_given_shapes
 from aimet_torch.meta import connectedgraph_utils
 from aimet_torch.v1.qc_quantize_op import StaticGridQuantWrapper, StaticGridPerTensorQuantizer
 from aimet_torch.v1.quantsim import QuantizationSimModel
@@ -503,8 +503,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
             self.assertTrue(isinstance(transformer_model.decoder.layers[i].self_attn, torch.nn.MultiheadAttention))
 
         # auto replace PyTorch MHA in given transformer layer with quantizable MHA
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         # validate replacement is done for both encoder and decoder
         for i in range(num_encoder_layers):
@@ -561,8 +562,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
         prepare_pt_transformer_for_quantsim(transformer_model)
 
         # auto replace PyTorch MHA in given transformer layer with quantizable MHA
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         ops_with_missing_modules = connectedgraph_utils.get_ops_with_missing_modules(transformer_model, (src, src))
 
@@ -612,8 +614,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
 
         # current method being followed
         prepare_pt_transformer_for_quantsim(transformer_model_1)
-        replace_modules_of_type1_using_constructor(transformer_model_1, torch.nn.MultiheadAttention,
-                                                   create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model_1,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
         transformer_model_1.eval()
         out_fp_1 = transformer_model_1(src=copy.deepcopy(src), tgt=copy.deepcopy(src))
         diff = out_fp_1 - out_fp
@@ -622,12 +625,11 @@ class TestQuantizationSimTransformers(unittest.TestCase):
 
         # add in quantizable enc/dec
         prepare_pt_transformer_for_quantsim(transformer_model_2)
-        replace_modules_of_type1_using_constructor(transformer_model_2.encoder, nn.TransformerEncoderLayer,
-                                                   create_quantizable_transformer_encoder_layer)
-        replace_modules_of_type1_using_constructor(transformer_model_2.decoder, nn.TransformerDecoderLayer,
-                                                   create_quantizable_transformer_decoder_layer)
-        replace_modules_of_type1_using_constructor(transformer_model_2, torch.nn.MultiheadAttention,
-                                                   create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model_2.encoder,
+                              lambda module: isinstance(module, (nn.TransformerEncoderLayer,
+                                                                 nn.TransformerDecoderLayer,
+                                                                 nn.MultiheadAttention)),
+                              create_quantizable_transformer_encoder_layer)
         transformer_model_2.eval()
         out_fp_2 = transformer_model_2(src=copy.deepcopy(src), tgt=copy.deepcopy(src))
         diff = out_fp_2 - out_fp
@@ -663,8 +665,9 @@ class TestQuantizationSimTransformers(unittest.TestCase):
         model = MhaModel().eval()
         aimet_torch.utils.modules_to_treat_as_leaf = [torch.nn.MultiheadAttention, QuantizableMultiheadAttention]
 
-        utils.replace_modules_of_type1_using_constructor(model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
         aimet_sim = QuantizationSimModel(model, dummy_input=copy.deepcopy(dummy_input), quant_scheme='tf')
 
@@ -749,8 +752,9 @@ def test_mha_as_leaf_module(replace_with_q_mha):
     aimet_torch.utils.modules_to_treat_as_leaf = []
 
     if replace_with_q_mha:
-        utils.replace_modules_of_type1_using_constructor(transformer_model, torch.nn.MultiheadAttention,
-                                                         create_quantizable_multihead_attention)
+        utils.replace_modules(transformer_model,
+                              lambda module: isinstance(module, torch.nn.MultiheadAttention),
+                              create_quantizable_multihead_attention)
 
     cg_0 = ConnectedGraph(transformer_model, model_input=dummy_input)
 


### PR DESCRIPTION
Unified three util functions into `replace_module`

* replace_modules_with_instances_of_new_type
* replace_modules_of_type1_using_constructor
* replace_modules_of_type1_with_type2