### PR TITLE
Decide minimum scale dynamically based on target dtype

### DIFF
--- a/TrainingExtensions/torch/test/python/v2/quantization/test_encoding_analyzer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/test_encoding_analyzer.py
@@ -36,11 +36,17 @@
 # =============================================================================
 import torch
 import math
-import warnings
 import pytest
 import numpy as np
 import random
-from aimet_torch.v2.quantization.encoding_analyzer import SqnrEncodingAnalyzer, PercentileEncodingAnalyzer, MinMaxEncodingAnalyzer, _HistogramObserver
+from aimet_torch.v2.quantization.affine import quantize_dequantize
+from aimet_torch.v2.quantization.encoding_analyzer import (
+    SqnrEncodingAnalyzer,
+    PercentileEncodingAnalyzer,
+    MinMaxEncodingAnalyzer,
+    _HistogramObserver,
+    _get_minimum_scale,
+)
 
 @pytest.fixture(autouse=True)
 def set_seed():
@@ -61,8 +67,8 @@ class TestEncodingAnalyzer():
         for encoding_analyzer in encoding_analyzers:
             encoding_analyzer.update_stats(torch.randn(3, 4))
             with pytest.raises(ValueError):
-                    encoding_analyzer.compute_encodings(num_steps=0, is_symmetric = False)
-    
+                encoding_analyzer.compute_encodings(num_steps=0, is_symmetric=False)
+
     def test_reset_stats(self, encoding_analyzers):
         for encoding_analyzer in encoding_analyzers:
             encoding_analyzer.update_stats(torch.randn(3, 4))
@@ -72,7 +78,7 @@ class TestEncodingAnalyzer():
             else:
                 assert all(x.min is not None for x in encoding_analyzer.observer.stats)
                 assert all(x.max is not None for x in encoding_analyzer.observer.stats)
-            
+
             encoding_analyzer.reset_stats()
             if isinstance(encoding_analyzer, MinMaxEncodingAnalyzer):
                 assert not encoding_analyzer.observer.stats.min
@@ -81,11 +87,10 @@ class TestEncodingAnalyzer():
                 assert all(x.min is None for x in encoding_analyzer.observer.stats)
                 assert all(x.max is None for x in encoding_analyzer.observer.stats)
 
-            
     def test_compute_encodings_with_no_stats(self, encoding_analyzers):
         for encoding_analyzer in encoding_analyzers:
             with pytest.raises(RuntimeError):
-               encoding_analyzer.compute_encodings(num_steps=8, is_symmetric = False)
+               encoding_analyzer.compute_encodings(num_steps=8, is_symmetric=False)
 
     @pytest.mark.parametrize('dtype', [torch.float, torch.half])
     @pytest.mark.parametrize('symmetric', [True, False])
@@ -95,13 +100,16 @@ class TestEncodingAnalyzer():
             normal_range = torch.arange(-128, 128).to(dtype).cuda() / 256
             eps = torch.finfo(dtype).eps
 
-            num_steps = math.pow(2, 8) - 2
+            num_steps = 2**8 - 2
             min_1, max_1 = encoding_analyzer.compute_dynamic_encodings(normal_range * (1 - eps),
-                                                                    num_steps=num_steps, is_symmetric=symmetric)
+                                                                       num_steps=num_steps,
+                                                                       is_symmetric=symmetric)
             min_2, max_2 = encoding_analyzer.compute_dynamic_encodings(normal_range,
-                                                                    num_steps=num_steps, is_symmetric=symmetric)
+                                                                       num_steps=num_steps,
+                                                                       is_symmetric=symmetric)
             min_3, max_3 = encoding_analyzer.compute_dynamic_encodings(normal_range * (1 + eps),
-                                                                    num_steps=num_steps, is_symmetric=symmetric)
+                                                                       num_steps=num_steps,
+                                                                       is_symmetric=symmetric)
 
             assert min_3 <= min_2 <= min_1 <= max_1 <= max_2 <= max_3
             assert torch.allclose(max_1, max_2, atol=eps)
@@ -109,36 +117,44 @@ class TestEncodingAnalyzer():
             assert torch.allclose(max_2, max_3, atol=eps)
             assert torch.allclose(min_2, min_3, atol=eps)
 
-class TestMinMaxEncodingAnalyzer():    
-
+class TestMinMaxEncodingAnalyzer():
     def test_compute_encodings_asymmetric(self):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
-        input_tensor =  torch.arange(start=0, end=26, step=0.5, dtype=torch.float)
+        input_tensor =  torch.arange(start=0, end=26, step=0.5)
         encoding_analyzer.update_stats(input_tensor)
 
-        num_steps = math.pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        assert torch.all(torch.isclose(asymmetric_min, torch.zeros(tuple(encoding_analyzer.observer.shape))))
-        assert torch.all(torch.isclose(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 25.5)))
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                             is_symmetric=False)
+        expected_min = torch.zeros_like(asymmetric_min)
+        expected_max = torch.full_like(asymmetric_max, 25.5)
+        assert torch.allclose(asymmetric_min, expected_min)
+        assert torch.allclose(asymmetric_max, expected_max)
 
     def test_compute_encodings_strict_symmetric(self):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
-        input_tensor =  torch.arange(start=0, end=26, step=0.5, dtype=torch.float)
+        input_tensor =  torch.arange(start=0, end=26, step=0.5)
         encoding_analyzer.update_stats(input_tensor)
 
-        num_steps = math.pow(2, 8) - 2
-        symmetric_min_1, symmetric_max_1 = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = True)
-        assert torch.all(torch.isclose(symmetric_min_1, torch.full(tuple(encoding_analyzer.observer.shape), -25.5)))
-        assert torch.all(torch.isclose(symmetric_max_1, torch.full(tuple(encoding_analyzer.observer.shape), 25.5)))
-    
+        num_steps = 2**8 - 2
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                           is_symmetric=True)
+        expected_min = torch.full_like(symmetric_min, -25.5)
+        expected_max = torch.full_like(symmetric_max,  25.5)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
     def test_compute_encodings_non_strict_symmetric(self):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
         input_tensor =  torch.arange(start=-2, end=10, step=1, dtype=torch.float)
         encoding_analyzer.update_stats(input_tensor)
