### PR TITLE
Export bias encodings in sim.onnx.export

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -47,6 +47,7 @@ from torch import nn
 
 from aimet_torch.utils import is_vector_encoding
 from aimet_torch.v2.quantization.affine.encoding import VectorEncoding, AffineEncoding
+from aimet_torch.v2.quantization.affine import QuantizeDequantize
 
 from aimet_torch.v2.quantization.tensor import QuantizedTensorBase
 from aimet_torch.v2.quantization.base import QuantizerBase
@@ -686,6 +687,49 @@ class BaseQuantizationMixin(abc.ABC):
         ctx_2 = self._remove_param_quantizers()
         return _ContextManager(action=lambda: None,
                                cleanup=lambda: (ctx_1._cleanup(), ctx_2._cleanup()))
+
+    def _create_int32_bias_quantizer(self, input, _): # pylint: disable=redefined-builtin
+        assert hasattr(self, "bias")
+        bias = self.bias
+        qmin = -2**31
+        qmax = 2**31 - 1
+        bias_qtzr = QuantizeDequantize(shape=bias.shape,
+                                       qmin=qmin,
+                                       qmax=qmax,
+                                       symmetric=True)
+        bias_qtzr.to(dtype=bias.dtype, device=bias.device)
+        self.param_quantizers["bias"] = bias_qtzr
+
+        input, = input
+
+        if self.param_quantizers["weight"]:
+            weight_scale = self.param_quantizers["weight"].get_scale()
+        else:
+            weight_scale = None
+
+        if self.input_quantizers[0]:
+            input_scale = self.input_quantizers[0].get_scale()
+        elif isinstance(input, QuantizedTensorBase) and isinstance(input.encoding, AffineEncoding):
+            input_scale = input.encoding.scale
+        else:
+            input_scale = None
+
+        try:
+            bias_scale = self._derive_bias_scale(input_scale, weight_scale)
+        except NotImplementedError:
+            bias_scale = None
+
+        if bias_scale is not None:
+            bias_qtzr.set_range(bias_scale * qmin, bias_scale * qmax)
+
+        if not bias_qtzr.is_initialized():
+            # Compute bias scale without input and weight scale.
+            # This should be avoided as much as possible
+            with bias_qtzr.compute_encodings():
+                _ = bias_qtzr(bias)
+
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        raise NotImplementedError
 
 
 def _remove_quantizers(quantizers, keys):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -690,6 +690,8 @@ class BaseQuantizationMixin(abc.ABC):
 
     def _create_int32_bias_quantizer(self, input, _): # pylint: disable=redefined-builtin
         assert hasattr(self, "bias")
+        assert isinstance(self.bias, torch.Tensor)
+
         bias = self.bias
         qmin = -2**31
         qmax = 2**31 - 1

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -700,19 +700,19 @@ class BaseQuantizationMixin(abc.ABC):
         bias_qtzr.to(dtype=bias.dtype, device=bias.device)
         self.param_quantizers["bias"] = bias_qtzr
 
-        input, = input
-
         if self.param_quantizers["weight"]:
             weight_scale = self.param_quantizers["weight"].get_scale()
         else:
             weight_scale = None
 
-        if self.input_quantizers[0]:
-            input_scale = self.input_quantizers[0].get_scale()
-        elif isinstance(input, QuantizedTensorBase) and isinstance(input.encoding, AffineEncoding):
-            input_scale = input.encoding.scale
-        else:
-            input_scale = None
+        input_scale = None
+
+        if len(input) == 1:
+            input, = input
+            if self.input_quantizers[0]:
+                input_scale = self.input_quantizers[0].get_scale()
+            elif isinstance(input, QuantizedTensorBase) and isinstance(input.encoding, AffineEncoding):
+                input_scale = input.encoding.scale
 
         try:
             bias_scale = self._derive_bias_scale(input_scale, weight_scale)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
@@ -545,6 +545,7 @@ def _generate_docstring(parent_cls):
 
 def _derive_bias_scale(input_scale: Optional[torch.Tensor],
                        weight_scale: Optional[torch.Tensor],
+                       bias_shape: torch.Size,
                        channel_axis: int):
     if input_scale is None or weight_scale is None:
         return None
