### PR TITLE
Quantize scalar activations in aimet_torch.v1

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -72,9 +72,9 @@ from aimet_torch._base.nn.modules.custom import CustomSparseConv3DLayer
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Utils)
 
-dtypes_to_ignore_for_quantization = (int, float, bool, str, tuple, type(None))
+dtypes_to_ignore_for_quantization = (int, bool, str, tuple, type(None))
 torch_dtypes_to_ignore_for_quantization = [torch.int, torch.int8, torch.int16, torch.int32, torch.int64, torch.bool, torch.uint8]
-allowed_output_types = (torch.Tensor, *dtypes_to_ignore_for_quantization)
+allowed_output_types = (torch.Tensor, float, *dtypes_to_ignore_for_quantization)
 DROPOUT_TYPES = (torch.nn.Dropout, torch.nn.Dropout2d, torch.nn.Dropout3d)
 
 # list of modules which need to be treated as a leaf module

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
@@ -860,7 +860,7 @@ class StaticGridQuantWrapper(QcQuantizeWrapper):
         :return: Quantized output from the wrapped module
         """
 
-        def inner_quantization(input_tensor, index):
+        def inner_quantization(input_tensor, index): # pylint: disable=too-many-branches
             if isinstance(input_tensor, (List, Tuple)):
                 inner_outputs = []
                 for inner_input in input_tensor:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
@@ -471,9 +471,8 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
 
         if isinstance(tensor, utils.dtypes_to_ignore_for_quantization) or \
                 tensor.dtype in utils.torch_dtypes_to_ignore_for_quantization or \
-                (tensor_quantizer.is_const and torch.numel(tensor) == 1) or \
                 not tensor_quantizer.enabled:
-            # If the tensor is unquantizable or if it's a  scalar-constant, disable the quantizer explicitly
+            # If the tensor is unquantizable, disable the quantizer explicitly
             tensor_quantizer.enabled = False
             return False
         return True
@@ -875,7 +874,10 @@ class StaticGridQuantWrapper(QcQuantizeWrapper):
                     f"but got {type(input_tensor)}"
                 )
 
-            if not self.should_perform_quant_dequant(input_tensor, tensor_quantizers[index]):
+            input_type = type(input_tensor)
+            if issubclass(input_type, float):
+                input_tensor = torch.tensor(input_tensor)
+            elif not self.should_perform_quant_dequant(input_tensor, tensor_quantizers[index]):
                 return input_tensor
 
             if self._mode is QcQuantizeOpMode.ANALYSIS and not tensor_quantizers[index].is_encoding_frozen:
@@ -902,6 +904,9 @@ class StaticGridQuantWrapper(QcQuantizeWrapper):
 
             else:
                 output = input_tensor
+
+            if issubclass(input_type, float):
+                output = output.item()
 
             return output
 
@@ -1153,7 +1158,10 @@ class LearnedGridQuantWrapper(QcQuantizeWrapper):
                     inner_outputs.append(inner_quantization(inner_input, index))
                 return inner_outputs
 
-            if not self.should_perform_quant_dequant(input_tensor, tensor_quantizers[index]):
+            input_type = type(input_tensor)
+            if issubclass(input_type, float):
+                input_tensor = torch.tensor(input_tensor)
+            elif not self.should_perform_quant_dequant(input_tensor, tensor_quantizers[index]):
                 return input_tensor
 
             if not isinstance(input_tensor, torch.Tensor):
@@ -1164,7 +1172,12 @@ class LearnedGridQuantWrapper(QcQuantizeWrapper):
 
             encoding_min = getattr(self, type_of_quantizer + str(index) + '_encoding_min')
             encoding_max = getattr(self, type_of_quantizer + str(index) + '_encoding_max')
-            return tensor_quantizers[index].quantize_dequantize(input_tensor, encoding_min, encoding_max)
+            out = tensor_quantizers[index].quantize_dequantize(input_tensor, encoding_min, encoding_max)
+
+            if issubclass(input_type, float):
+                out = out.item()
+
+            return out
 
         quantized_tensors = []
         for index, tensor_to_quantize in enumerate(tensors_to_quantize):

--- a/TrainingExtensions/torch/test/python/v1/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantizer.py
@@ -5387,3 +5387,97 @@ def test_histogram(device):
     prob = torch.tensor([prob for _, prob in q.getStatsHistogram()], device=device)
 
     assert torch.equal(prob * 1025, ground_truth)
+
+
+class ScalarModel(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.prelu = torch.nn.PReLU()
+        self.linear = torch.nn.Linear(10, 10)
+        self.add1 = aimet_modules.Add()
+        self.add2 = aimet_modules.Add()
+        self.add3 = aimet_modules.Add()
+
+    def forward(self, x: torch.Tensor, y: torch.Tensor):
+        """
+        This model continas 5 scalars, all of which are expected to be quantized
+
+        |     name     |      description     |
+        |--------------|----------------------|
+        | prelu.weight | scalar Parameter     |
+        |     y        | scalar Tensor input  |
+        |     y_out    | scalar Tensor output |
+        |     z        | Python float input   |
+        |     z_out    | Python float output  |
+        """
+
+        assert y.numel() == 1
+
+        x_out = self.linear(x)
+        x_out = self.prelu(x_out)
+
+        y_out = self.add1(y, 1.0)
+        assert y.device == y_out.device # IMPORTANT
+        assert y.dtype == y_out.dtype   # IMPORTANT
+
+        z = 1.0
+        z_out = self.add2(y_out, z)
+        assert y_out.device == z_out.device # IMPORTANT
+        assert y_out.dtype == z_out.dtype   # IMPORTANT
+
+        return self.add3(x_out, z_out)
+
+
+@pytest.mark.cuda
+@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+@pytest.mark.parametrize('quant_scheme', [QuantScheme.post_training_tf,
+                                          QuantScheme.training_range_learning_with_tf_init])
+def test_scalar_tensors(quant_scheme, device):
+    """
+    Given: Model with various scalar input/output/parameters
+    """
+    model = ScalarModel().to(device)
+    x = torch.randn((10, 10), device=device).detach()
+    y = torch.randn((), device=device).detach()
+
+    """
+    When: Create quantsim and compute_encodings
+    Then: All quantizers that takes scalars should be enabled
+    """
+    sim = QuantizationSimModel(model, (x, y), quant_scheme=quant_scheme)
+    sim.model.to(device)
+
+    sim.compute_encodings(lambda model, _: model(x, y), None)
+
+    assert     sim.model.linear.input_quantizers[0].enabled
+    assert     sim.model.linear.output_quantizers[0].enabled
+    assert     sim.model.linear.param_quantizers['weight'].enabled
+
+    assert not sim.model.prelu.input_quantizers[0].enabled
+    assert     sim.model.prelu.output_quantizers[0].enabled
+    assert     sim.model.prelu.param_quantizers['weight'].enabled # IMPORTANT
+
+    assert     sim.model.add1.input_quantizers[0].enabled # IMPORTANT
+    assert     sim.model.add1.input_quantizers[1].enabled # IMPORTANT
+    assert     sim.model.add1.output_quantizers[0].enabled
+
+    assert not sim.model.add2.input_quantizers[0].enabled
+    assert     sim.model.add2.input_quantizers[1].enabled  # IMPORTANT
+    assert     sim.model.add2.output_quantizers[0].enabled # IMPORTANT
+
+    assert not sim.model.add3.input_quantizers[0].enabled
+    assert not sim.model.add3.input_quantizers[1].enabled
+    assert     sim.model.add3.output_quantizers[0].enabled
+
+    """
+    When: export
+    Then: Should produce expected number of activation & param encodings
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        sim.export(tmpdir, 'quant_sim', (x.cpu(), y.cpu()))
+
+        with open(os.path.join(tmpdir, 'quant_sim.encodings')) as f:
+            encodings = json.load(f)
+
+        assert sum(len(entry) for entry in encodings['activation_encodings'].values()) == 9
+        assert sum(len(entry) for entry in encodings['param_encodings'].values()) == 2

