### PR TITLE
Enable input quantizers that take external scalar parameter as input

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/_builder.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/_builder.py
@@ -55,9 +55,6 @@ class _V2LazyQuantizer(LazyQuantizer):
         if not self.enabled:
             return None
 
-        if self.is_const and self.is_parm and self.is_singleton:
-            return None
-
         self._validate_quantizer_properties()
 
         scale_shape = self._get_scale_shape()

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -1152,62 +1152,6 @@ class TestQuantsim:
         with pytest.raises(RuntimeError):
             _ = QuantizationSimModel(model, dummy_input)
 
-    @pytest.mark.parametrize("module_factory", [
-                                lambda: custom.Add(),
-                                lambda: custom.Subtract(),
-                                lambda: custom.Multiply(),
-                                lambda: custom.Divide(), 
-                            ])
-    @pytest.mark.parametrize("input_shape", [tuple(), (1,), (1, 1), (2,), (2, 1)])
-    def test_quantize_constant(self, module_factory, input_shape):
-        """ Test that model input quantizers are enabled correctly when using different constant types """
-        dummy_input = torch.randn(input_shape)
-
-        """
-        Given: A model with constant in buffer
-        When: Instantiate quantsim
-        Then: The input quantizer quantizing buffer constant should be enabled
-        """
-
-        class BufferModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.module = module_factory()
-                self.register_buffer("const", torch.randn(input_shape))
-
-            def forward(self, *inputs):
-                x = self.module(inputs[0], self.const)
-                return x
-
-        model = BufferModel()
-        sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf,
-                                    dummy_input=dummy_input, in_place=True)
-
-        assert sim.model.module.input_quantizers[1] is not None
-
-        """
-        Given: A model with parameter constant
-        When: Instantiate quantsim
-        Then: The input quantizer quantizing parameter constant should be enabled if the constant is not singleton
-        """
-
-        class ParamModel(torch.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.module = module_factory()
-                self.const = torch.nn.Parameter(torch.randn(input_shape))
-
-            def forward(self, *inputs):
-                x = self.module(inputs[0], self.const)
-                return x
-
-        model = ParamModel()
-        sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf,
-                                    dummy_input=dummy_input, in_place=True)
-
-        assert (sim.model.module.input_quantizers[1] is None) == all(dim == 1 for dim in input_shape)
-
-
     def test_quantize_constant_python_float(self):
         """ Test that model input quantizers are enabled correctly when using different constant types """
         dummy_input = torch.randn(2, 1)


### PR DESCRIPTION
## Main Changes
Enabled quantization of input quantizers that take external scalar parameter as input.
This is a very specific edge case usually only observed in MPP models.
```py
class Model(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.p = torch.nn.Parameter(torch.ones(()))
        self.mul = custom.Multiply()

    def forward(self, x):
        # NOTE: The second input quantizer of self.mul will be disabled 
        #        since it takes external scalar parameter as input
        return self.mul(x, self.p) 
```

**NOTE**: Except the edge case explained above, **aimet_torch.v2 has been already simulating quantization of scalar or 1D vector weights** in all the other cases
|                                |        simulated?         |            exported?           |    note   |
|:---------------------:|:----------------------:|:-------------------------:|-------------|
| `nn.BatchNormNd`  |           ✔️                |                  ✔️               |  1D vector weight |
| `nn.PReLU`               |           ✔️                |                  ✔️               | scalar weight         |
| `nn.LayerNorm`        |           ✔️                |                  ✔️               | 1D weight but only supports per-tensor |
| `nn.GroupNorm`      |           ✔️                |                  ✔️               | 1D weight but only supports per-tensor |