### PR TITLE
Use standard onnx operator names in quantsim config file

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/aic100_config.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/aic100_config.json
@@ -26,7 +26,7 @@
 		{
 		  "is_output_quantized": "False"
 		},
-		"LayerNorm":
+		"LayerNormalization":
 		{
 			"is_output_quantized": "True",
 			"supported_kernels":

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/aic100_per_channel_config.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/aic100_per_channel_config.json
@@ -27,7 +27,7 @@
 		{
 		  "is_output_quantized": "False"
 		},
-		"LayerNorm":
+		"LayerNormalization":
 		{
 			"is_output_quantized": "True",
 			"supported_kernels":
@@ -46,7 +46,7 @@
 				}
 			]
 		},
-		"GELU": {
+		"Gelu": {
 			"is_output_quantized": "True",
 			"supported_kernels":
 			[

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/backend_aware_htp_quantsim_config_v75.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/backend_aware_htp_quantsim_config_v75.json
@@ -294,7 +294,7 @@
         "Gemm": {
             "per_channel_quantization": "False"
         },
-        "GroupNorm": {
+        "GroupNormalization": {
             "per_channel_quantization": "False",
             "params": {
                 "bias": {
@@ -354,7 +354,7 @@
                 }
             ]
         },
-        "LayerNorm": {
+        "LayerNormalization": {
             "per_channel_quantization": "False",
             "params": {
                 "weight": {
@@ -2312,7 +2312,7 @@
                 }
             ]
         },
-        "InstanceNorm": {
+        "InstanceNormalization": {
             "supported_kernels": [
                 {
                     "activation": {

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/default_config_per_channel.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/default_config_per_channel.json
@@ -67,7 +67,7 @@
     {
       "per_channel_quantization": "False"
     },
-    "LayerNorm":
+    "LayerNormalization":
     {
       "per_channel_quantization": "False"
     },

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v68.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v68.json
@@ -138,10 +138,6 @@
     {
       "is_output_quantized": "False"
     },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False"
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False"

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v69.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v69.json
@@ -138,10 +138,6 @@
     {
       "is_output_quantized": "False"
     },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False"
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False"

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v73.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v73.json
@@ -97,16 +97,6 @@
         }
       }
     },
-    "GroupNormalization":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "bias":
-        {
-          "is_quantized": "True"
-        }
-      }
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False",

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v73.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v73.json
@@ -87,7 +87,7 @@
     {
       "per_channel_quantization": "False"
     },
-    "GroupNorm":
+    "GroupNormalization":
     {
       "per_channel_quantization": "False",
       "params": {
@@ -104,15 +104,6 @@
         "bias":
         {
           "is_quantized": "True"
-        }
-      }
-    },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "weight": {
-          "is_symmetric": "False"
         }
       }
     },

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v75.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v75.json
@@ -101,16 +101,6 @@
         }
       }
     },
-    "GroupNormalization":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "bias":
-        {
-          "is_quantized": "True"
-        }
-      }
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False",

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v75.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v75.json
@@ -91,7 +91,7 @@
     {
       "per_channel_quantization": "False"
     },
-    "GroupNorm":
+    "GroupNormalization":
     {
       "per_channel_quantization": "False",
       "params": {
@@ -108,15 +108,6 @@
         "bias":
         {
           "is_quantized": "True"
-        }
-      }
-    },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "weight": {
-          "is_symmetric": "False"
         }
       }
     },

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v79.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v79.json
@@ -101,16 +101,6 @@
         }
       }
     },
-    "GroupNormalization":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "bias":
-        {
-          "is_quantized": "True"
-        }
-      }
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False",

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v79.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v79.json
@@ -91,7 +91,7 @@
     {
       "per_channel_quantization": "False"
     },
