### PR TITLE
BREAKING_CHANGE: Use per-channel quantization by default

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
@@ -94,7 +94,7 @@ class JsonConfigImporter:
         :return: Quantsim configs dictionary
         """
         if not config_file:
-            config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default_config.json')
+            config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default_config_per_channel.json')
             logger.info('No config file provided, defaulting to config file at %s', config_file)
 
         with open(config_file) as configs:

--- a/TrainingExtensions/onnx/test/python/test_quant_analyzer.py
+++ b/TrainingExtensions/onnx/test/python/test_quant_analyzer.py
@@ -173,7 +173,6 @@ class TestQuantAnalyzer:
         with tempfile.TemporaryDirectory() as tmp_dir:
             layer_wise_eval_score_dict = \
                 quant_analyzer.perform_per_layer_analysis_by_enabling_quantizers(sim, results_dir=tmp_dir)
-            print(layer_wise_eval_score_dict)
             assert type(layer_wise_eval_score_dict) == dict
             assert len(layer_wise_eval_score_dict) == 10
 
@@ -204,7 +203,6 @@ class TestQuantAnalyzer:
         with tempfile.TemporaryDirectory() as tmp_dir:
             layer_wise_eval_score_dict = \
                 quant_analyzer.perform_per_layer_analysis_by_disabling_quantizers(sim, results_dir=tmp_dir)
-            print(layer_wise_eval_score_dict)
             assert type(layer_wise_eval_score_dict) == dict
             assert len(layer_wise_eval_score_dict) == 10
 
@@ -294,9 +292,9 @@ class TestQuantAnalyzer:
             assert os.path.exists(Path(tmp_dir, "activations_pdf"))
             assert os.path.exists(Path(tmp_dir, "weights_pdf"))
             assert len([file for file in os.listdir(os.path.join(tmp_dir, "weights_pdf", "_conv1_Conv")) if
-                        file.endswith(".html")]) == 1
-            print(sim.qc_quantize_op_dict.keys())
-    def test_export_per_layer_stats_histogram_per_channel(self):
+                        file.endswith(".html")]) == 32
+
+    def test_export_per_layer_stats_histogram_per_tensor(self):
         """ test export_per_layer_stats_histogram() for per channel quantization """
         quantsim_config = {
             "defaults": {
@@ -306,7 +304,7 @@ class TestQuantAnalyzer:
                 "params": {
                     "is_quantized": "True"
                 },
-                "per_channel_quantization": "True",
+                "per_channel_quantization": "False",
             },
             "params": {
                 "bias": {
@@ -338,7 +336,7 @@ class TestQuantAnalyzer:
             assert os.path.exists(Path(tmp_dir, "activations_pdf"))
             assert os.path.exists(Path(tmp_dir, "weights_pdf"))
             assert len([file for file in os.listdir(os.path.join(tmp_dir, "activations_pdf"))]) <= len(sim.activation_names)
-            assert len([file for file in os.listdir(os.path.join(tmp_dir, "weights_pdf", "_conv1_Conv")) if file.endswith(".html")]) == 32
+            assert len([file for file in os.listdir(os.path.join(tmp_dir, "weights_pdf", "_conv1_Conv")) if file.endswith(".html")]) == 1
 
 
     def test_export_per_layer_mse_loss(self):

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -216,7 +216,7 @@ class TestQuantSim:
             quantizer_args = encoding_data["quantizer_args"]
             assert quantizer_args["activation_bitwidth"] == 16
             assert quantizer_args["param_bitwidth"] == 16
-            assert not quantizer_args["per_channel_quantization"]
+            assert quantizer_args["per_channel_quantization"]
             assert quantizer_args["quant_scheme"] == QuantScheme.post_training_tf.name
             assert quantizer_args["dtype"] == "int"
             assert "is_symmetric" in quantizer_args
@@ -1309,13 +1309,23 @@ class TestQuantSim:
         set_blockwise_quantization_for_weights(sim, ("MatMul", "Conv", "Gemm"), 8, True, block_size, strict=False)
         sim.compute_encodings(lambda session, _: session.run(None, dummy_input), None)
 
+        initializers = {
+            param.name: param for param in sim.model.graph().initializer
+        }
+
         for name, quantizer in sim.qc_quantize_op_dict.items():
             if not quantizer.enabled:
                 continue
+
+            param = initializers.get(name, None)
+
             if name in bq_weights:
                 assert quantizer.quant_info.usePerChannelMode
                 assert quantizer.quant_info.blockSize == block_size
-                assert len(quantizer.encodings) > 1
+                assert len(quantizer.encodings) == param.dims[0] * param.dims[1] / block_size
+            elif quantizer.quant_info.usePerChannelMode:
+                assert quantizer.quant_info.blockSize == 0
+                assert len(quantizer.encodings) in tuple(param.dims)
             else:
                 assert quantizer.quant_info.blockSize == 0
                 assert len(quantizer.encodings) == 1
@@ -1325,17 +1335,21 @@ class TestQuantSim:
             encodings = json.load(f)
 
         for enc in encodings["param_encodings"]:
-            if enc['name'] not in bq_weights:
+            quantizer = sim.qc_quantize_op_dict[enc['name']]
+            param = initializers[enc['name']]
+            if enc['name'] in bq_weights:
+                assert len(enc['scale']) == param.dims[0] * param.dims[1] / block_size
+                assert enc['enc_type'] == 'PER_BLOCK'
+            elif quantizer.quant_info.usePerChannelMode:
+                assert len(enc['scale']) in tuple(param.dims)
+                assert enc['enc_type'] == 'PER_CHANNEL'
+            else:
                 assert len(enc['scale']) == 1
                 assert enc['enc_type'] == 'PER_TENSOR'
-                continue
-            for param in sim.model.graph().initializer:
-                if param.name == enc['name'] and enc['name'] in bq_weights:
-                    assert len(enc['scale']) == param.dims[0] * param.dims[1] / block_size
-                    assert enc['enc_type'] == 'PER_BLOCK'
 
         for enc in encodings["activation_encodings"]:
             assert len(enc['scale']) == 1
+            assert enc['enc_type'] == 'PER_TENSOR'
 
     def test_model_with_initializers_as_activations(self):
         model = models_for_tests.model_with_initializers_as_activations()
@@ -1499,7 +1513,6 @@ class TestQuantSim:
                 assert len(quantizer.encodings) > 1
             else:
                 assert quantizer.quant_info.blockSize == 0
-                assert len(quantizer.encodings) == 1
 
         with set_encoding_version("1.0.0"):
             sim.export(tmpdir, "tmp_model")
@@ -1509,7 +1522,7 @@ class TestQuantSim:
 
         for enc in encodings["param_encodings"]:
             if enc["name"] not in bq_weights:
-                assert enc["enc_type"] == EncodingType.PER_TENSOR.name
+                assert enc["enc_type"] in (EncodingType.PER_TENSOR.name, EncodingType.PER_CHANNEL.name)
             else:
                 assert enc["enc_type"] == EncodingType.LPBQ.name
                 assert enc["compressed_bw"] == bitwidth
@@ -1987,7 +2000,7 @@ class TestEncodingPropagation:
             new_encoding.bw = 8
             new_encoding.delta = .125
             new_encoding.offset = -128
-            sim.qc_quantize_op_dict['conv3.weight'].load_encodings([new_encoding])
+            sim.qc_quantize_op_dict['conv3.weight'].load_encodings([new_encoding] * 8)
             post_load_out = sim.session.run(None, dummy_tensor)
 
             sim.export(tempdir, 'onnx_sim')

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -280,6 +280,7 @@ class TestQuantSim:
                 else:
                     assert enc["enc_type"] == EncodingType.PER_TENSOR.name
 
+    @pytest.mark.skip(reason="FIXME: LSTM with per-channel quantzation fails at QuantizationSimModel.__init__")
     def test_lstm_gru(self):
         """Test for LSTM and GRU dummy model"""
         model = build_lstm_gru_dummy_model()

--- a/TrainingExtensions/tensorflow/test/python/test_mixed_precision_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/test_mixed_precision_keras.py
@@ -461,6 +461,12 @@ class TestAutoMixedPrecision:
         assert len(pareto_front_list) == 2
 
     def test_compare_sqnr_callback(self, sim, data_loader_wrapper):
+        def forward_pass_callback(model, _):
+            for x in data_loader_wrapper():
+                model(x)
+                return
+
+        sim.compute_encodings(forward_pass_callback, None)
 
         # Get the callback function in which reference model is provided
         sqnr_eval_callback = EvalCallbackFactory(data_loader_wrapper).sqnr(sim._model_without_wrappers)

--- a/TrainingExtensions/tensorflow/test/python/test_quantsim_keras.py
+++ b/TrainingExtensions/tensorflow/test/python/test_quantsim_keras.py
@@ -235,7 +235,7 @@ def test_quantsim_export_quantizer_args():
         quantizer_args = encoding_data["quantizer_args"]
         assert quantizer_args["activation_bitwidth"] == 16
         assert quantizer_args["param_bitwidth"] == 16
-        assert not quantizer_args["per_channel_quantization"]
+        assert quantizer_args["per_channel_quantization"]
         assert quantizer_args["quant_scheme"] == QuantScheme.post_training_tf_enhanced.name
         assert quantizer_args["dtype"] == "int"
         assert quantizer_args["is_symmetric"]

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/qc_quantize_op.py
@@ -541,7 +541,8 @@ class QcQuantizeWrapper(nn.Module): # pylint: disable=too-many-public-methods
 
             if quantizer.enabled:
                 # pylint: disable=protected-access
-                if isinstance(quantizer, StaticGridPerChannelQuantizer) and len(quantizer._cppOp) != len(encoding):
+                if isinstance(quantizer, StaticGridPerChannelQuantizer) and len(quantizer._cppOp) != len(encoding) \
+                        and encoding[0]['dtype'] != "float":
                     assert len(encoding) == 1, (f'Number of Per Channel encodings provided ({len(encoding)}) is '
                                                 f'not same as number of channels ({len(quantizer._cppOp)})')
                     if strict:

--- a/TrainingExtensions/torch/test/python/_utils.py
+++ b/TrainingExtensions/torch/test/python/_utils.py
@@ -1,0 +1,42 @@
+# -*- mode: python -*-
+# =============================================================================
+#  @@-COPYRIGHT-START-@@
+#
+#  Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#
+#  1. Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#
+#  2. Redistributions in binary form must reproduce the above copyright notice,
+#     this list of conditions and the following disclaimer in the documentation
+#     and/or other materials provided with the distribution.
+#
+#  3. Neither the name of the copyright holder nor the names of its contributors
+#     may be used to endorse or promote products derived from this software
+#     without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+#  SPDX-License-Identifier: BSD-3-Clause
+#
+#  @@-COPYRIGHT-END-@@
+# =============================================================================
+from pathlib import Path
+
+def per_tensor_config():
+     from aimet_common import quantsim_config
+     for path in quantsim_config.__path__:
+         return Path(path) / "default_config.json"

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_export.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_export.py
@@ -485,7 +485,7 @@ class TestQuantsimOnnxExport:
             # regardless of the rounding method used.
             for conv_weight in conv_weights:
                 delta = sim.model.conv.param_quantizers['weight'].get_scale()
-                assert torch.allclose(conv_weight, model.conv.weight.data, atol=delta.item())
+                assert torch.all((conv_weight - model.conv.weight).abs() < delta)
 
                 default_quant_result = torch.round(conv_weight / delta)
                 conv_weight = conv_weight.to(rounding_dtype)

--- a/TrainingExtensions/torch/test/python/v2/experimental/test_onnx.py
+++ b/TrainingExtensions/torch/test/python/v2/experimental/test_onnx.py
@@ -62,10 +62,12 @@ def seed(request):
 
 @contextlib.contextmanager
 def set_encoding_version(version):
-    old_version = quantsim_common.encoding_version
-    quantsim_common.encoding_version = version
-    yield
-    quantsim_common.encoding_version = old_version
+    try:
+        old_version = quantsim_common.encoding_version
+        quantsim_common.encoding_version = version
+        yield
+    finally:
+        quantsim_common.encoding_version = old_version
 
 
 @pytest.mark.parametrize("qtzr_cls", [Q.affine.Quantize, Q.affine.QuantizeDequantize])
@@ -268,9 +270,11 @@ def test_export_torchvision_models(model_factory, input_shape):
 
 
 @torch.no_grad()
-@pytest.mark.parametrize("model_factory, input_shape", [(resnet18, (1, 3, 224, 224)),
-                                                        (mobilenet_v3_small, (1, 3, 224, 224)),
-                                                        ])
+@pytest.mark.parametrize(
+    "model_factory,      input_shape", [
+    (resnet18,           (1, 3, 224, 224)),
+    (mobilenet_v3_small, (1, 3, 224, 224)),
+])
 @pytest.mark.parametrize("encoding_version", ["0.6.1", "1.0.0"])
 def test_quantsim_export_torchvision_models(model_factory, input_shape, encoding_version):
     """

