### PR TITLE
Allow not defining quantized definition of trivial modules

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -119,8 +119,10 @@ def _convert_to_qmodel(model: torch.nn.Module):
                 except UnknownModuleError:
                     pass
 
-                if not qmodule and not tuple(module.children()):
-                    exceptions[e.module_cls] = e
+                if type(module).forward != torch.nn.Module.forward: # We don't complain if the user has no intent of
+                                                                    # running forward with this module
+                    if not qmodule and not tuple(module.children()):
+                        exceptions[e.module_cls] = e
 
         for name, child in module.named_children():
             setattr(module, name, _convert_to_qmodule(child))


### PR DESCRIPTION
## Main change
For _**trivial modules**_ that the users has no intent of running forward with, we will ignore them even though the user didn't declare its quantized definition.
(_**trivial module**_ := modules that don't define forward function)