--- a/TrainingExtensions/torch/test/python/v1/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantizer.py
@@ -1161,25 +1161,29 @@ class TestQuantizationSimStaticGrad:
         model = ModelWithConstantQuantization()
         dummy_input = torch.rand(1, 2)
         sim = QuantizationSimModel(model, dummy_input)
+
+        assert     sim.model.relu.input_quantizers[0].enabled
+        assert     sim.model.relu.output_quantizers[0].enabled
+
         assert not sim.model.add.input_quantizers[0].enabled
-        assert sim.model.add.input_quantizers[1].enabled
-        assert sim.model.add2.input_quantizers[0].enabled
+        assert     sim.model.add.input_quantizers[1].enabled
+        assert     sim.model.add.output_quantizers[0].enabled
+
+        assert     sim.model.add2.input_quantizers[0].enabled
         assert not sim.model.add2.input_quantizers[1].enabled
+        assert     sim.model.add2.output_quantizers[0].enabled
+
         assert not sim.model.add3.input_quantizers[0].enabled
-        assert sim.model.add3.input_quantizers[1].enabled
+        assert     sim.model.add3.input_quantizers[1].enabled
+        assert     sim.model.add3.output_quantizers[0].enabled
 
         sim.compute_encodings(lambda m, _: m(dummy_input), None)
-        # As add and add2 use constants with numel 1, we expect the quantizers to not have any encoding stats and thus
-        # be disabled after compute encodings.
-        assert not sim.model.add.input_quantizers[1].enabled
-        assert not sim.model.add2.input_quantizers[1].enabled
-        assert sim.model.add3.input_quantizers[1].enabled
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             sim.export(tmp_dir, 'model_with_constant_quantization', dummy_input)
             with open(os.path.join(tmp_dir, "model_with_constant_quantization.encodings"), "r") as encodings_file:
                 activation_encoding_tensors = set(json.load(encodings_file)['activation_encodings'].keys())
-                assert len(activation_encoding_tensors) == 6
+                assert len(activation_encoding_tensors) == 8
 
     # -------------------------------------------
     def test_input_and_output_quantization(self):


### PR DESCRIPTION
## Main Changes
Below table shows which tensors are quantized in AIMET
|                                     |  aimet-onnx  | aimet-torch v1 | aimet-torch v2 |
|-------------------------:|:---------------:|:-----------------:|:------------------:|
| Python int                          |      N/A         |      ❌              |   ❌                  |
| Python float                       |      N/A         |      ❌->✔️     |   ❌                  |
| scalar input _**tensor**_    |      ✔️          |      ❌->✔️     |    ✔️              |
| scalar output _**tensor**_  |      ✔️          |      ❌->✔️     |    ✔️            |
| scalar param _**tensor**_   |      ✔️          |      ✔️             |    ❌               |
| non-scalar _**tensor**_      |      ✔️          |      ✔️             |    ✔️                |

(_**tensor**_ : `torch.Tensor | np.ndarray`)