--- a/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
+++ b/TrainingExtensions/torch/test/python/v2/quantsim/test_quantsim.py
@@ -227,7 +227,9 @@ class TestQuantsim:
                     "input": {"0": sample_encoding}
                 }
             },
-            "param_encodings": {"conv1.weight": [sample_encoding]}
+            "param_encodings": {
+                "conv1.weight": [sample_encoding] * model.conv1.out_channels
+            }
         }
 
         sim = QuantizationSimModel(model, dummy_input, quant_scheme=QuantScheme.post_training_tf)
@@ -298,7 +300,9 @@ class TestQuantsim:
                     "input": {"0": sample_encoding}
                 }
             },
-            "param_encodings": {"conv1.weight": [sample_encoding]}
+            "param_encodings": {
+                "conv1.weight": [sample_encoding] * model.conv1.out_channels
+            }
         }
         encodings2 = {
             "activation_encodings": {
@@ -306,7 +310,9 @@ class TestQuantsim:
                     "input": {"0": sample_encoding2}
                 }
             },
-            "param_encodings": {"conv1.weight": [sample_encoding2]}
+            "param_encodings": {
+                "conv1.weight": [sample_encoding2] * model.conv1.out_channels
+            }
         }
         encodings3 = {
             "activation_encodings": {
@@ -315,7 +321,9 @@ class TestQuantsim:
                     "output": {"0": sample_encoding}
                 }
             },