-        num_bins = pow(2, 3) - 1
-        non_strict_symmetric_min, non_strict_symmetric_max = encoding_analyzer.compute_encodings(is_symmetric = True, num_steps = num_bins)
-        assert torch.all(torch.isclose(non_strict_symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), -12.0)))
-        assert torch.all(torch.isclose(non_strict_symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 9.0)))
+        num_bins = 2**3 - 1
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_bins,
+                                                                           is_symmetric=True)
+        expected_min = torch.full_like(symmetric_min, -12.)
+        expected_max = torch.full_like(symmetric_max,  9.)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
 
     @pytest.mark.parametrize("min_max_size", [[3,4], [2, 3, 1], [4], [1]])
     def test_update_stats_with_different_dimensions(self,min_max_size):
@@ -152,284 +168,84 @@ class TestMinMaxEncodingAnalyzer():
         encoding_analyzer = MinMaxEncodingAnalyzer([3, 4])
         with pytest.raises(RuntimeError):
             encoding_analyzer.update_stats(torch.randn(2, 3, 5))
-   
+
     def test_compute_encodings_with_same_nonzero_tensor(self):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
-        encoding_analyzer.update_stats(torch.full((), 3.0))
+        encoding_analyzer.update_stats(torch.full((), 3.))
 
-        num_steps = pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        assert torch.allclose(asymmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), 0.0))
-        assert torch.allclose(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 3.0))
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                             is_symmetric=False)
+        expected_min = torch.zeros_like(asymmetric_min)
+        expected_max = torch.full_like(asymmetric_max, 3.)
+        assert torch.allclose(asymmetric_min, expected_min)
+        assert torch.allclose(asymmetric_max, expected_max)
 
-        symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric = True)
-        assert torch.allclose(symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), -3.0))
-        assert torch.allclose(symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 3.0))
-    
+        symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                            is_symmetric=True)
+        # Symmetric encodings have one more bins on the negative side
+        expected_min = torch.full_like(symmetric_min, -3.) - (symmetric_max / (num_steps // 2))
+        expected_max = torch.full_like(symmetric_max,  3.)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
     def test_compute_encodings_with_only_zero_tensor(self):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
         encoding_analyzer.update_stats(torch.zeros(()))
 
-        num_steps = pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        updated_min = torch.zeros(())
-        updated_max = torch.finfo(torch.float32).eps * num_steps
-        assert torch.all(torch.eq(asymmetric_min,  torch.full(tuple(encoding_analyzer.observer.shape), -updated_min)))
-        assert torch.all(torch.eq(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), updated_max)))
+        num_steps = 2**8 - 1
+        minimum_scale = torch.tensor(_get_minimum_scale(num_steps))
 
-        symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = True)
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                             is_symmetric=False)
+        expected_min = torch.zeros_like(asymmetric_min)
+        expected_max = torch.full_like(asymmetric_max, minimum_scale * num_steps)
+        assert torch.allclose(asymmetric_min, expected_min)
+        assert torch.allclose(asymmetric_max, expected_max)
+
+        symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                            is_symmetric=True)
         num_pos_bins = math.floor(num_steps / 2)
         num_neg_bins = math.ceil(num_steps / 2)
-        updated_min = -torch.finfo(torch.float32).eps * num_neg_bins
-        updated_max = torch.finfo(torch.float32).eps * num_pos_bins
-        assert torch.all(torch.eq(symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), updated_min)))
-        assert torch.all(torch.eq(symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), updated_max)))
-    
+        expected_min = torch.full_like(symmetric_min, -minimum_scale * num_neg_bins)
+        expected_max = torch.full_like(symmetric_max,  minimum_scale * num_pos_bins)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
     @pytest.mark.parametrize('symmetric', [True, False])
-    def test_overflow(self, symmetric):
+    @pytest.mark.parametrize('dtype', [torch.float16, torch.bfloat16, torch.float32])
+    def test_overflow(self, symmetric, dtype):
         encoding_analyzer = MinMaxEncodingAnalyzer(())
-        float_input_min = (torch.arange(10) * torch.finfo(torch.float).eps)
-        encoding_analyzer.update_stats(float_input_min)
-        num_steps = pow(2, 8) - 2
-        min, max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=symmetric)
+        input = (torch.arange(10) * torch.finfo(torch.float).tiny)
+        encoding_analyzer.update_stats(input)
+        num_steps = 2**8 - 2
+        minimum_scale = torch.tensor(_get_minimum_scale(num_steps))
+        min, max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                       is_symmetric=symmetric)
         scale = (max - min) / 255
 
         # Scale should be at least as large as torch.min
         assert scale != 0
-        assert torch.allclose(scale, torch.tensor(torch.finfo(scale.dtype).eps), rtol=0.01)
+        assert torch.allclose(scale, minimum_scale, rtol=0.01)
 
         float_input_max = (torch.arange(10) * torch.finfo(torch.float).max)
         encoding_analyzer.update_stats(float_input_max)
-        min_1, max_1 = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=symmetric)
+        min_1, max_1 = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                           is_symmetric=symmetric)
         assert torch.all(torch.isfinite(min_1))
         assert torch.all(torch.isfinite(max_1))
 
 class TestHistogramEncodingAnalyzer:
-    @pytest.fixture
-    def histogram_based_encoding_analyzers(self, request):
-        min_max_shape = request.param[0]
-        num_bins = request.param[1]
-
-        percentile_encoding_analyzer = PercentileEncodingAnalyzer(min_max_shape, num_bins = num_bins, percentile = 99)
-        #sqnr_encoding_analyzer = SqnrEncodingAnalyzer(min_max_shape, num_bins)
-        encoding_analyzer_list = [percentile_encoding_analyzer]
-        yield encoding_analyzer_list
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_compute_encodings_with_same_nonzero_tensor(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            encoding_analyzer.update_stats(torch.full((), 3.0))
-
-            stats = encoding_analyzer.observer.stats[0]
-            cum_sum = torch.cumsum(stats.histogram, dim=0)
-            index = torch.searchsorted(cum_sum, torch.quantile(cum_sum, 99/100))
-            max_val = stats.bin_edges[index]
-           
-            num_steps = pow(2, 8) - 1
-            asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-            assert torch.allclose(asymmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), 0.0))
-            assert torch.allclose(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), max_val))
-
-            
-            symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric = True)
-            assert torch.allclose(symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), -1 * max_val))
-            assert torch.allclose(symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), max_val))
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_compute_encodings_with_only_zero_tensor(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            encoding_analyzer.update_stats(torch.zeros(()))
-
-            stats = encoding_analyzer.observer.stats[0]
-            cum_sum = torch.cumsum(stats.histogram, dim=0)
-            index = torch.searchsorted(cum_sum, torch.quantile(cum_sum, 99/100))
-            min_value = stats.bin_edges[index]
-           
-            num_steps = pow(2, 8) - 1
-            asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-            assert torch.allclose(asymmetric_min,  torch.full(tuple(encoding_analyzer.observer.shape), min_value))
-            assert torch.all(torch.eq(asymmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 0)))
-            
-            symmetric_min , symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric = True)
-            assert torch.allclose(symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), min_value))
-            assert torch.allclose(symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), -1 * min_value))
-        
     @pytest.mark.parametrize('num_bins', [-1, 0])
     def test_invalid_bin_value(self, num_bins):
         min_max_shape = ()
