### PR TITLE
Make QuantizedEmbedding's output inherit weight encodings

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -38,8 +38,11 @@
 
 import abc
 import copy
+import functools
+from itertools import repeat
 
 import torch
+import torch.nn.functional as F
 from torch.utils._pytree import tree_map
 
 from aimet_torch.v2.quantization.base import EncodingBase
@@ -54,10 +57,81 @@ def implements(torch_function):
     Register an override for QuantizedTensorBase
     """
     def decorator(func):
-        HANDLED_FUNCTIONS[torch_function] = func
-        return func
+        @functools.wraps(func)
+        def wrapped_func(*args, **kwargs):
+            original = HANDLED_FUNCTIONS.pop(torch_function, None)
+
+            try:
+                return func(*args, **kwargs)
+            finally:
+                if original:
+                    HANDLED_FUNCTIONS[torch_function] = original
+
+        HANDLED_FUNCTIONS[torch_function] = wrapped_func
+        return wrapped_func
 
     return decorator
+
+
+@implements(F.embedding)
+def _embedding(input: torch.Tensor, weight: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+    # pylint: disable=protected-access, redefined-builtin, import-outside-toplevel
+    from .affine import AffineEncoding
+
+    out = F.embedding(input, weight, *args, **kwargs)
+
+    if not isinstance(weight, QuantizedTensorBase):
+        return out
+
+    out = out.as_subclass(type(weight))
+    out.encoding = weight.encoding._clone() if weight.encoding else None
+
+    if not isinstance(out.encoding, AffineEncoding):
+        return out
+
+    out_scale = out.encoding.scale
+    out_offset = out.encoding.offset
+    blk_0, blk_1 = out.encoding.block_size or (-1, -1)
+
+    if blk_0 == -1:
+        blk_0 = weight.shape[0] // (out_scale.shape[0] if out_scale.shape != () else 1)
+
+    if blk_0 == weight.shape[0]:
+        # Edge case:
+        # block_size in axis 0 is equal to weight dim 0.
+        # Output can safely inherit weight encoding
+        # since F.embedding only selects weights along axis 0.
+
+        # In practice, this means one of the following
+        #   * Per-tensor quantization
+        #   * Per-channel quantization with axis=1
+        while out_scale.dim() > out.dim():
+            out_scale.squeeze_(0)
+
+        while out_offset.dim() > out.dim():
+            out_offset.squeeze_(0)
+    else:
+        # Common case:
+        # block_size in axis 0 is different from weight dim 0.
+        # Output scale & offset also needs to be selected by indices along axis 0
+
+        # In practice, this means one of the following
+        #   * Per-channel quantization with axis=0
+        #   * Per-block quantization
+        input = input // blk_0
+        out_scale = F.embedding(input, out_scale, *args, **kwargs)
+        out_offset = F.embedding(input, out_offset, *args, **kwargs)
+
+    # NOTE: output tensor can't inherit blk_0 since F.embedding has dismantled axis 0
+    out_block_size = (*repeat(-1, out_scale.dim()-1), blk_1) if out_scale.dim() > 0 else None
+
+    out.encoding = AffineEncoding(scale=out_scale,
+                                  offset=out_offset,
+                                  qmin=out.encoding.qmin,
+                                  qmax=out.encoding.qmax,
+                                  symmetry=out.encoding.symmetry,
+                                  block_size=out_block_size)
+    return out
 
 
 class QuantizedTensorBase(torch.Tensor):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/tensor.py
@@ -91,10 +91,10 @@ def _embedding(input: torch.Tensor, weight: torch.Tensor, *args, **kwargs) -> to
 
     out_scale = out.encoding.scale
     out_offset = out.encoding.offset
-    blk_0, blk_1 = out.encoding.block_size or (-1, -1)
+    blk_0, *blk_1 = out.encoding.block_size or (-1, -1)
 
     if blk_0 == -1:
-        blk_0 = weight.shape[0] // (out_scale.shape[0] if out_scale.shape != () else 1)
+        blk_0 = weight.shape[0] // (out_scale.shape[0] if out_scale.dim() == weight.dim() else 1)
 
     if blk_0 == weight.shape[0]:
         # Edge case:
@@ -123,7 +123,7 @@ def _embedding(input: torch.Tensor, weight: torch.Tensor, *args, **kwargs) -> to
         out_offset = F.embedding(input, out_offset, *args, **kwargs)
 
     # NOTE: output tensor can't inherit blk_0 since F.embedding has dismantled axis 0
-    out_block_size = (*repeat(-1, out_scale.dim()-1), blk_1) if out_scale.dim() > 0 else None
+    out_block_size = (*repeat(-1, out_scale.dim()-1), *blk_1) if out_scale.dim() > 0 else None
 
     out.encoding = AffineEncoding(scale=out_scale,
                                   offset=out_offset,

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -1113,6 +1113,8 @@ def test_subclassing():
     ((),           None),    # per-tensor
     ((10, 1),      None),    # per-channel with axis=0
     ((1, 10),      None),    # per-channel with axis=1
+    ((10,),        None),    # per-channel with axis=1
+    ((10,),        (-1,)),   # per-channel with axis=1
     ((10, 2),      (-1, 5)), # per-block with channel_axis=0, block_axis=1
     ((2, 10),      (5, -1)), # per-block with channel_axis=1, block_axis=0
 ])

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -59,6 +59,7 @@ from aimet_torch.v2.nn import (
     QuantizedConvTranspose1d,
     QuantizedConvTranspose2d,
     QuantizedConvTranspose3d,
+    QuantizedEmbedding,
     QuantizedGELU,
     QuantizedLinear,
     QuantizationMixin,
@@ -1100,3 +1101,41 @@ def test_subclassing():
     my_qlinear.bias.copy_(qlinear.bias)
 
     assert torch.equal(qlinear(x), my_qlinear(x))
+
+
+@pytest.mark.parametrize("indices", [
+    torch.tensor(2),                      # scalar index
+    torch.tensor([0, 1, 3, 5, 7, 9]),     # 1D indices
+    torch.tensor([[1, 3, 5], [8, 6, 4]]), # 2D indices
+])
+@pytest.mark.parametrize(
+    "scale_shape,  block_size", [
+    ((),           None),    # per-tensor
+    ((10, 1),      None),    # per-channel with axis=0
+    ((1, 10),      None),    # per-channel with axis=1
+    ((10, 2),      (-1, 5)), # per-block with channel_axis=0, block_axis=1
+    ((2, 10),      (5, -1)), # per-block with channel_axis=1, block_axis=0
+])
+def test_qembedding_output_encoding(scale_shape, block_size, indices):
+    """
+    Given: QuantizedEmbedding with weight-only quantization
+    """
+    qembedding = QuantizedEmbedding(10, 10)
+    weight_qtzr = QuantizeDequantize(scale_shape,
+                                     qmin=-128,
+                                     qmax=127,
+                                     symmetric=True,
+                                     block_size=block_size)
+    qembedding.param_quantizers['weight'] = weight_qtzr
+    qembedding.compute_param_encodings()
+
+    """
+    When: Run forward
+    Then: Output should inherit the weight encodings
+    """
+    qout = qembedding(indices)
+    qweight = weight_qtzr(qembedding.weight)
+
+    assert isinstance(qout, DequantizedTensor)
+    assert torch.equal(qout, qweight[indices])
+    assert torch.equal(qout.quantize(), qweight.quantize()[indices])


### PR DESCRIPTION
fixes #4262 

## Problem
In weight-only quantization, output of `QuantizedEmbedding` is not a quantized tensor.
This itself isn't necessarily a bug, but it's a good-to-have feature, and QuantizedEmbedding is too important to not handle perfectly

## Main Changes
Added special encoding inheritance logic for `QuantizedEmbedding`.


