### PR TITLE
Work around spconv bug in latest pytorch

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/custom/custom_modules.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/custom/custom_modules.py
@@ -298,4 +298,4 @@ else:
         :return: Newly created QuantizableSparseSequential
         """
         # pylint: disable=protected-access
-        return QuantizableSparseSequential(module._modules)
+        return QuantizableSparseSequential(**module._modules)


### PR DESCRIPTION
## Problem
spconv has a bug in torch>=2.5.0.
It strictly assumes torch.nn.Module._modules is an OrderedDict, but this is no more true since torch>=2.5.0 (now it's just a plain dict)