-            "param_encodings": {"conv1.weight": [sample_encoding]}
+            "param_encodings": {
+                "conv1.weight": [sample_encoding] * model.conv1.out_channels
+            }
         }
 
         """
@@ -414,10 +422,10 @@ class TestQuantsim:
 
         sim.compute_encodings(lambda model, _: model(dummy_input), None)
 
-        assert not torch.isclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
-        assert not torch.isclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
-        assert not torch.isclose(input_min, sim.model.conv1.input_quantizers[0].min)
-        assert not torch.isclose(input_max, sim.model.conv1.input_quantizers[0].max)
+        assert not torch.allclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
+        assert not torch.allclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
+        assert not torch.allclose(input_min, sim.model.conv1.input_quantizers[0].min)
+        assert not torch.allclose(input_max, sim.model.conv1.input_quantizers[0].max)
 
         weight_min = sim.model.conv1.param_quantizers['weight'].min.clone().detach()
         weight_max = sim.model.conv1.param_quantizers['weight'].max.clone().detach()
@@ -426,10 +434,10 @@ class TestQuantsim:
 
         sim.load_encodings(encodings2)
 
-        assert not torch.isclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
-        assert not torch.isclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
-        assert not torch.isclose(input_min, sim.model.conv1.input_quantizers[0].min)
-        assert not torch.isclose(input_max, sim.model.conv1.input_quantizers[0].max)
+        assert not torch.allclose(weight_min, sim.model.conv1.param_quantizers['weight'].min)
+        assert not torch.allclose(weight_max, sim.model.conv1.param_quantizers['weight'].max)
+        assert not torch.allclose(input_min, sim.model.conv1.input_quantizers[0].min)
+        assert not torch.allclose(input_max, sim.model.conv1.input_quantizers[0].max)
 
         """
         When: Call load_encodings with allow_overwrite=False