@@ -563,7 +564,12 @@ def _derive_bias_scale(input_scale: Optional[torch.Tensor],
     non_channel_axes = tuple(axis for axis in range(bias_scale.dim()) if axis != channel_axis)
     bias_scale = torch.amax(bias_scale, dim=non_channel_axes)
 
-    return bias_scale
+    if bias_scale.shape in ((), bias_shape):
+        return bias_scale
+
+    # This means channel_axis != output channel axis.
+    # In this case, do not derive bias encoding from input and weight encodings
+    return None
 
 
 @QuantizationMixin.implements(nn.AdaptiveAvgPool1d)
@@ -785,7 +791,7 @@ class QuantizedConv1d(_DispatchMixin, QuantizationMixin, nn.Conv1d):  # pylint: 
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.Conv2d)
@@ -796,7 +802,7 @@ class QuantizedConv2d(_DispatchMixin, QuantizationMixin, nn.Conv2d):  # pylint: 
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.Conv3d)
@@ -807,7 +813,7 @@ class QuantizedConv3d(_DispatchMixin, QuantizationMixin, nn.Conv3d):  # pylint: 
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.ConvTranspose1d)
@@ -818,7 +824,7 @@ class QuantizedConvTranspose1d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=1)
 
 
 @QuantizationMixin.implements(nn.ConvTranspose2d)
@@ -829,7 +835,7 @@ class QuantizedConvTranspose2d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=1)
 
 
 @QuantizationMixin.implements(nn.ConvTranspose3d)
@@ -840,7 +846,7 @@ class QuantizedConvTranspose3d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     __quant_init__ = QuantizationMixin.__unary__
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=1)
 
 
 @QuantizationMixin.implements(nn.CosineEmbeddingLoss)
@@ -1466,7 +1472,7 @@ class QuantizedLinear(_DispatchMixin, QuantizationMixin, nn.Linear):
             return super().forward(*args, **kwargs)
 
     def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