-        
+
         with pytest.raises(ValueError):
             PercentileEncodingAnalyzer(num_bins = num_bins, shape=min_max_shape, percentile  = 99)
-        
+
         with pytest.raises(ValueError):
             SqnrEncodingAnalyzer(min_max_shape, num_bins)
 
-    @pytest.mark.cuda
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    @pytest.mark.parametrize('symmetric', [True, False])
-    def test_cuda_inputs(self, histogram_based_encoding_analyzers, symmetric):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor = torch.tensor([2.0, 3.5, 4.2, 5.0])
-            encoding_analyzer.update_stats(input_tensor.cuda())
-            num_steps = pow(2, 8) - 1
-            encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = symmetric)
-            encoding_analyzer.update_stats(input_tensor.cuda())
-            
-            input_tensor_2 = input_tensor * 1.1 - 0.1 
-            encoding_analyzer.update_stats(input_tensor_2.cuda())
-            encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = symmetric)
-            
-            assert encoding_analyzer.observer.stats[0].histogram.is_cuda
-            assert encoding_analyzer.observer.stats[0].bin_edges.is_cuda
-
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_merge_stats_resize_histogram(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([2.0, 3.5, 4.2, 5.0])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 2
-            assert encoding_analyzer.observer.stats[0].max == 5
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([1.0, 1.0, 2.0])))
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([2.0, 3.0, 4.0, 5.0])))
-            
-            # update max
-            input_tensor_2 = torch.tensor([5.3, 6.4, 7.0, 8.0])
-            encoding_analyzer.update_stats(input_tensor_2)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 2
-            assert encoding_analyzer.observer.stats[0].max == 8
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([2.0, 3.0, 3.0])))
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([2.0, 4.0, 6.0, 8.0])))
-
-            # update min
-            input_tensor_3 = torch.tensor([-4.2, 0, 2.3, 4.5])
-            encoding_analyzer.update_stats(input_tensor_3)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == -4.2
-            assert encoding_analyzer.observer.stats[0].max == 8
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([1, 4, 7])))
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([-4.2000, -0.133333, 3.933333, 8.000]))
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_merge_stats_resize_histogram_with_ambiguous_bins(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([-4.2, 2.4, 7.0, 8.0])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == -4.2
-            assert encoding_analyzer.observer.stats[0].max == 8
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([1.0, 1.0, 2.0])))
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([-4.2000, -0.133333, 3.933333, 8.000]))
-
-            input_tensor_2 = torch.tensor([-6.7, -2.5, 7.2, 10.3])
-            # hist is [2, 0, 2] for this tensor only
-            encoding_analyzer.update_stats(input_tensor_2) 
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == -6.7
-            assert encoding_analyzer.observer.stats[0].max == 10.3
-            '''
-            Ambiguity lies when mapping 1st and 3rd num_steps ex: values in [-4.2, -0.133) could map to [-6.7, -1.033) or [-1.033, 4.633)
-            '''
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([3.0, 1.0, 4.0])))
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([-6.7000, -1.03333,  4.63333, 10.3000]))
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_merge_stats_resize_histogram_with_bin_splitting(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([1, 7, 5.3, 6, 5.7, 6.8, 6.2, 2.8, 3.9])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 1
-            assert encoding_analyzer.observer.stats[0].max == 7
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([2.0, 1.0, 6.0])))
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([1, 3, 5, 7]))
-
-            input_tensor_2 = torch.tensor([0, 9, 7.8, 2.5, 4.6, 6.2, 8.8])
-            encoding_analyzer.update_stats(input_tensor_2)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 0
-            assert encoding_analyzer.observer.stats[0].max == 9
-            # 6 values from the source's histograms 3rd bucket are split in half into the destination's 2nd and 3rd bucket
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([4.0, 5.0, 7.0])))
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([0, 3, 6, 9]))
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 1)], indirect=True)
-    def test_histogram_with_one_bin(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([1, 7, 5.3, 6, 5.7, 6.8, 6.2, 2.8, 3.9])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert encoding_analyzer.observer.stats[0].min == 1
-            assert encoding_analyzer.observer.stats[0].max == 7
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 10)], indirect=True)
-    def test_handle_inf_inputs(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([1, 7, 5.3, 6, float('inf'), float('inf')])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert encoding_analyzer.observer.stats[0].min == 1
-            assert encoding_analyzer.observer.stats[0].max == 7
-            # 2 inf values are clipped to 7
-            assert encoding_analyzer.observer.stats[0].histogram[9] == 3
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, 
-                                      torch.Tensor([1.0000, 1.6000, 2.2000, 2.8000, 3.4000, 4.0000, 4.6000, 5.2000, 5.8000, 6.4000, 7.0000]))
-
-
-            input_tensor_2 = torch.tensor([0, 17, -5, 3, -float('inf'), float('inf'), -float('inf')])
-            encoding_analyzer.update_stats(input_tensor_2)
-            assert encoding_analyzer.observer.stats[0].min == -5
-            assert encoding_analyzer.observer.stats[0].max == 17
-            # 1 inf value clipped to 17
-            assert encoding_analyzer.observer.stats[0].histogram[9] == 2
-            # 2 neg inf value clipped to -5
-            assert encoding_analyzer.observer.stats[0].histogram[0] == 3
-            old_histogram = encoding_analyzer.observer.stats[0].histogram
-            assert torch.allclose(encoding_analyzer.observer.stats[0].bin_edges, 
-                                      torch.Tensor([-5.0000, -2.8000, -0.6000,  1.6000,  3.8000,  6.0000,  8.2000, 10.4000, 12.6000, 14.8000, 17.0000]))
-
-            
-            input_tensor_3 = torch.tensor([10, -float('inf'), float('inf'), -float('inf')])
-            encoding_analyzer.update_stats(input_tensor_3)
-            assert encoding_analyzer.observer.stats[0].histogram[0] == old_histogram[0] + 2
-            assert encoding_analyzer.observer.stats[0].histogram[-1] == old_histogram[-1] + 1
-
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 10)], indirect=True)
-    def test_handle_only_inf_inputs(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([float('inf'), -float('inf'), -float('inf'), float('inf'), float('inf')])
-            with pytest.raises(ValueError):
-                encoding_analyzer.update_stats(input_tensor_1)
-    
-    @pytest.mark.parametrize("histogram_based_encoding_analyzers", [((), 3)], indirect=True)
-    def test_merge_stats_without_resizing(self, histogram_based_encoding_analyzers):
-        for encoding_analyzer in histogram_based_encoding_analyzers:
-            input_tensor_1 = torch.tensor([2.0, 3.5, 4.2, 5.0])
-            encoding_analyzer.update_stats(input_tensor_1)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 2
-            assert encoding_analyzer.observer.stats[0].max == 5
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([1, 1, 2])))
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([2, 3, 4, 5])))
-            
-            # same min, max values
-            input_tensor_2 = torch.tensor([2.0, 3.3, 4.8, 5])
-            encoding_analyzer.update_stats(input_tensor_2)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 2
-            assert encoding_analyzer.observer.stats[0].max == 5
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([2, 2, 4])))
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([2, 3, 4, 5])))
-
-            # min and max within current range
-            input_tensor_3 = torch.tensor([3.1, 3.3, 3.7, 3.9])
-            encoding_analyzer.update_stats(input_tensor_3)
-            assert len(encoding_analyzer.observer.stats) == 1
-            assert encoding_analyzer.observer.stats[0].min == 2
-            assert encoding_analyzer.observer.stats[0].max == 5
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].histogram, torch.Tensor([2, 6, 4])))
-            assert torch.all(torch.eq(encoding_analyzer.observer.stats[0].bin_edges, torch.Tensor([2, 3, 4, 5])))
-
-    
     @pytest.mark.cuda
     @pytest.mark.parametrize('symmetric', [True, False])
     @pytest.mark.parametrize('device', ['cuda', 'cpu'])
