### PR TITLE
Fix LPBQ output dtype bug

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -480,14 +480,14 @@ class GroupedBlockEncoding(AffineEncoding):
         symmetry=False,
         block_size: Optional[Tuple[int, ...]] = None,
         block_grouping: Optional[Tuple[int, ...]] = None,
-        decompressed_bw: Optional[int] = None,
+        compressed_bw: Optional[int] = None,
         per_channel_scale: Optional[torch.Tensor] = None,
         per_block_int_scale: Optional[torch.Tensor] = None,
         **kwargs,
     ):
         super().__init__(scale, offset, bitwidth, signed, symmetry, block_size, **kwargs)
         self.block_grouping = block_grouping
-        self.decompressed_bw = decompressed_bw
+        self.compressed_bw = compressed_bw
         self.per_channel_scale = per_channel_scale
         self.per_block_int_scale = per_block_int_scale
 
@@ -502,17 +502,11 @@ class GroupedBlockEncoding(AffineEncoding):
             # Equivalent to AffineEncoding
             pass
         else:
-            encoding_dict['bw'] = self.decompressed_bw
-            encoding_dict['compressed_bw'] = self.bitwidth
+            encoding_dict['bw'] = self.bitwidth
+            encoding_dict['compressed_bw'] = self.compressed_bw
             encoding_dict['scale'] = self.per_channel_scale.flatten().tolist()
             encoding_dict['offset'] = \
-                [-2 ** (self.decompressed_bw - 1) for _ in encoding_dict['scale']]
+                [-2 ** (self.bitwidth - 1) for _ in encoding_dict['scale']]
             encoding_dict['enc_type'] = EncodingType.LPBQ.name
             encoding_dict['per_block_int_scale'] = self.per_block_int_scale.flatten().tolist()
         return encoding_dict
-
-    def quantize(self, input: torch.Tensor) -> torch.Tensor:
-        raise NotImplementedError
-
-    def dequantize(self, input: torch.Tensor) -> torch.Tensor:
-        raise NotImplementedError

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/quantizer.py
@@ -831,12 +831,12 @@ class GroupedBlockQuantizeDequantize(QuantizeDequantize): # pylint: disable=too-
         if self.is_initialized():
             return GroupedBlockEncoding(scale=self.get_scale(dtype=torch.float32),
                                         offset=self.get_offset(dtype=torch.float32),
-                                        bitwidth=self.bitwidth,
+                                        bitwidth=self.decompressed_bw,
                                         signed=self.signed,
                                         symmetry=self.symmetric,
                                         block_size=self.block_size,
                                         block_grouping=self.block_grouping,
-                                        decompressed_bw=self.decompressed_bw,
+                                        compressed_bw=self.bitwidth,
                                         per_channel_scale=self.get_per_channel_scale(dtype=torch.float32),
                                         per_block_int_scale=self.get_per_block_integer_scale())
         return None

--- a/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/quantization/affine/test_affine_quantizer.py
@@ -675,18 +675,18 @@ def test_asymmetric_learning(q, x, optim_cls):
     assert not torch.equal(q.get_offset(), original_offset)
 
 def test_extreme_values_warning():
-        extreme_val = torch.finfo(torch.float16).max
-        dummy_input = torch.arange(start = 0, end=extreme_val, dtype=torch.float16)        
-        param_shape = (1,)
-        encoding_shape = (1,)
-        qdq = QuantizeDequantize(param_shape, 8, True, MinMaxEncodingAnalyzer(encoding_shape))
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            with qdq.compute_encodings():
-                qdq(dummy_input)
-            assert len(w) == 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "Extreme values" in str(w[-1].message)
+    extreme_val = torch.finfo(torch.float16).max
+    dummy_input = torch.arange(start = 0, end=extreme_val, dtype=torch.float16)
+    param_shape = (1,)
+    encoding_shape = (1,)
+    qdq = QuantizeDequantize(param_shape, 8, True, MinMaxEncodingAnalyzer(encoding_shape))
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        with qdq.compute_encodings():
+            qdq(dummy_input)
+        assert len(w) == 1
+        assert issubclass(w[-1].category, UserWarning)
+        assert "Extreme values" in str(w[-1].message)
 
 def test_invalid_encoding_analyzer():
     """
@@ -1015,6 +1015,9 @@ def test_quantized_tensor_with_block_size():
     assert torch.equal(q.dequantize(), affine.dequantize(q, bq.get_scale(), bq.get_offset(), bq.block_size))
 
 def test_gbbq_sanity():
+    """
+    Given: LPBQ quantizer with compressed_bw=4, decompressed_bw=8
+    """
     tensor = torch.randn(8, 12)
     gbbq = GroupedBlockQuantizeDequantize(shape=(8, 4),
                                           bitwidth=4,
@@ -1026,6 +1029,9 @@ def test_gbbq_sanity():
                             bitwidth=4,
                             symmetric=True)
 
+    """
+    When: Compute encodings
+    """
     with gbbq.compute_encodings():
         _ = gbbq(tensor)
 
@@ -1034,10 +1040,32 @@ def test_gbbq_sanity():
 
     assert gbbq.get_scale().shape == (8, 4)
 
-    # The largest scale for any given channel GBBQ should equal the scale for per channel
+    """
+    Then: The largest scale for any given channel GBBQ should equal the scale for per channel
+    """
     assert torch.equal(torch.amax(gbbq.get_scale(), dim=1, keepdim=True), pc.get_scale())
 
-    assert not torch.equal(gbbq(tensor), pc(tensor))
+    """
+    When: Run forward
+    """
+    gbbq_out = gbbq(tensor)
+    pcq_out = pc(tensor)
+
+    """
+    Then (1): Output shouldn't be equal to per-channel quantization
+    """
+    assert not torch.equal(gbbq_out, pcq_out)
+
+    """
+    Then (2): Output should be an 8-bit tensor, NOT a 4-bit tensor
+    """
+    assert gbbq_out.encoding.bitwidth == 8
+    assert torch.all((-128 <= gbbq_out.quantize()) & (gbbq_out.quantize() < 128))
+
+    """
+    Then (3): output.quantize().dequantze() should be no-op
+    """
+    assert torch.equal(gbbq_out.quantize().dequantize(), gbbq_out)
 
 @pytest.mark.parametrize('bitwidth, decompressed_bw', [[4, 8], [4, 16], [4, 12], [3, 5], [5, 9], [6, 6]])
 def test_gbbq_per_block_sanity(bitwidth, decompressed_bw):


### PR DESCRIPTION
## Problem
LPBQ quantizer was returning wrong output dtype.

### Minimal reproducible example
```py
import torch
from aimet_torch.quantization.affine import GroupedBlockQuantizeDequantize

x = torch.randn(10, 10)
qtzr = GroupedBlockQuantizeDequantize(shape=(10, 5),
                                      bitwidth=4,
                                      symmetric=True,
                                      decompressed_bw=8,
                                      block_size=(1, 2),
                                      block_grouping=(1, 5))

with qtzr.compute_encodings():
    _ = qtzr(x)

out = qtzr(x)
assert out.encoding.bitwidth == 8
```