### PR TITLE
Redefine LPBQ output_dtype of 2.0.0 encoding schema

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
@@ -920,7 +920,7 @@ class GroupedBlockQuantizeDequantize(QcQuantizeOp):
             "per_channel_float_scale": per_channel_scale.tolist(),
             "y_zero_point": None,
             **encodings,
-            "output_dtype": f"int{decompressed_bw}" if output_dtype.startswith("int") else f"uint{decompressed_bw}"
+            "output_dtype": f"int{compressed_bw}" if output_dtype.startswith("int") else f"uint{compressed_bw}"
         }
 
     def _fill_mismatching_encoding_settings_info(self, encoding_dict: Optional[dict], encoding_mismatch_info: _EncodingMismatchInfo):

--- a/TrainingExtensions/onnx/test/python/test_qc_quantize_op.py
+++ b/TrainingExtensions/onnx/test/python/test_qc_quantize_op.py
@@ -1232,7 +1232,6 @@ def _onnx_LPBQ(input_shape, per_block_int_scale, per_channel_float_scale,
     op = OperatorSetIdProto()
     op.version = 21
 
-    assert output_dtype in ("int8", "int16", "uint8", "uint16")
     assert y_zero_point is None
 
     x_int_dtype = TensorProto.INT16 if output_dtype == "int16" else \
@@ -1358,7 +1357,7 @@ def test_lpbq_encoding_schema_2_0_0(input_shape, block_axis, block_size, compres
     assert encoding["y_zero_point"] is None
     assert encoding["axis"] == block_axis
     assert encoding["block_size"] == block_size
-    assert encoding["output_dtype"] == f"int{decompressed_bw}"
+    assert encoding["output_dtype"] == f"int{compressed_bw}"
 
 
     """

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -513,7 +513,7 @@ class GroupedBlockEncoding(AffineEncoding):
             del encoding_dict["y_scale"]
             del encoding_dict["output_dtype"]
 
-            decompressed_bw = self.decompressed_bw
+            compressed_bw = self.bitwidth
             y_zero_point = encoding_dict.pop("y_zero_point")
 
             if y_zero_point is not None and torch.any(torch.tensor(y_zero_point) != 0):
@@ -526,7 +526,7 @@ class GroupedBlockEncoding(AffineEncoding):
                 "per_channel_float_scale": self.per_channel_scale.tolist(),
                 "y_zero_point": None,
                 **encoding_dict,
-                "output_dtype": f"int{decompressed_bw}" if self.signed else f"uint{decompressed_bw}"
+                "output_dtype": f"int{compressed_bw}" if self.signed else f"uint{compressed_bw}"
             }
 
         return encoding_dict


### PR DESCRIPTION
## Main Changes
Changed the definition of LPBQ `output_dtype` from `decompressed_bw` ("int8") to `compressed_bw` ("int4")