@@ -438,8 +254,9 @@ class TestHistogramEncodingAnalyzer:
         x = torch.arange(24, dtype=torch.float).view(2, 3, 4).to(device)
         encoding_analyzer = PercentileEncodingAnalyzer(shape=shape, percentile = 99)
         encoding_analyzer.update_stats(x)
-        num_steps = math.pow(2, 8) - 1
-        encoding_min, encoding_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=symmetric)
+        num_steps = 2**8 - 1
+        encoding_min, encoding_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                         is_symmetric=symmetric)
         assert encoding_min.shape == shape
         assert encoding_max.shape == shape
         if device == 'cuda':
@@ -448,8 +265,7 @@ class TestHistogramEncodingAnalyzer:
         else:
             assert not encoding_min.is_cuda
             assert not encoding_max.is_cuda
- 
-    
+
     def test_collect_stats_multidimensional(self):
         x = torch.arange(24, dtype=torch.float).view(2, 3, 4)
         shape = (4,)
@@ -472,7 +288,6 @@ class TestHistogramEncodingAnalyzer:
         for i in range(2):
             assert torch.equal(histograms[i].min,  x[i,:,:].min())
             assert torch.equal(histograms[i].max,  x[i,:,:].max())
-    
 
         shape = (3, 4)
         observer = _HistogramObserver(shape, num_bins=5)
@@ -510,7 +325,7 @@ class TestHistogramEncodingAnalyzer:
             m = i % 4
             assert torch.equal(histograms[i].min,  x[j,k,m].min())
             assert torch.equal(histograms[i].max,  x[j,k,m].max())
-    
+
     def test_histogram_during_merging(self):
         observer = _HistogramObserver((), num_bins=10)
         input = torch.arange(-50, 51, dtype=torch.float)
@@ -539,105 +354,314 @@ class TestHistogramEncodingAnalyzer:
         # -75      -60      -45      -30      -15       0        15       30       45       60       75
         #
         #                                       (new_histogram)
-            
 
