### PR TITLE
Fix Adaround caching bug in torch>=2.5

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quant_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quant_analyzer.py
@@ -647,10 +647,12 @@ class QuantAnalyzerBase(ABC):
         batch_index = 0
         for model_inputs in self._unlabeled_dataset_iterable:
             assert isinstance(model_inputs, (torch.Tensor, tuple, list))
-            _, quantized_out_acts = quant_module_collector.collect_inp_out_data(model_inputs,
+            _, quantized_out_acts = quant_module_collector.collect_inp_out_data(args=(model_inputs,),
+                                                                                kwargs={},
                                                                                 collect_input=False,
                                                                                 collect_output=True)
-            _, fp32_out_acts = orig_module_collector.collect_inp_out_data(model_inputs,
+            _, fp32_out_acts = orig_module_collector.collect_inp_out_data(args=(model_inputs,),
+                                                                          kwargs={},
                                                                           collect_input=False,
                                                                           collect_output=True)
             loss += torch.nn.functional.mse_loss(fp32_out_acts, quantized_out_acts).item()

--- a/TrainingExtensions/torch/test/python/test_utils.py
+++ b/TrainingExtensions/torch/test/python/test_utils.py
@@ -288,29 +288,34 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
         model_input = torch.randn(1, 3, 32, 32).to(device=device)
 
         module_data = utils.ModuleData(model, model.conv1)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=False)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=False, collect_output=False)
         self.assertEqual(inp, None)
         self.assertEqual(out, None)
 
         module_data = utils.ModuleData(model, model.conv1)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=False)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=True, collect_output=False)
         self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input.cpu().detach().numpy()))
         self.assertEqual(out, None)
 
         module_data = utils.ModuleData(model, model.conv1)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=False, collect_output=True)
         conv1_out = model.conv1(model_input)
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), conv1_out.cpu().detach().numpy()))
         self.assertEqual(inp, None)
 
         module_data = utils.ModuleData(model, model.conv1)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=True, collect_output=True)
         conv1_out = model.conv1(model_input)
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), conv1_out.cpu().detach().numpy()))
         self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input.cpu().detach().numpy()))
 
         module_data = utils.ModuleData(model, model.fc)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=False, collect_output=True)
         fc_out = model(model_input)
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), fc_out.cpu().detach().numpy()))
         self.assertEqual(inp, None)
@@ -336,24 +341,28 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
             model(*inputs)
 
         module_data = utils.ModuleData(model, model.conv1, forward_fn)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=False)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=True, collect_output=False)
         self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input[0].cpu().detach().numpy()))
         self.assertEqual(out, None)
 
         module_data = utils.ModuleData(model, model.conv1, forward_fn)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=False, collect_output=True)
         conv1_out = model.conv1(model_input[0])
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), conv1_out.cpu().detach().numpy()))
         self.assertEqual(inp, None)
 
         module_data = utils.ModuleData(model, model.conv3, forward_fn)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=True, collect_output=True)
         conv3_out = model.conv3(model_input[1])
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), conv3_out.cpu().detach().numpy()))
         self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input[1].cpu().detach().numpy()))
 
         module_data = utils.ModuleData(model, model.fc, forward_fn)
-        inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                    collect_input=False, collect_output=True)
         fc_out = model(*model_input)
         self.assertTrue(np.array_equal(out.cpu().detach().numpy(), fc_out.cpu().detach().numpy()))
         self.assertEqual(inp, None)
@@ -374,7 +383,8 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
         model.eval()
         input_ids = torch.randint(1000, (10, 128))
         module_data = utils.ModuleData(model, model.linear)
-        inp, out = module_data.collect_inp_out_data(input_ids, collect_input=True, collect_output=True)
+        inp, out = module_data.collect_inp_out_data(args=(input_ids,), kwargs={},
+                                                    collect_input=True, collect_output=True)
         assert torch.equal(inp, model.embedding(input_ids.to(device)))
         assert torch.equal(out, model.linear(model.embedding(input_ids.to(device))))
 
@@ -399,12 +409,14 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
             model_input = torch.randn(1, 3, 32, 32).to(device=device)
 
             module_data = utils.ModuleData(model, model.fc)
-            inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+            inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                        collect_input=False, collect_output=True)
             fc_out = model(model_input)
             self.assertFalse(np.array_equal(out.cpu().detach().numpy(), fc_out.cpu().detach().numpy()))
 
             module_data = utils.ModuleData(model, model.conv1)