-        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+        return _derive_bias_scale(input_scale, weight_scale, self.bias.shape, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.LocalResponseNorm)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/true_quant.py
@@ -542,6 +542,30 @@ def _generate_docstring(parent_cls):
         For more information, see :class:`QuantizationMixin`.
     """
 
+
+def _derive_bias_scale(input_scale: Optional[torch.Tensor],
+                       weight_scale: Optional[torch.Tensor],
+                       channel_axis: int):
+    if input_scale is None or weight_scale is None:
+        return None
+
+    bias_scale = input_scale.detach() * weight_scale.detach()
+
+    # bias_scale.shape is not yet compatible with bias.shape due to one of the following reasons:
+    #
+    # 1. trivial reason (per-channel quantization):
+    #      weight_scale and bias_scale are of shape [Cout, 1, 1, 1]
+    #
+    # 2. non-trivial reason (blockwise quantization):
+    #      weight_scale and bias_scale are of shape [Cout, NUM_BLOCKS, 1, 1]
+    #
+    # In any case, we need to reduce bias_scale into a 1D vector of the same shape as bias (=[Cout])
+    non_channel_axes = tuple(axis for axis in range(bias_scale.dim()) if axis != channel_axis)
+    bias_scale = torch.amax(bias_scale, dim=non_channel_axes)
+
+    return bias_scale
+
+
 @QuantizationMixin.implements(nn.AdaptiveAvgPool1d)
 class QuantizedAdaptiveAvgPool1d(_DispatchMixin, QuantizationMixin, nn.AdaptiveAvgPool1d):
     # pylint: disable=missing-class-docstring
@@ -760,6 +784,9 @@ class QuantizedConv1d(_DispatchMixin, QuantizationMixin, nn.Conv1d):  # pylint: 
     _builtin_torch_fn = F.conv1d
     __quant_init__ = QuantizationMixin.__unary__
 
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+
 
 @QuantizationMixin.implements(nn.Conv2d)
 class QuantizedConv2d(_DispatchMixin, QuantizationMixin, nn.Conv2d):  # pylint: disable=too-many-ancestors
@@ -767,6 +794,9 @@ class QuantizedConv2d(_DispatchMixin, QuantizationMixin, nn.Conv2d):  # pylint: 
     __doc__ = _generate_docstring(parent_cls=nn.Conv2d)
     _builtin_torch_fn = F.conv2d
     __quant_init__ = QuantizationMixin.__unary__
+
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.Conv3d)
@@ -776,6 +806,9 @@ class QuantizedConv3d(_DispatchMixin, QuantizationMixin, nn.Conv3d):  # pylint: 
     _builtin_torch_fn = F.conv3d
     __quant_init__ = QuantizationMixin.__unary__
 
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
+
 
 @QuantizationMixin.implements(nn.ConvTranspose1d)
 class QuantizedConvTranspose1d(_DispatchMixin, QuantizationMixin, nn.ConvTranspose1d): # pylint: disable=too-many-ancestors
@@ -783,6 +816,9 @@ class QuantizedConvTranspose1d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     __doc__ = _generate_docstring(parent_cls=nn.ConvTranspose1d)
     _builtin_torch_fn = F.conv_transpose1d
     __quant_init__ = QuantizationMixin.__unary__
+
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
 
 
 @QuantizationMixin.implements(nn.ConvTranspose2d)
@@ -792,6 +828,9 @@ class QuantizedConvTranspose2d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     _builtin_torch_fn = F.conv_transpose2d
     __quant_init__ = QuantizationMixin.__unary__
 
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
+
 
 @QuantizationMixin.implements(nn.ConvTranspose3d)
 class QuantizedConvTranspose3d(_DispatchMixin, QuantizationMixin, nn.ConvTranspose3d): # pylint: disable=too-many-ancestors
@@ -799,6 +838,9 @@ class QuantizedConvTranspose3d(_DispatchMixin, QuantizationMixin, nn.ConvTranspo
     __doc__ = _generate_docstring(parent_cls=nn.ConvTranspose3d)
     _builtin_torch_fn = F.conv_transpose3d
     __quant_init__ = QuantizationMixin.__unary__
+
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=1)
 
 
 @QuantizationMixin.implements(nn.CosineEmbeddingLoss)
@@ -1422,6 +1464,9 @@ class QuantizedLinear(_DispatchMixin, QuantizationMixin, nn.Linear):
         # before running forward.
         with patch_attr(F, 'linear', type(self)._builtin_torch_fn):
             return super().forward(*args, **kwargs)
+
+    def _derive_bias_scale(self, input_scale: Optional[torch.Tensor], weight_scale: Optional[torch.Tensor]):
+        return _derive_bias_scale(input_scale, weight_scale, channel_axis=0)
 
 
 @QuantizationMixin.implements(nn.LocalResponseNorm)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -65,11 +65,10 @@ from aimet_torch.v2 import nn as aimet_nn
 from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin, UnknownModuleError
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
 from aimet_torch.v2._builder import _V2LazyQuantizeWrapper
-from aimet_torch.v2.quantization import QuantizedTensorBase
 from aimet_torch.v2.quantization.base import QuantizerBase
-from aimet_torch.v2.quantization.affine import AffineQuantizerBase, QuantizeDequantize, AffineEncoding
+from aimet_torch.v2.quantization.affine import AffineQuantizerBase
 from aimet_torch.v2.quantization.encoding_analyzer import PercentileEncodingAnalyzer
-from aimet_torch.v2.utils import patch_attr, _is_expandable
+from aimet_torch.v2.utils import patch_attr
 from aimet_torch import utils
 from aimet_torch.utils import deprecated, _red
 from aimet_torch.v2.deepspeed_utils import _register_zero3_forward_hooks
@@ -594,48 +593,6 @@ class QuantizationSimModel(_QuantizationSimModelBase):
 
     @contextlib.contextmanager
     def _concretize_int32_bias_quantizers(self, args):
-        def create_bias_quantizer(module, input, _): # pylint: disable=redefined-builtin
-            input, = input
-
-            if module.param_quantizers["weight"]:
-                weight_scale = module.param_quantizers["weight"].get_scale()
-            else:
-                weight_scale = None
-
-            if module.input_quantizers[0]:
-                input_scale = module.input_quantizers[0].get_scale()
-            elif isinstance(input, QuantizedTensorBase) and isinstance(input.encoding, AffineEncoding):
-                input_scale = input.encoding.scale
-            else:
-                input_scale = None
-
-            bias = module.bias
-            qmin = -2**31
-            qmax = 2**31 - 1
-            bias_qtzr = QuantizeDequantize(shape=bias.shape,
-                                           qmin=qmin,
-                                           qmax=qmax,
-                                           symmetric=True)
-            bias_qtzr.to(dtype=bias.dtype, device=bias.device)
-            module.param_quantizers["bias"] = bias_qtzr
-
-            if weight_scale is not None and input_scale is not None:
-                # Happy case: Can derive bias scale from input and weight scale
-                bias_scale = input_scale.detach() * weight_scale.detach()
-
-                # bias_scale.shape may not be always compatible with bias.shape,
-                # for example when weight quantizer is a blockwise quantizer
-                if bias_scale.numel() == bias.numel():
-                    bias_scale = bias_scale.view(bias.shape)
-
-                if _is_expandable(bias_scale.shape, bias.shape):
-                    bias_qtzr.set_range(bias_scale * qmin, bias_scale * qmax)
-
-            if not bias_qtzr.is_initialized():
-                # Compute bias scale without input and weight scale.
-                # This should be avoided as much as possible
-                module._compute_param_encodings(overwrite=False) # pylint: disable=protected-access
-
         if not isinstance(args, (tuple, list)):
             args = (args,)
 
@@ -654,7 +611,9 @@ class QuantizationSimModel(_QuantizationSimModelBase):
                     # In this case, we honor the custom bias quantizer defined by the user
                     continue
 
-                handles.append(qmodule.register_forward_hook(create_bias_quantizer))
+                # pylint: disable=protected-access
+                handle = qmodule.register_forward_hook(type(qmodule)._create_int32_bias_quantizer)
+                handles.append(handle)
             try:
                 self.model(*args)
             finally:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -600,7 +600,7 @@ class QuantizationSimModel(_QuantizationSimModelBase):
         orig_bias_quantizers = {
             qmodule: qmodule.param_quantizers["bias"]
             for qmodule in self.qmodules()
-            if "bias" in qmodule.param_quantizers
+            if "bias" in qmodule.param_quantizers and qmodule.bias is not None
         }
 
         try:

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -65,10 +65,11 @@ from aimet_torch.v2 import nn as aimet_nn
 from aimet_torch.v2.nn import BaseQuantizationMixin, QuantizationMixin, UnknownModuleError
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
 from aimet_torch.v2._builder import _V2LazyQuantizeWrapper
+from aimet_torch.v2.quantization import QuantizedTensorBase
 from aimet_torch.v2.quantization.base import QuantizerBase
-from aimet_torch.v2.quantization.affine import AffineQuantizerBase
+from aimet_torch.v2.quantization.affine import AffineQuantizerBase, QuantizeDequantize, AffineEncoding
 from aimet_torch.v2.quantization.encoding_analyzer import PercentileEncodingAnalyzer
-from aimet_torch.v2.utils import patch_attr
+from aimet_torch.v2.utils import patch_attr, _is_expandable
 from aimet_torch import utils
 from aimet_torch.utils import deprecated, _red
 from aimet_torch.v2.deepspeed_utils import _register_zero3_forward_hooks
@@ -442,6 +443,8 @@ class QuantizationSimModel(_QuantizationSimModelBase):
                     with utils.in_eval_mode(self.model), torch.no_grad():
                         _ = self.model(*dummy_input)
 
+                # TODO
+                # stack.enter_context(self._concretize_int32_bias_quantizers(dummy_input))
                 return super().export(path, filename_prefix, dummy_input, *args, **kwargs)
 
         finally:
@@ -589,6 +592,80 @@ class QuantizationSimModel(_QuantizationSimModelBase):
             if not utils.is_leaf_module(module):
                 cls._remove_quantization_wrappers(module, list_of_modules_to_exclude)
 
+    @contextlib.contextmanager
+    def _concretize_int32_bias_quantizers(self, args):
+        def create_bias_quantizer(module, input, _): # pylint: disable=redefined-builtin
+            input, = input
+
+            if module.param_quantizers["weight"]:
+                weight_scale = module.param_quantizers["weight"].get_scale()
+            else:
+                weight_scale = None
+
+            if module.input_quantizers[0]:
+                input_scale = module.input_quantizers[0].get_scale()
+            elif isinstance(input, QuantizedTensorBase) and isinstance(input.encoding, AffineEncoding):
+                input_scale = input.encoding.scale
+            else:
+                input_scale = None
+
+            bias = module.bias
+            qmin = -2**31
+            qmax = 2**31 - 1
+            bias_qtzr = QuantizeDequantize(shape=bias.shape,
+                                           qmin=qmin,
+                                           qmax=qmax,
+                                           symmetric=True)
+            bias_qtzr.to(dtype=bias.dtype, device=bias.device)
+            module.param_quantizers["bias"] = bias_qtzr
+
+            if weight_scale is not None and input_scale is not None:
+                # Happy case: Can derive bias scale from input and weight scale
+                bias_scale = input_scale.detach() * weight_scale.detach()
+
+                # bias_scale.shape may not be always compatible with bias.shape,
+                # for example when weight quantizer is a blockwise quantizer
+                if bias_scale.numel() == bias.numel():
+                    bias_scale = bias_scale.view(bias.shape)
+
+                if _is_expandable(bias_scale.shape, bias.shape):
+                    bias_qtzr.set_range(bias_scale * qmin, bias_scale * qmax)
+
+            if not bias_qtzr.is_initialized():
+                # Compute bias scale without input and weight scale.
+                # This should be avoided as much as possible
+                module._compute_param_encodings(overwrite=False) # pylint: disable=protected-access
+
+        if not isinstance(args, (tuple, list)):
+            args = (args,)
+
+        handles = []
+        orig_bias_quantizers = {
+            qmodule: qmodule.param_quantizers["bias"]
+            for qmodule in self.qmodules()
+            if "bias" in qmodule.param_quantizers
+        }
+
+        try:
+            for qmodule, qtzr in orig_bias_quantizers.items():
+                if qtzr is not None:
+                    # Bias quantizer already exists.
+                    # This means the user created bias quantizer by him/herself
+                    # In this case, we honor the custom bias quantizer defined by the user
+                    continue
+
+                handles.append(qmodule.register_forward_hook(create_bias_quantizer))
+            try:
+                self.model(*args)
+            finally:
+                for handle in handles:
+                    handle.remove()
+            yield
+        finally:
+            for qmodule, qtzr in orig_bias_quantizers.items():
+                qmodule.param_quantizers["bias"] = qtzr
+
+
 class _QuantizationSimOnnxExport:
     """
     Helper class for exporting quantized models to ONNX format.