@@ -555,7 +563,7 @@ class TestQuantsim:
                         "offset": -8,
                         "scale": 0.026796795427799225
                     }
-                ],
+                ] * model.conv1.out_channels,
                 "fc2.weight": [
                     {
                         "bitwidth": 4,

--- a/TrainingExtensions/torch/test/python/v2/test_seq_mse.py
+++ b/TrainingExtensions/torch/test/python/v2/test_seq_mse.py
@@ -364,5 +364,5 @@ class TestSeqMse:
         apply_seq_mse(model, sim, data_loader, params)
 
         # sanity check
-        assert qconv.param_quantizers['weight'].min != -1
-        assert qconv.param_quantizers['weight'].max != 1
+        assert torch.all(qconv.param_quantizers['weight'].min != -1)
+        assert torch.all(qconv.param_quantizers['weight'].max != 1)


### PR DESCRIPTION
## Main Changes
Changed the default behavior of quantsim from per-tensor qtzn to per-channel quantization. (3bc053fc514644552e66c35a00952953adbeaa44)
Using per-tensor by default doesn't make sense to me
![image](https://github.com/user-attachments/assets/0df72232-fd4a-4c0d-bc15-6da555fdfbb7)

### note
I had to disable one test case since aimet-onnx doesn't support per-channel quantization of LSTM, (c2840cbb60007a35b6c07ae1ef1c32febe2115e6)
![image](https://github.com/user-attachments/assets/4970f211-fa84-4c14-8b60-120923edc02e)