-class TestPercentileEncodingAnalyzer():  
+
+class TestPercentileEncodingAnalyzer():
+    @pytest.fixture
+    def percentile_encoding_analyzer(self):
+        return PercentileEncodingAnalyzer(shape=(), num_bins=3, percentile=99)
+
+    def test_compute_encodings_with_same_nonzero_tensor(self, percentile_encoding_analyzer):
+        percentile_encoding_analyzer.update_stats(torch.full((), 3.))
+
+        stats = percentile_encoding_analyzer.observer.stats[0]
+        cum_sum = torch.cumsum(stats.histogram, dim=0)
+        index = torch.searchsorted(cum_sum, torch.quantile(cum_sum, 99/100))
+        max_val = stats.bin_edges[index]
+
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = percentile_encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                                        is_symmetric=False)
+        expected_min = torch.zeros_like(asymmetric_min)
+        expected_max = torch.full_like(asymmetric_max, max_val)
+        assert torch.allclose(asymmetric_min, expected_min)
+        assert torch.allclose(asymmetric_max, expected_max)
+
+        symmetric_min , symmetric_max = percentile_encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                                       is_symmetric=True)
+        # Symmetric encodings have one more bins on the negative side
+        expected_min = torch.full_like(symmetric_min, -max_val) - (symmetric_max / (num_steps // 2))
+        expected_max = torch.full_like(symmetric_max,  max_val)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
+    def test_compute_encodings_with_only_zero_tensor(self, percentile_encoding_analyzer):
+        percentile_encoding_analyzer.update_stats(torch.zeros(()))
+
+        stats = percentile_encoding_analyzer.observer.stats[0]
+        cum_sum = torch.cumsum(stats.histogram, dim=0)
+        index = torch.searchsorted(cum_sum, torch.quantile(cum_sum, 99/100))
+        min_value = stats.bin_edges[index]
+
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = percentile_encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                                        is_symmetric=False)
+        expected_min = torch.full_like(asymmetric_min, min_value)
+        expected_max = torch.zeros_like(asymmetric_max)
+        assert torch.allclose(asymmetric_min, expected_min)
+        assert torch.allclose(asymmetric_max, expected_max)
+
+        symmetric_min , symmetric_max = percentile_encoding_analyzer.compute_encodings(num_steps=num_steps - 1,
+                                                                                       is_symmetric=True)
+        expected_min = torch.full_like(symmetric_min, min_value)
+        expected_max = torch.full_like(symmetric_max, -min_value)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
+    @pytest.mark.cuda
+    @pytest.mark.parametrize('symmetric', [True, False])
+    def test_cuda_inputs(self, percentile_encoding_analyzer, symmetric):
+        input_tensor = torch.tensor([2., 3.5, 4.2, 5.])
+        percentile_encoding_analyzer.update_stats(input_tensor.cuda())
+        num_steps = 2**8 - 1
+        percentile_encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                       is_symmetric=symmetric)
+        percentile_encoding_analyzer.update_stats(input_tensor.cuda())
+
+        input_tensor_2 = input_tensor * 1.1 - 0.1
+        percentile_encoding_analyzer.update_stats(input_tensor_2.cuda())
+        percentile_encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                       is_symmetric=symmetric)
+
+        assert percentile_encoding_analyzer.observer.stats[0].histogram.is_cuda
+        assert percentile_encoding_analyzer.observer.stats[0].bin_edges.is_cuda
+
+    def test_merge_stats_resize_histogram(self, percentile_encoding_analyzer):
+        input_tensor_1 = torch.tensor([2., 3.5, 4.2, 5.])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 5
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([1., 1., 2.]))
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([2., 3., 4., 5.]))
+
+        # update max
+        input_tensor_2 = torch.tensor([5.3, 6.4, 7., 8.])
+        percentile_encoding_analyzer.update_stats(input_tensor_2)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 8
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([2., 3., 3.]))
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([2., 4., 6., 8.]))
+
+        # update min
+        input_tensor_3 = torch.tensor([-4.2, 0, 2.3, 4.5])
+        percentile_encoding_analyzer.update_stats(input_tensor_3)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == -4.2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 8
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([1, 4, 7]))
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([-4.2, -0.133333, 3.933333, 8.]))
+
+    def test_merge_stats_resize_histogram_with_ambiguous_bins(self, percentile_encoding_analyzer):
+        input_tensor_1 = torch.tensor([-4.2, 2.4, 7., 8.])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == -4.2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 8
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([1., 1., 2.]))
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([-4.2, -0.133333, 3.933333, 8.]))
+
+        input_tensor_2 = torch.tensor([-6.7, -2.5, 7.2, 10.3])
+        # hist is [2, 0, 2] for this tensor only
+        percentile_encoding_analyzer.update_stats(input_tensor_2)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == -6.7
+        assert percentile_encoding_analyzer.observer.stats[0].max == 10.3
+        '''
+        Ambiguity lies when mapping 1st and 3rd num_steps ex: values in [-4.2, -0.133) could map to [-6.7, -1.033) or [-1.033, 4.633)
+        '''
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([3., 1., 4.]))
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([-6.7, -1.03333,  4.63333, 10.3]))
+
+    def test_merge_stats_resize_histogram_with_bin_splitting(self, percentile_encoding_analyzer):
+        input_tensor_1 = torch.tensor([1, 7, 5.3, 6, 5.7, 6.8, 6.2, 2.8, 3.9])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 1
+        assert percentile_encoding_analyzer.observer.stats[0].max == 7
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([2., 1., 6.]))
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([1., 3., 5., 7.]))
+
+        input_tensor_2 = torch.tensor([0, 9, 7.8, 2.5, 4.6, 6.2, 8.8])
+        percentile_encoding_analyzer.update_stats(input_tensor_2)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 0
+        assert percentile_encoding_analyzer.observer.stats[0].max == 9
+        # 6 values from the source's histograms 3rd bucket are split in half into the destination's 2nd and 3rd bucket
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([4., 5., 7.]))
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([0., 3., 6., 9.]))
+
+    def test_histogram_with_one_bin(self, percentile_encoding_analyzer):
+        input_tensor_1 = torch.tensor([1, 7, 5.3, 6, 5.7, 6.8, 6.2, 2.8, 3.9])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert percentile_encoding_analyzer.observer.stats[0].min == 1
+        assert percentile_encoding_analyzer.observer.stats[0].max == 7
+
+    def test_handle_inf_inputs(self):
+        percentile_encoding_analyzer = PercentileEncodingAnalyzer(shape=(), num_bins=10, percentile=99)
+        input_tensor_1 = torch.tensor([1, 7, 5.3, 6, float('inf'), float('inf')])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert percentile_encoding_analyzer.observer.stats[0].min == 1
+        assert percentile_encoding_analyzer.observer.stats[0].max == 7
+        # 2 inf values are clipped to 7
+        assert percentile_encoding_analyzer.observer.stats[0].histogram[9] == 3
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges,
+                                  torch.tensor([1., 1.6, 2.2, 2.8, 3.4, 4., 4.6, 5.2, 5.8, 6.4, 7.]))
+
+        input_tensor_2 = torch.tensor([0, 17, -5, 3, -float('inf'), float('inf'), -float('inf')])
+        percentile_encoding_analyzer.update_stats(input_tensor_2)
+        assert percentile_encoding_analyzer.observer.stats[0].min == -5
+        assert percentile_encoding_analyzer.observer.stats[0].max == 17
+        # 1 inf value clipped to 17
+        assert percentile_encoding_analyzer.observer.stats[0].histogram[9] == 2
+        # 2 neg inf value clipped to -5
+        assert percentile_encoding_analyzer.observer.stats[0].histogram[0] == 3
+        old_histogram = percentile_encoding_analyzer.observer.stats[0].histogram
+        assert torch.allclose(percentile_encoding_analyzer.observer.stats[0].bin_edges,
+                                  torch.tensor([-5., -2.8, -0.6,  1.6,  3.8,  6.,  8.2, 10.4, 12.6, 14.8, 17.]))
+
+        input_tensor_3 = torch.tensor([10, -float('inf'), float('inf'), -float('inf')])
+        percentile_encoding_analyzer.update_stats(input_tensor_3)
+        assert percentile_encoding_analyzer.observer.stats[0].histogram[0] == old_histogram[0] + 2
+        assert percentile_encoding_analyzer.observer.stats[0].histogram[-1] == old_histogram[-1] + 1
+
+    def test_handle_only_inf_inputs(self):
+        percentile_encoding_analyzer = PercentileEncodingAnalyzer(shape=(), num_bins=10, percentile=99)
+        input_tensor_1 = torch.tensor([float('inf'), -float('inf'), -float('inf'), float('inf'), float('inf')])
+        with pytest.raises(ValueError):
+            percentile_encoding_analyzer.update_stats(input_tensor_1)
+
+    def test_merge_stats_without_resizing(self, percentile_encoding_analyzer):
+        input_tensor_1 = torch.tensor([2., 3.5, 4.2, 5.])
+        percentile_encoding_analyzer.update_stats(input_tensor_1)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 5
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([1, 1, 2]))
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([2, 3, 4, 5]))
+
+        # same min, max values
+        input_tensor_2 = torch.tensor([2., 3.3, 4.8, 5])
+        percentile_encoding_analyzer.update_stats(input_tensor_2)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 5
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([2, 2, 4]))
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([2, 3, 4, 5]))
+
+        # min and max within current range
+        input_tensor_3 = torch.tensor([3.1, 3.3, 3.7, 3.9])
+        percentile_encoding_analyzer.update_stats(input_tensor_3)
+        assert len(percentile_encoding_analyzer.observer.stats) == 1
+        assert percentile_encoding_analyzer.observer.stats[0].min == 2
+        assert percentile_encoding_analyzer.observer.stats[0].max == 5
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].histogram, torch.tensor([2, 6, 4]))
+        assert torch.equal(percentile_encoding_analyzer.observer.stats[0].bin_edges, torch.tensor([2, 3, 4, 5]))
+
     @pytest.mark.parametrize("percentile_value", [-1, 49, 5, 101])
     def test_invalid_percentile_value(self, percentile_value):
         with pytest.raises(ValueError):