@@ -620,28 +697,25 @@ class _QuantizationSimOnnxExport:
                                "Other quantizer types are not supported.")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            with self.sim._apply_qdq_to_model_parameters(self.sim.model):
+            with self.sim._concretize_int32_bias_quantizers(args), \
+                    self.sim._apply_qdq_to_model_parameters(self.sim.model):
                 tmp_onnx_path = os.path.join(tmp_dir, "quantized_model.onnx")
                 export(self.sim.model, args, tmp_onnx_path, *posargs, **kwargs)
                 onnx_model = onnx.load(tmp_onnx_path)
 
+                param_names = {
+                    f"{layer_name}.{param_name}"
+                    for layer_name, layer in self.sim.model.named_modules()
+                    if isinstance(layer, QuantizationMixin)
+                    for param_name, quantizer in layer.param_quantizers.items()
+                    if quantizer
+                }
+
         tensor_to_encoding_map = remove_quantization_nodes_from_onnx_graph(onnx_model)
         onnx.save(onnx_model, f)
 
-        param_names = []
         param_encodings = {}
         activation_encodings = {}
-
-        for layer_name, layer in self.sim.model.named_modules():
-            if not isinstance(layer, self.sim._quantized_modules):
-                continue
-
-            if isinstance(layer, _QuantizedModuleProtocol) and isinstance(layer.get_original_module(), utils.DROPOUT_TYPES):
-                continue
-
-            for param_name, quantizer in layer.param_quantizers.items():
-                if quantizer:
-                    param_names.append(f"{layer_name}.{param_name}")
 
         for tensor, encoding in tensor_to_encoding_map.items():
             qnn_encoding = encoding.to_qnn_encoding_dict(encoding_version=quantsim.encoding_version)
