### PR TITLE
Replace IterFirstX with itertools.islice

### DIFF
--- a/NightlyTests/torch/test_compress_example_torch.py
+++ b/NightlyTests/torch/test_compress_example_torch.py
@@ -35,6 +35,7 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 
+import itertools
 import logging
 import os
 import pytest
@@ -64,7 +65,6 @@ from models import mnist_torch_model
 from models.imagenet_dataloader import ImageNetDataLoader
 from models.supervised_classification_pipeline import \
     create_stand_alone_supervised_classification_evaluator
-from aimet_torch.utils import IterFirstX
 from aimet_torch.visualize_serialized_data import VisualizeCompression
 
 
@@ -755,7 +755,7 @@ def evaluate(model, early_stopping_iterations, use_cuda):
     data_loader = ImageNetDataLoader(image_dir, image_size, batch_size, num_workers)
     if early_stopping_iterations is not None:
         # wrapper around validation data loader to run only 'X' iterations to save time
-        val_loader = IterFirstX(data_loader.val_loader, early_stopping_iterations)
+        val_loader = itertools.islice(data_loader.val_loader, early_stopping_iterations)
     else:
         # iterate over entire validation data set
         val_loader = data_loader.val_loader

--- a/NightlyTests/torch/test_quantize_resnet18.py
+++ b/NightlyTests/torch/test_quantize_resnet18.py
@@ -35,8 +35,8 @@
 #  @@-COPYRIGHT-END-@@
 # =============================================================================
 
+import itertools
 import json
-import os
 import tempfile
 from pathlib import Path
 
@@ -53,7 +53,6 @@ from aimet_common.defs import QuantScheme
 from aimet_torch.v1.quantsim import QuantizationSimModel
 
 from models.imagenet_dataloader import ImageNetDataLoader
-from aimet_torch.utils import IterFirstX
 from models.supervised_classification_pipeline import create_stand_alone_supervised_classification_evaluator,\
     create_supervised_classification_trainer
 from aimet_torch.bn_reestimation import reestimate_bn_stats
@@ -108,7 +107,7 @@ def model_eval(model, early_stopping_iterations):
     data_loader = _get_data_loader()
     if early_stopping_iterations is not None:
         # wrapper around validation data loader to run only 'X' iterations to save time
-        val_loader = IterFirstX(data_loader.val_loader, early_stopping_iterations)
+        val_loader = itertools.islice(data_loader.val_loader, early_stopping_iterations)
     else:
         # iterate over entire validation data set
         val_loader = data_loader.val_loader

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -81,19 +81,6 @@ DROPOUT_TYPES = (torch.nn.Dropout, torch.nn.Dropout2d, torch.nn.Dropout3d)
 # list of modules which need to be treated as a leaf module
 modules_to_treat_as_leaf = []
 
-class IterFirstX:
-    """ Iterator for the first x samples in a given data-loader """
-
-    def __init__(self, data_loader, num_samples):
-        self.data_loader = data_loader
-        self.num_samples = num_samples
-
-    def __iter__(self):
-        for i, batch in enumerate(self.data_loader):
-            if i >= self.num_samples:
-                break
-            yield batch
-
 
 class StopForwardException(Exception):
     """


### PR DESCRIPTION
Replaced unnecessary custom util function `IterFirstX` with Python standard library `itertools.islice`
![image](https://github.com/user-attachments/assets/a5558024-b948-459f-b65e-948193e2147d)