-            PercentileEncodingAnalyzer((), percentile = percentile_value, num_bins = 3)  
-    
+            PercentileEncodingAnalyzer((), percentile = percentile_value, num_bins = 3)
+
     def test_compute_encodings_asymmetric_normalized(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 99)
         mean = std_dev = 2
         input_tensor = np.random.normal(mean, std_dev, size=(100000))
         encoding_analyzer.update_stats(torch.from_numpy(input_tensor))
-        num_steps = math.pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                             is_symmetric=False)
+
         # 99% of the population is within 2 1/2 standard deviations of the mean
         assert asymmetric_min > mean - std_dev * 2.5
-        assert asymmetric_max < mean + std_dev * 2.5  
-    
+        assert asymmetric_max < mean + std_dev * 2.5
+
     def test_compute_encodings_asymmetric_sequential(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 99, num_bins = 500)
         input_tensor =  torch.arange(start=0, end=1001, step=1, dtype=torch.float)
         encoding_analyzer.update_stats(input_tensor)
 
-        num_steps = math.pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
-        
+        num_steps = 2**8 - 1
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                             is_symmetric=False)
+
         # encoding max is the histogram bin edge which contains 99% percentile (990.02)
         assert asymmetric_min == 0
         assert asymmetric_max == 990.0
-        
+
     def test_compute_encodings_signed_symmetric_normalized(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 99, num_bins = 3)
         mean = std_dev = 2
         input_tensor = np.random.normal(mean, std_dev, size=(10000))
         encoding_analyzer.update_stats(torch.from_numpy(input_tensor))
 
-        num_steps = math.pow(2, 8) - 1
-        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = True)
+        num_steps = 2**8 - 1
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                           is_symmetric=True)
         largest_absolute_value = max(abs(element) for element in input_tensor)
         assert symmetric_min > -largest_absolute_value
         assert symmetric_max < largest_absolute_value
-    
+
     def test_compute_encodings_signed_symmetric_sequential(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 99, num_bins = 500)
         input_tensor =  torch.arange(start=0, end=1001, step=1, dtype=torch.float)
         encoding_analyzer.update_stats(input_tensor)
-        
-        num_steps = math.pow(2, 8) - 2
-        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = True)
+
+        num_steps = 2**8 - 2
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                           is_symmetric=True)
         assert symmetric_min == -990.0
         assert symmetric_max == 990.0
-    
+
     def test_compute_encodings_non_strict_symmetric(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 100, num_bins = 1)
         input_tensor =  torch.arange(start=-2, end=10, step=1, dtype=torch.float)
 
         encoding_analyzer.update_stats(input_tensor)
 
-        num_bins = pow(2, 3) - 1
-        non_strict_symmetric_min, non_strict_symmetric_max = encoding_analyzer.compute_encodings(is_symmetric = True, num_steps = num_bins)
-        assert torch.all(torch.isclose(non_strict_symmetric_min, torch.full(tuple(encoding_analyzer.observer.shape), -12.0)))
-        assert torch.all(torch.isclose(non_strict_symmetric_max, torch.full(tuple(encoding_analyzer.observer.shape), 9.0)))
-    
+        num_steps = 2**3 - 1
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                                           is_symmetric=True)
+        expected_min = torch.full_like(symmetric_min, -12.)
+        expected_max = torch.full_like(symmetric_max,  9.)
+        assert torch.allclose(symmetric_min, expected_min)
+        assert torch.allclose(symmetric_max, expected_max)
+
     def test_compute_encodings_100_percentile(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 100, num_bins = 3)
         mean = std_dev = 2
         input_tensor = torch.randn(10000) * std_dev + mean
         encoding_analyzer.update_stats(input_tensor)
 
-        num_steps = math.pow(2, 8) - 1
-        strict_symmetric_min, strict_symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric = True)
+        num_steps = 2**8 - 1
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1,
+                                                                           is_symmetric=True)
         absmax = input_tensor.abs().max()
-        assert torch.allclose(strict_symmetric_min, -absmax)
-        assert torch.allclose(strict_symmetric_max, absmax)
+        assert torch.allclose(symmetric_min, -absmax)
+        assert torch.allclose(symmetric_max,  absmax)
 
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=False)
         assert torch.allclose(asymmetric_min, input_tensor.min())
         assert torch.allclose(asymmetric_max, input_tensor.max())
 
-    
     def test_compute_encodings_50_percentile(self):
         encoding_analyzer = PercentileEncodingAnalyzer((), percentile = 50, num_bins = 3)
         input_tensor =  torch.arange(start=0, end=1001, step=1, dtype=torch.float)
         encoding_analyzer.update_stats(input_tensor)