@@ -671,7 +745,7 @@ class _QuantizationSimOnnxExport:
         onnx_file_path = (f if isinstance(f, str) else f.name)
         encoding_file_path = os.path.splitext(onnx_file_path)[0] + ".encodings"
         with open(encoding_file_path, 'w', encoding='utf-8') as encoding_file:
-            json.dump(encodings_dict, encoding_file, sort_keys=True, indent=4)
+            json.dump(encodings_dict, encoding_file, indent=2)
 
     @staticmethod
     def _has_non_affine_quantizer(module: torch.nn.Module):

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -53,6 +53,7 @@ from aimet_torch.v2.quantization.affine.backends import quantize, quantize_dequa
 from aimet_torch.v2.quantization.affine import Quantize, QuantizeDequantize
 import aimet_torch.v2 as aimet
 from aimet_torch.v2.nn import (
+    QuantizationMixin,
     QuantizedConv1d,
     QuantizedConv2d,
     QuantizedConv3d,
@@ -61,12 +62,14 @@ from aimet_torch.v2.nn import (
     QuantizedConvTranspose3d,
     QuantizedEmbedding,
     QuantizedGELU,
+    QuantizedGroupNorm,
+    QuantizedInstanceNorm1d,
+    QuantizedInstanceNorm2d,
+    QuantizedInstanceNorm3d,
+    QuantizedLayerNorm,
     QuantizedLinear,
-    QuantizationMixin,
     QuantizedSigmoid,
     QuantizedSoftmax,
-    QuantizedLayerNorm,
-    QuantizedGroupNorm,
     UnknownModuleError,
 )
 from aimet_torch.v2.nn.fake_quant import _legacy_impl
@@ -1141,3 +1144,200 @@ def test_qembedding_output_encoding(scale_shape, block_size, indices):
     assert isinstance(qout, DequantizedTensor)
     assert torch.equal(qout, qweight[indices])
     assert torch.equal(qout.quantize(), qweight.quantize()[indices])
+
+
+@pytest.mark.parametrize(
+    "qmodule_factory,                             input_shape", [
+    (lambda: QuantizedConv2d(16, 16, 3),          (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3), (1, 16, 3, 3)),
+    (lambda: QuantizedLinear(16, 16),             (1, 9, 16)),
+])
+def test_create_int32_bias_quantizer_standalone(qmodule_factory, input_shape):
+    """
+    Given: Quantized module without input or weight quantizer
+    """
+    qmodule = qmodule_factory()
+    input = torch.randn(input_shape)
+    qmodule.input_quantizers[0] = None
+    qmodule.param_quantizers["weight"] = None
+
+    """
+    When: Call _create_int32_bias_quantizer
+    Then: Bias encoding should be calibrated only based on the values bias,
+          and hence shouldn't incur any quantization noise
+    """
+    qmodule._create_int32_bias_quantizer((input,), None)
+    bias_qtzr = qmodule.param_quantizers["bias"]
+    assert torch.allclose(bias_qtzr(qmodule.bias), qmodule.bias)
+
+
+@pytest.mark.parametrize(
+    "qmodule_factory,                             scale_shape,      block_size,          input_shape", [
+    (lambda: QuantizedConv1d(16, 16, 3),          (),               None,                (1, 16, 3)),
+    (lambda: QuantizedConv1d(16, 16, 3),          (16, 1, 1),       None,                (1, 16, 3)),
+    (lambda: QuantizedConv1d(16, 16, 3),          (16, 4, 1),       (-1, 4, -1),         (1, 16, 3)),
+    (lambda: QuantizedConv2d(16, 16, 3),          (),               None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConv2d(16, 16, 3),          (16, 1, 1, 1),    None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConv2d(16, 16, 3),          (16, 4, 1, 1),    (-1, 4, -1, -1),     (1, 16, 3, 3)),
+    (lambda: QuantizedConv3d(16, 16, 3),          (),               None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConv3d(16, 16, 3),          (16, 1, 1, 1, 1), None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConv3d(16, 16, 3),          (16, 4, 1, 1, 1), (-1, 4, -1, -1, -1), (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConvTranspose1d(16, 16, 3), (),               None,                (1, 16, 3)),
+    (lambda: QuantizedConvTranspose1d(16, 16, 3), (1, 16, 1),       None,                (1, 16, 3)),
+    (lambda: QuantizedConvTranspose1d(16, 16, 3), (4, 16, 1),       (4, -1, -1),         (1, 16, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3), (),               None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3), (1, 16, 1, 1),    None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3), (4, 16, 1, 1),    (4, -1, -1, -1),     (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose3d(16, 16, 3), (),               None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConvTranspose3d(16, 16, 3), (1, 16, 1, 1, 1), None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConvTranspose3d(16, 16, 3), (4, 16, 1, 1, 1), (4, -1, -1, -1, -1), (1, 16, 3, 3, 3)),
+    (lambda: QuantizedLinear(16, 16),             (),               None,                (1, 9, 16)),
+    (lambda: QuantizedLinear(16, 16),             (16, 1),          None,                (1, 9, 16)),
+    (lambda: QuantizedLinear(16, 16),             (16, 4),          (-1, 4),             (1, 9, 16)),
+])
+def test_create_int32_bias_quantizer_affine(qmodule_factory, scale_shape, block_size, input_shape):
+    """
+    Given: Quantized module with input and weight quantizer
+    """
+    qmodule = qmodule_factory()
+
+    input = torch.randn(input_shape)
+    qmodule.input_quantizers[0] = QuantizeDequantize((), qmin=0, qmax=255, symmetric=False)
+    qmodule.param_quantizers["weight"] = QuantizeDequantize(scale_shape,
+                                                            qmin=-128, qmax=127, symmetric=True,
+                                                            block_size=block_size)
+
+    with qmodule.compute_encodings():
+        _ = qmodule(input)
+
+    """
+    When: Call _create_int32_bias_quantizer
+    Then: Bias encoding should be derived from input and weight scales, such that
+          bias_scale = input_scale * weight_scale
+    """
+    qmodule._create_int32_bias_quantizer((input,), None)
+    input_qtzr = qmodule.input_quantizers[0]
+    weight_qtzr = qmodule.param_quantizers["weight"]
+    bias_qtzr = qmodule.param_quantizers["bias"]
+
+    input_scale = input_qtzr.get_scale()
+    weight_scale = weight_qtzr.get_scale()
+    expected_bias_scale = input_scale * weight_scale
+    if block_size is None:
+        expected_bias_scale = expected_bias_scale.flatten()
+    elif isinstance(qmodule, nn.modules.conv._ConvTransposeNd):
+        expected_bias_scale = expected_bias_scale.amax(dim=[d for d in range(qmodule.weight.dim()) if d != 1])
+    elif isinstance(qmodule, nn.modules.conv._ConvNd):
+        expected_bias_scale = expected_bias_scale.amax(dim=[d for d in range(qmodule.weight.dim()) if d != 0])
+    elif isinstance(qmodule, nn.Linear):
+        expected_bias_scale = expected_bias_scale.amax(dim=[1])
+    else:
+        raise ValueError
+    assert torch.allclose(bias_qtzr.get_scale(), expected_bias_scale)
+
+    """
+    Given:
+      * Quantized module with weight quantizer but without input quantizer
+      * input is a DequantizedTensor
+    """
+    qmodule = qmodule_factory()
+
+    input = torch.randn(input_shape).as_subclass(DequantizedTensor)
+    input.encoding = AffineEncoding(scale=(input.max() - input.min()) / 255,
+                                    offset=torch.zeros(()),
+                                    qmin=0, qmax=255, symmetry=False)
+    qmodule.input_quantizers[0] = None
+    qmodule.param_quantizers["weight"] = QuantizeDequantize(scale_shape,
+                                                            qmin=-128, qmax=127, symmetric=True,
+                                                            block_size=block_size)
+
+    with qmodule.compute_encodings():
+        _ = qmodule(input)
+
+    """
+    When: Call _create_int32_bias_quantizer
+    Then: Bias encoding should be derived from input and weight scales, such that
+          bias_scale = input_scale * weight_scale
+    """
+    qmodule._create_int32_bias_quantizer((input,), None)
+    weight_qtzr = qmodule.param_quantizers["weight"]
+    bias_qtzr = qmodule.param_quantizers["bias"]
+
+    input_scale = input.encoding.scale
+    weight_scale = weight_qtzr.get_scale()
+    expected_bias_scale = input_scale * weight_scale
+    if block_size is None:
+        expected_bias_scale = expected_bias_scale.flatten()
+    elif isinstance(qmodule, nn.modules.conv._ConvTransposeNd):
+        expected_bias_scale = expected_bias_scale.amax(dim=[d for d in range(qmodule.weight.dim()) if d != 1])
+    elif isinstance(qmodule, nn.modules.conv._ConvNd):
+        expected_bias_scale = expected_bias_scale.amax(dim=[d for d in range(qmodule.weight.dim()) if d != 0])
+    elif isinstance(qmodule, nn.Linear):
+        expected_bias_scale = expected_bias_scale.amax(dim=[1])
+    else:
+        raise ValueError
+    assert torch.allclose(bias_qtzr.get_scale(), expected_bias_scale)
+
+
+
+@pytest.mark.parametrize(
+    "qmodule_factory,                                 scale_shape,      block_size,          input_shape", [
+    (lambda: QuantizedConv1d(16, 16, 3),              (1, 16, 1),       None,                (1, 16, 3)),
+    (lambda: QuantizedConv1d(16, 16, 3),              (4, 16, 1),       (4, -1, -1),         (1, 16, 3)),
+    (lambda: QuantizedConv2d(16, 16, 3),              (1, 16, 1, 1),    None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConv2d(16, 16, 3),              (4, 16, 1, 1),    (4, -1, -1, -1),     (1, 16, 3, 3)),
+    (lambda: QuantizedConv3d(16, 16, 3),              (1, 16, 1, 1, 1), None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConv3d(16, 16, 3),              (4, 16, 1, 1, 1), (4, -1, -1, -1, -1), (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConvTranspose1d(16, 16, 3),     (16, 1, 1),       None,                (1, 16, 3)),
+    (lambda: QuantizedConvTranspose1d(16, 16, 3),     (16, 4, 1),       (-1, 4, -1),         (1, 16, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3),     (16, 1, 1, 1),    None,                (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose2d(16, 16, 3),     (16, 4, 1, 1),    (-1, 4, -1, -1),     (1, 16, 3, 3)),
+    (lambda: QuantizedConvTranspose3d(16, 16, 3),     (16, 1, 1, 1, 1), None,                (1, 16, 3, 3, 3)),
+    (lambda: QuantizedConvTranspose3d(16, 16, 3),     (16, 4, 1, 1, 1), (-1, 4, -1, -1, -1), (1, 16, 3, 3, 3)),
+    (lambda: QuantizedLinear(16, 16),                 (1, 16),          None,                (1, 9, 16)),
+    (lambda: QuantizedLinear(16, 16),                 (4, 16),          (4, -1),             (1, 9, 16)),
+    (lambda: QuantizedLayerNorm(9),                   (),               None,                (1, 4, 9)),
+    (lambda: QuantizedLayerNorm(9),                   (9,),             None,                (1, 4, 9)),
+    (lambda: QuantizedGroupNorm(3, 9),                (),               None,                (1, 9, 4)),
+    (lambda: QuantizedGroupNorm(3, 9),                (9,),             None,                (1, 9, 4)),
+    (lambda: QuantizedInstanceNorm1d(9, affine=True), (),               None,                (1, 9, 4)),
+    (lambda: QuantizedInstanceNorm1d(9, affine=True), (9,),             None,                (1, 9, 4)),
+    (lambda: QuantizedInstanceNorm2d(9, affine=True), (),               None,                (1, 9, 4, 4)),
+    (lambda: QuantizedInstanceNorm2d(9, affine=True), (9,),             None,                (1, 9, 4, 4)),
+    (lambda: QuantizedInstanceNorm3d(9, affine=True), (),               None,                (1, 9, 4, 4, 4)),
+    (lambda: QuantizedInstanceNorm3d(9, affine=True), (9,),             None,                (1, 9, 4, 4, 4)),
+])
+def test_create_int32_bias_quantizer_bias_encoding_derivation_not_supported(qmodule_factory, 
+                                                                            scale_shape,
+                                                                            block_size,
+                                                                            input_shape):
+    """
+    Given: Quantized module whose bias encodings should NOT be derived from input and weight encodings.
+           Notable among them are:
+
+           - nn.ConvNd with channel_axis != 0
+           - nn.ConvTransposeNd with channel_axis != 1
+           - nn.Linear with channel_axis != 0
+           - nn.GroupNorm
+           - nn.LayerNorm
+           - nn.InstanceNorm
+    """
+    qmodule = qmodule_factory()
+
+    input = torch.randn(input_shape)
+    qmodule.input_quantizers[0] = QuantizeDequantize((), qmin=0, qmax=255, symmetric=False)
+    qmodule.param_quantizers["weight"] = QuantizeDequantize(scale_shape,
+                                                            qmin=-128, qmax=127, symmetric=True,
+                                                            block_size=block_size)
+
+    with qmodule.compute_encodings():
+        _ = qmodule(input)
+
+    """
+    When: Call _create_int32_bias_quantizer
+    Then: Bias encoding should be calibrated only based on the values bias,
+          and hence shouldn't incur any quantization noise
+    """
+    qmodule._create_int32_bias_quantizer((input,), None)
+    bias_qtzr = qmodule.param_quantizers["bias"]
+    assert torch.allclose(bias_qtzr(qmodule.bias), qmodule.bias)


### PR DESCRIPTION
## Main Changes
Export int32 bias encodings in `sim.onnx.export`

Few things to note
* bias encodings are derived as `input_scale * weight_scale` whenever possible
* In this PR, only `sim.onnx.export` exports bias encodings; `sim.export` doesn't export bias encodings yet