### PR TITLE
Avoid multiple instances of same quantizer group

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/amp/quantizer_groups.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/amp/quantizer_groups.py
@@ -271,8 +271,9 @@ def _add_quantizer_group(quantizer_groups: List[QuantizerGroup], activation_quan
     """
     quantizer_group = QuantizerGroup(parameter_quantizers=parameter_quantizers,
                                      activation_quantizers=activation_quantizers)
-    quantizer_groups.append(quantizer_group)
-    logger.info('Quantizer Group added: %s', quantizer_group)
+    if quantizer_group not in quantizer_groups:
+        quantizer_groups.append(quantizer_group)
+        logger.info('Quantizer Group added: %s', quantizer_group)
 
 
 def _add_input_quantizer_group(op_to_param_dict: Dict, sim: QuantizationSimModel, quantizer_groups: List):


### PR DESCRIPTION
Fixes #3807 

Because of shared tensors, multiple instances of a quantizer-group were getting created. The presence of same group of tensors in different parts of the graph leads to this.

Duplicate quantizer-groups create trouble in tracking the list of disabled quantizers, which further we re-enable. We use quantizer-group (qg) as key in dictionary that holds quantizers that are disabled. The first insert properly adds the quantizers, but after that we override the dict-value to `None` losing track of quantizers ([link](https://github.com/quic/aimet/tree/develop/TrainingExtensions/common/src/python/aimet_common/amp/mixed_precision_algo.py#L338)). And hence, the quantizers in quantizer-groups having duplicates were always disabled after finding the fp32 eval scores and we were not getting their encodings.

Duplicate quantizer-groups was also adding time over-head in accuracy-list computation.