-        
-        num_steps = math.pow(2, 8) - 1
-        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric = True)
-        
+
+        num_steps = 2**8 - 1
+        symmetric_min, symmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps - 1, is_symmetric=True)
+
         stats = encoding_analyzer.observer.stats[0]
         cum_sum = torch.cumsum(stats.histogram, dim=0)
         index = torch.searchsorted(cum_sum, torch.quantile(cum_sum, 50/100))
         mid_value = stats.bin_edges[index]
-        
+
         assert symmetric_min == -1 * mid_value
         assert symmetric_max == mid_value
 
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric = False)
+        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=False)
         assert asymmetric_min == 0
         assert asymmetric_max == mid_value
 
@@ -647,13 +671,13 @@ class TestPercentileEncodingAnalyzer():
         input_tensor[-1] = 1000
         input_tensor[-2] = 800
         encoding_analyzer.update_stats(input_tensor)
-        num_steps = math.pow(2, 8) - 1
-        asymmetric_min, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=False)
-        assert asymmetric_max < 91 and asymmetric_max > 89
+        num_steps = 2**8 - 1
+        _, asymmetric_max = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=False)
+        assert 89 < asymmetric_max < 91
 
 
 class TestSqnrEncodingAnalyzer:
-    
+
     def test_computed_encodings_uniform_dist(self):
         """
         Given: Update stats on an equally spaced input (no outliers)
@@ -663,15 +687,16 @@ class TestSqnrEncodingAnalyzer:
         x = torch.arange(-100, 101) / 100
         encoding_analyzer = SqnrEncodingAnalyzer(shape=(1, ), gamma=1)
         # Expected min/max isn't exactly -1, 1 due to offset rounding
-        observed_delta = torch.tensor(2 / 255.0)
+        observed_delta = torch.tensor(2 / 255.)
         observed_offset = torch.round(-1 / observed_delta)
         observed_min = observed_offset * observed_delta
         observed_max = observed_min + 255 * observed_delta
         encoding_analyzer.update_stats(x)
-        num_steps = math.pow(2, 8) - 1
-        qmin, qmax = encoding_analyzer.compute_encodings(num_steps=num_steps, is_symmetric=False)
-        assert torch.equal(qmin, observed_min.view((1, )))
-        assert torch.equal(qmax, observed_max.view((1, )))
+        num_steps = 2**8 - 1
+        _min, _max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                         is_symmetric=False)
+        assert torch.equal(_min, observed_min.view((1, )))
+        assert torch.equal(_max, observed_max.view((1, )))
 
     def test_computed_encodings_with_outliers(self):
         """
@@ -680,7 +705,7 @@ class TestSqnrEncodingAnalyzer:
         Then: Min/max range should be less than the observed min/max
         """
         # Aim for an optimal max_encoding of 3/4 the outlier value
-        expected_delta = torch.Tensor([0.1])
+        expected_delta = torch.tensor([0.1])
         outlier_val = (255 * expected_delta) / 0.75
         """
         Some math required to determine the number of non-outliers to make expected_delta optimal:
@@ -692,21 +717,22 @@ class TestSqnrEncodingAnalyzer:
             MSE = n * delta ^ 2 / 12 + (m - 255 * delta)^2
             d_MSE / d_delta = n * delta / 6  + 2 * 255^2 * delta - 510 * m
         Optimal delta at d_MSE / d_delta = 0, solve for n
-            n = 12 * 255 * m / delta - 12 * 255 ^ 2    
+            n = 12 * 255 * m / delta - 12 * 255 ^ 2
         """
         # In this case, n should evaluate to 210,100
         n = round(12 * 255 * outlier_val.item() / expected_delta.item() - 12 * (255 ** 2))
-        encoding_analyzer = SqnrEncodingAnalyzer((1, ), gamma=1.0)
+        encoding_analyzer = SqnrEncodingAnalyzer((1, ), gamma=1.)
         x = torch.rand((1, n)) * 255 * expected_delta
         encoding_analyzer.update_stats(x)
-        outlier = torch.Tensor([outlier_val]).view(1, 1)
+        outlier = torch.tensor([outlier_val]).view(1, 1)
         encoding_analyzer.update_stats(outlier)
-        num_steps = math.pow(2, 8) - 1
-        qmin, qmax = encoding_analyzer.compute_encodings(num_steps, is_symmetric=False)
-        expected_min = torch.Tensor([0])
+        num_steps = 2**8 - 1
+        _min, _max = encoding_analyzer.compute_encodings(num_steps=num_steps,
+                                                         is_symmetric=False)
+        expected_min = torch.zeros_like(_min)
         expected_max = expected_delta * 255
-        assert torch.allclose(qmin, expected_min)
-        assert torch.allclose(qmax, expected_max)
+        assert torch.allclose(_min, expected_min)
+        assert torch.allclose(_max, expected_max)
 
     def test_shape(self):
         """
@@ -749,15 +775,15 @@ class TestSqnrEncodingAnalyzer:
         """
         encoding_analyzer = SqnrEncodingAnalyzer(shape=())
         num_steps = 255
-        deltas = torch.Tensor([[1 / 4, 3 / 4, 5 / 4]])
-        offsets = torch.Tensor([-255, -128, 0])[None, :]
-        should_clamp = torch.Tensor([
+        deltas = torch.tensor([[1 / 4, 3 / 4, 5 / 4]])
+        offsets = torch.tensor([-255, -128, 0])[None, :]
+        should_clamp = torch.tensor([
             [False, False, False],
             [True,  False, True],
             [True,  True,  True],
         ]).to(torch.bool)
-        deltas_clamp, offsets_clamp = encoding_analyzer._clamp_delta_offset_values(torch.Tensor([-128]),
-                                                                                   torch.Tensor([127]),
+        deltas_clamp, offsets_clamp = encoding_analyzer._clamp_delta_offset_values(torch.tensor([-128]),
+                                                                                   torch.tensor([127]),
                                                                                    num_steps,
                                                                                    deltas,
                                                                                    offsets)
@@ -769,19 +795,20 @@ class TestSqnrEncodingAnalyzer:
         assert torch.all(min_after_clamp > -128.5)
         assert torch.all(max_after_clamp < 127.5)
 
-
     def test_pick_test_candidates_asymmetric(self):
         """
         Given: An initialized encoding analyzer and min/max observations
         When: Encoder selects the search space for asymmetric delta/offset combinations
         """
-        min_obs = torch.Tensor([-128])
-        max_obs = torch.Tensor([127])
+        min_obs = torch.tensor([-128])
+        max_obs = torch.tensor([127])
         observed_offset = -128
         observed_scale = 1.0
         num_steps = 255
         encoding_analyzer = SqnrEncodingAnalyzer(shape=(), asymmetric_delta_candidates=5, offset_candidates=7)
-        deltas, offsets = encoding_analyzer._pick_test_candidates_asymmetric(min_obs, max_obs, num_steps)
+        deltas, offsets = encoding_analyzer._pick_test_candidates_asymmetric(min_obs,
+                                                                             max_obs,
+                                                                             num_steps)
         """
         Then: 1) The number of candidates should be equal to num_encodings * num_delta_candidates * num_offset_candidates
         """
@@ -814,8 +841,8 @@ class TestSqnrEncodingAnalyzer:
         Given: An initialized encoding analyzer and min/max observations
         When: Encoder selects the search space for symmetric delta/offset combinations
         """