-    "GroupNorm":
+    "GroupNormalization":
     {
       "per_channel_quantization": "False",
       "params": {
@@ -108,15 +108,6 @@
         "bias":
         {
           "is_quantized": "True"
-        }
-      }
-    },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "weight": {
-          "is_symmetric": "False"
         }
       }
     },

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v81.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v81.json
@@ -101,16 +101,6 @@
         }
       }
     },
-    "GroupNormalization":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "bias":
-        {
-          "is_quantized": "True"
-        }
-      }
-    },
     "LayerNormalization":
     {
       "per_channel_quantization": "False",

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v81.json
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/htp_quantsim_config_v81.json
@@ -91,7 +91,7 @@
     {
       "per_channel_quantization": "False"
     },
-    "GroupNorm":
+    "GroupNormalization":
     {
       "per_channel_quantization": "False",
       "params": {
@@ -108,15 +108,6 @@
         "bias":
         {
           "is_quantized": "True"
-        }
-      }
-    },
-    "LayerNorm":
-    {
-      "per_channel_quantization": "False",
-      "params": {
-        "weight": {
-          "is_symmetric": "False"
         }
       }
     },

--- a/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/onnx_utils.py
@@ -91,13 +91,13 @@ map_torch_types_to_onnx = {
     nn.Dropout2d: ['Dropout'],
     nn.Embedding: ['Gather'],
     nn.Flatten: ['Flatten'],
-    nn.GELU: ['GELU'],                  # Not a supported op in ONNX, adding this entry for usage by Connected Graph
-    nn.GroupNorm: ['GroupNorm'],
+    nn.GELU: ['Gelu'],
+    nn.GroupNorm: ['GroupNormalization'],
     nn.GRU: ['GRU'],
     nn.Hardswish: ['HardSwish'],
     nn.MaxPool2d: ['MaxPool'],
     nn.MaxPool3d: ['MaxPool'],
-    nn.LayerNorm: ['LayerNorm'],        # Not a supported op in ONNX, adding this entry for usage by Connected Graph
+    nn.LayerNorm: ['LayerNormalization'],
     nn.InstanceNorm2d: ['InstanceNormalization'],
     nn.InstanceNorm1d: ['InstanceNormalization'],
     nn.LeakyReLU: ['LeakyRelu'],

--- a/TrainingExtensions/torch/test/python/test_gptvq_weight.py
+++ b/TrainingExtensions/torch/test/python/test_gptvq_weight.py
@@ -69,7 +69,7 @@ QUANTSIM_CONFIG = {
         "Mean": {"is_output_quantized": "False"},
         # Enable per-channel quantization for Gemm to validate GPTVQ algorithm
         "Gemm": {"per_channel_quantization": "True"},
-        "LayerNorm": {"per_channel_quantization": "False"},
+        "LayerNormalization": {"per_channel_quantization": "False"},
         "Gather": {"is_output_quantized": "False"},
     },
     "supergroups": [

--- a/TrainingExtensions/torch/test/python/v1/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantizer.py
@@ -4649,7 +4649,7 @@ class TestQuantizationSimLearnedGrid:
             },
             "params": {},
             "op_type": {
-                    "GroupNorm":
+                    "GroupNormalization":
                     {
                       "per_channel_quantization": "False",
                       "params": {

--- a/TrainingExtensions/torch/test/python/v1/test_quantsim_config.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantsim_config.py
@@ -1231,7 +1231,7 @@ class TestQuantsimConfig:
             },
             "params": {},
             "op_type": {
-                "LayerNorm": {
+                "LayerNormalization": {
                     "is_input_quantized": "True",
                     "params": {
                         "bias": {
@@ -1239,7 +1239,7 @@ class TestQuantsimConfig:
                         },
                     },
                 },
-                "GELU": {
+                "Gelu": {
                     "is_input_quantized": "True",
                 }
             },
@@ -1902,7 +1902,7 @@ class TestQuantsimConfig:
             },
             "params": {},
             "op_type": {
-                "LayerNorm": {
+                "LayerNormalization": {
                     "supported_kernels":
                         [
                             {
@@ -1917,7 +1917,7 @@ class TestQuantsimConfig:
                             },
                         ]
                 },
-                "GELU": {
+                "Gelu": {
                     "is_output_quantized": "True",
                     "supported_kernels":
                         [

--- a/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
+++ b/TrainingExtensions/torch/test/python/v1/test_quantsim_transformers.py
@@ -83,7 +83,7 @@ def generate_custom_quantsim_config(file_path: str):
         },
         "params": {},
         "op_type": {
-            "LayerNorm": {
+            "LayerNormalization": {
                 "is_output_quantized": "True",
                 "supported_kernels":
                     [
@@ -99,7 +99,7 @@ def generate_custom_quantsim_config(file_path: str):
                         }
                     ]
             },
-            "GELU": {
+            "Gelu": {
                 "is_output_quantized": "True",
                 "supported_kernels":
                     [

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantizer.py
@@ -3594,7 +3594,7 @@ class TestQuantizationSimLearnedGrid:
             },
             "params": {},
             "op_type": {
-                    "GroupNorm":
+                    "GroupNormalization":
                     {
                       "per_channel_quantization": "False",
                       "params": {
@@ -3877,7 +3877,7 @@ class TestQuantizationSimLearnedGrid:
             },
             'params': {},
             'op_type': {
-                'GroupNorm': {
+                'GroupNormalization': {
                     'per_channel_quantization': 'False',
                     'params': {'bias': {'is_quantized': 'True'}},
                 },

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_config.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_config.py
@@ -1200,7 +1200,7 @@ class TestQuantsimConfig:
             },
             "params": {},
             "op_type": {
-                "LayerNorm": {
+                "LayerNormalization": {
                     "is_input_quantized": "True",
                     "params": {
                         "bias": {
@@ -1208,7 +1208,7 @@ class TestQuantsimConfig:
                         },
                     },
                 },
-                "GELU": {
+                "Gelu": {
                     "is_input_quantized": "True",
                 }
             },
@@ -1861,7 +1861,7 @@ class TestQuantsimConfig:
             },
             "params": {},
             "op_type": {
-                "LayerNorm": {
+                "LayerNormalization": {
                     "supported_kernels":
                         [
                             {
@@ -1876,7 +1876,7 @@ class TestQuantsimConfig:
                             },
                         ]
                 },
-                "GELU": {
+                "Gelu": {
                     "is_output_quantized": "True",
                     "supported_kernels":
                         [

--- a/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_transformers.py
+++ b/TrainingExtensions/torch/test/python/v2/ab_test/test_quantsim_transformers.py
@@ -81,7 +81,7 @@ def generate_custom_quantsim_config(file_path: str):
         },
         "params": {},
         "op_type": {
-            "LayerNorm": {
+            "LayerNormalization": {
                 "is_output_quantized": "True",
                 "supported_kernels":
                     [
@@ -97,7 +97,7 @@ def generate_custom_quantsim_config(file_path: str):
                         }
                     ]
             },
-            "GELU": {
+            "Gelu": {
                 "is_output_quantized": "True",
                 "supported_kernels":
                     [


### PR DESCRIPTION
## Main Changes
Renamed config file entries to standard onnx operator names.

* GELU -> Gelu
* GroupNorm -> GroupNormalization
* InstanceNorm -> InstanceNormalization
* LayerNorm -> LayerNormalization


## Remaining Problems
There are still some op names that only exist in QNN but not in onnx.

#### In htp_quantsim_config_v*.json
* 'BatchPermutation'
* 'BatchToSpace'
* 'ChannelShuffle'
* 'CropAndResize'
* 'SpaceToBatch'

#### In backend_aware_*_quantsim_config.json
* 'ArgbToRgb'
* 'Argmax'
* 'Argmin'
* 'AxisAlignedBboxTransform'
* 'BatchPermutation'
* 'BatchToSpace'
* 'Batchnorm'
* (...99 more)