### PR TITLE
Fix autograd in-place modification error

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/nn/modules/custom.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/nn/modules/custom.py
@@ -882,11 +882,11 @@ class ScatterElements(torch.nn.Module):
 
         if self.reduce:
             if isinstance(src, torch.Tensor):
-                return x.scatter_reduce_(self.dim, index, src, self.reduce)
+                return x.scatter_reduce(self.dim, index, src, self.reduce)
             # If src is a single float value
-            return x.scatter_(self.dim, index, src, reduce=self.reduce)
+            return x.scatter(self.dim, index, src, reduce=self.reduce)
 
-        return x.scatter_(self.dim, index, src)
+        return x.scatter(self.dim, index, src)
 
 
 class OneHot(torch.nn.Module):

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -694,6 +694,7 @@ class _QuantizationSimModelBase(_QuantizationSimModelInterface):
         module_name = '.'.join(module_names)
         return utils.get_named_module(self.model, module_name)
 
+    @torch.no_grad()
     def export(self, path: str, filename_prefix: str, dummy_input: Union[torch.Tensor, Tuple], # pylint: disable=arguments-differ
                onnx_export_args: Optional[Union[OnnxExportApiArgs, Dict]] = None, propagate_encodings: bool = False,
                export_to_torchscript: bool = False, use_embedded_encodings: bool = False, export_model: bool = True,


### PR DESCRIPTION
## Problem
When model contains [custom.ScatterElement](https://github.com/quic/aimet/blob/b3618a03555bb662b8c4e26d95084fd43fffe35f/TrainingExtensions/torch/src/python/aimet_torch/_base/nn/modules/custom.py#L861), sim.export would fail with the autograd error unless you call it under torch.no_grad.

## Main Changes
1. Removed in-place operations from custom.ScatterElement
2. Wrapped sim.export with torch.no_grad