-        min_obs = torch.Tensor([-100])
-        max_obs = torch.Tensor([127.5])
+        min_obs = torch.tensor([-100])
+        max_obs = torch.tensor([127.5])
         num_steps = 255
         encoding_analyzer = SqnrEncodingAnalyzer(shape=(), symmetric_delta_candidates=5)
         deltas, offsets = encoding_analyzer._pick_test_candidates_symmetric(min_obs, max_obs, num_steps)
@@ -833,7 +860,6 @@ class TestSqnrEncodingAnalyzer:
         assert torch.all(offsets == -128)
         assert offsets.numel() == 1
 
-
     def test_estimate_quantization_noise(self):
         """
         Given: 1) A histogram with sufficient granularity
@@ -849,15 +875,19 @@ class TestSqnrEncodingAnalyzer:
         # Get Histogram inputs
         histograms = encoding_analyzer.observer.collect_stats(input)
         # Create a wide range of delta/offsets to search
-        deltas = torch.Tensor([0.001, 0.1, 0.5, 1.0])[None, :, None].expand(2, 4, 6)
-        offsets = torch.Tensor([-255, -204, -153, -102, -51, 0]).expand_as(deltas)
+        deltas = torch.tensor([0.001, 0.1, 0.5, 1.])[None, :, None].expand(2, 4, 6)
+        offsets = torch.tensor([-255, -204, -153, -102, -51, 0]).expand_as(deltas)
         # Compute the actual MSE for each encoding candidate:
         delta_bc = deltas[:, :, :, None]
         offset_bc = offsets[:, :, :, None]
-        input_qdq = input[:, None, None, :].div(delta_bc).sub(offset_bc).round().clamp(0, 255).add(offset_bc).mul(delta_bc)
-        q_error_exp = torch.pow(input[:, None, None, :] - input_qdq, 2).sum(dim=-1)
+
+        # Broadcast & expand the input to match the shape of delta and offset
+        input = input[:, None, None, :].expand(2, 4, 6, -1)
+
+        input_qdq = quantize_dequantize(input, delta_bc, offset_bc, qmin=0, qmax=255)
+        q_error_exp = (input - input_qdq).square().sum(dim=-1)
         # Estimate the MSE from the observer histogram
-        q_error_est = encoding_analyzer._estimate_clip_and_quant_noise(histograms, deltas, offsets, 255, gamma=1.0)
+        q_error_est = encoding_analyzer._estimate_clip_and_quant_noise(histograms, deltas, offsets, 255, gamma=1.)
         # Estimated and measured errors should be very close
         assert torch.allclose(q_error_exp, q_error_est, rtol=0.01)
 
@@ -868,15 +898,14 @@ class TestSqnrEncodingAnalyzer:
         Then: Return the (delta, offset) pair which results in the lowest SQNR of the candidates
         """
         # Channels are in range ([-0.5, 0.5], [0, 2])
-        input = (torch.rand(2, 1000) - torch.Tensor([[0.5], [0.0]])) * torch.Tensor([[1.], [2.]])
-        encoding_analyzer = SqnrEncodingAnalyzer(shape=(2, 1), gamma=1.0)
+        input = (torch.rand(2, 1000) - torch.tensor([[0.5], [0.]])) * torch.tensor([[1.], [2.]])
+        encoding_analyzer = SqnrEncodingAnalyzer(shape=(2, 1), gamma=1.)
         # Get Histogram inputs
         histograms = encoding_analyzer.observer.collect_stats(input)
-        # best delta offset: delta=[1 / 255.0, 2 / 255.0], offset=[-128, 0]
-        deltas = torch.Tensor([1/510.0, 1/255.0, 2/255.0])[None, :, None].expand(2, 3, 3)
-        offsets = torch.Tensor([-200, -128, 0]).expand_as(deltas)
+        # best delta offset: delta=[1 / 255., 2 / 255.], offset=[-128, 0]
+        deltas = torch.tensor([1/510., 1/255., 2/255.])[None, :, None].expand(2, 3, 3)
+        offsets = torch.tensor([-200, -128, 0]).expand_as(deltas)
         # Find the best delta/offsets based on the candidates
         best_delta, best_offset = encoding_analyzer._select_best_candidates(deltas, offsets, histograms, 255)
-        assert torch.equal(best_delta, torch.Tensor([1/255.0, 2/255.0]).view(2, 1))
-        assert torch.equal(best_offset, torch.Tensor([-128, 0]).view(2, 1))
-    
+        assert torch.equal(best_delta, torch.tensor([1/255., 2/255.]).view(2, 1))
+        assert torch.equal(best_offset, torch.tensor([-128, 0]).view(2, 1))


### PR DESCRIPTION
## Problem
Today we are using float32.eps ~1.19e-7 as the minimum scale.
|       | float32 | float16 | bfloat16 | float64 |
|----|---------|--------|----------|-----------|
|tiny|  1.18e-38 | 6.10e-05 | 1.18e-38 | 2.23e-308 |
|eps|  1.19e-07 | 9.77e-04 | 7.81e-03 | 2.22e-16 |

This has been tiny enough for up to int16 encodings.
**However, scale of 1.19e-7 is way too coarse to export int32 encodings**, only able to represent ranges no narrower than [0, 512].
```pycon
>>> torch.finfo(torch.float32).eps * (2**32 - 1)
511.9999998807907
```

## Solution
This PR adds a dynamic mechanism for deciding minimum scale based on the target dtype.
The rule is described in this function
![image](https://github.com/user-attachments/assets/c9cff912-4987-4485-adf6-95d9445bb29e)