-            inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=False)
+            inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                        collect_input=True, collect_output=False)
             self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input.cpu().detach().numpy()))
 
     @pytest.mark.cuda
@@ -418,12 +430,14 @@ class TestTrainingExtensionsUtils(unittest.TestCase):
             model_input = torch.randn(1, 3, 32, 32).to(device=device)
 
             module_data = utils.ModuleData(model, model.fc)
-            inp, out = module_data.collect_inp_out_data(model_input, collect_input=False, collect_output=True)
+            inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                        collect_input=False, collect_output=True)
             fc_out = model(model_input)
             self.assertFalse(np.array_equal(out.cpu().detach().numpy(), fc_out.cpu().detach().numpy()))
 
             module_data = utils.ModuleData(model, model.conv1)
-            inp, out = module_data.collect_inp_out_data(model_input, collect_input=True, collect_output=False)
+            inp, out = module_data.collect_inp_out_data(args=(model_input,), kwargs={},
+                                                        collect_input=True, collect_output=False)
             self.assertTrue(np.array_equal(inp.cpu().detach().numpy(), model_input.cpu().detach().numpy()))
 
     def test_cached_dataset(self):

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -43,10 +43,9 @@ import pytest
 import random
 import numpy as np
 from aimet_common.quantsim_config.utils import get_path_for_per_channel_config
-from aimet_common.defs import QuantizationDataType
+from aimet_common.defs import QuantizationDataType, QuantScheme
 from aimet_torch import onnx_utils
-from aimet_torch.v1.quantsim import load_encodings_to_sim, QuantScheme
-from aimet_torch.v2.quantsim import QuantizationSimModel
+from aimet_torch.v2.quantsim import QuantizationSimModel, load_encodings_to_sim
 from aimet_torch.v2.quantization.encoding_analyzer import PercentileEncodingAnalyzer
 from aimet_torch.v2.quantization.base import QuantizerBase
 from aimet_torch.v2.quantization.affine import AffineQuantizerBase, GroupedBlockQuantizeDequantize, QuantizeDequantize

--- a/TrainingExtensions/torch/test/python/v2/test_adaround.py
+++ b/TrainingExtensions/torch/test/python/v2/test_adaround.py
@@ -51,13 +51,12 @@ from torchvision import models
 from aimet_common.utils import AimetLogger
 from aimet_common.defs import QuantScheme
 from aimet_common.quantsim import calculate_delta_offset
-from aimet_torch.v1.adaround.adaround_wrapper import AdaroundWrapper
 from aimet_torch.utils import create_fake_data_loader, create_rand_tensors_given_shapes, get_device
 from .models_ import test_models
 from aimet_torch._base.adaround.adaround_optimizer import AdaroundOptimizer
-from aimet_torch.v1.adaround.adaround_weight import AdaroundParameters
+from aimet_torch._base.adaround.adaround_weight import AdaroundParameters
 from aimet_torch.v2.quantsim import QuantizationSimModel
-from aimet_torch.v2.adaround import Adaround
+from aimet_torch.v2.adaround import Adaround, AdaroundWrapper
 from aimet_torch.v2.nn import BaseQuantizationMixin
 
 logger = AimetLogger.get_area_logger(AimetLogger.LogAreas.Test)

--- a/TrainingExtensions/torch/test/python/v2/visualization_tools/test_quant_stats_visualization.py
+++ b/TrainingExtensions/torch/test/python/v2/visualization_tools/test_quant_stats_visualization.py
@@ -41,8 +41,8 @@ import os.path
 import torch
 from ...models.test_models import TinyModel
 from ...models.test_models import ModelWithUnusedMatmul
+from aimet_common.defs import QuantScheme
 from aimet_torch.v2.quantsim import QuantizationSimModel
-from aimet_torch.v1.quantsim import QuantScheme
 from aimet_torch.v2.visualization_tools import visualize_stats, visualize_advanced_stats
 from aimet_common.quantsim_config.utils import get_path_for_per_channel_config
 


### PR DESCRIPTION
## Problem
The existing intermediate data caching code was very hacky and doesn't work in torch >= 2.5
https://github.com/quic/aimet/blob/de5c4b505e77f0b39dab25f3aa78b8910a3b7b01/TrainingExtensions/torch/src/python/aimet_torch/utils.py#L912-L914

## Solution
Removed hackiness. Save kwargs directly without assuming anything from the function signature
![image](https://github.com/user-attachments/assets/1c30bdfc-998a-4373-af8c-fb882a893b8e)
