### PR TITLE
Implement int32 bias encoding export mechanism in aimet-onnx

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim.py
@@ -332,3 +332,9 @@ def _get_minimum_scale(num_steps: int) -> float:
     _MINIMUM_RANGE_TO_REPRESENT = (-0.005, 0.005)
     _min, _max = _MINIMUM_RANGE_TO_REPRESENT
     return (_max - _min) / num_steps
+
+
+_INT4_MINIMUM_SCALE = _get_minimum_scale(2**4-1)
+_INT8_MINIMUM_SCALE = _get_minimum_scale(2**8-1)
+_INT16_MINIMUM_SCALE = _get_minimum_scale(2**16-1)
+_INT32_MINIMUM_SCALE = _get_minimum_scale(2**32-1)

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim.py
@@ -310,3 +310,25 @@ def extract_global_quantizer_args(quant_scheme: Union[str, QuantScheme],
                        "per_channel_quantization": is_per_channel_quant
                        })
     return quant_args
+
+
+def _get_minimum_scale(num_steps: int) -> float:
+    """
+    Return the minimum scale given the number of steps in the quantization grid.
+
+    We define the minimum scale as the smallest scale
+    that can represent input range [-0.005, 0.005] without clipping error
+
+    Following this rule, the minimum scale in practice will be:
+
+      | dtype | minimum scale |
+      |-------|---------------|
+      |  int4 |    6.67e-04   |
+      |  int8 |    3.92e-05   | (note: float16.eps =  9.7e-04)
+      | int16 |    1.52e-07   | (note: float32.eps = 1.19e-07)
+      | int32 |    2.33e-12   | (note: float64.eps = 2.22e-16)
+
+    """
+    _MINIMUM_RANGE_TO_REPRESENT = (-0.005, 0.005)
+    _min, _max = _MINIMUM_RANGE_TO_REPRESENT
+    return (_max - _min) / num_steps

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
@@ -809,26 +809,14 @@ class GroupedBlockQuantizeDequantize(QcQuantizeOp):
         self._enable_blockwise_quantization(block_size)
         self.data_type = QuantizationDataType.int
 
-    def _get_scale(self) -> Optional[np.ndarray]:
-        raw_scale = super()._get_scale()
-        if raw_scale is None:
-            return None
-
-        decompressed_bw = self.decompressed_bw
-        compressed_bw = self.bitwidth
-        per_block_int_scale, per_channel_scale = lpbq_utils.grouped_dynamic_quantize(raw_scale,
-                                                                                     self._block_grouping(),
-                                                                                     decompressed_bw - compressed_bw)
-        return per_block_int_scale * per_channel_scale
-
     def _get_per_channel_scale(self) -> Optional[np.ndarray]:
-        raw_scale = super()._get_scale()
-        if raw_scale is None:
+        scale = self._get_scale()
+        if scale is None:
             return None
 
         decompressed_bw = self.decompressed_bw
         compressed_bw = self.bitwidth
-        _, per_channel_scale = lpbq_utils.grouped_dynamic_quantize(raw_scale,
+        _, per_channel_scale = lpbq_utils.grouped_dynamic_quantize(scale,
                                                                    self._block_grouping(),
                                                                    decompressed_bw - compressed_bw)
         return per_channel_scale

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/qc_quantize_op.py
@@ -286,13 +286,13 @@ class QcQuantizeOp:
         """
         return self.get_encodings()
 
-    def _get_scale(self) -> np.ndarray:
+    def _get_scale(self) -> Optional[np.ndarray]:
         encodings = self.get_encodings()
         if encodings is None:
             return None
         return np.array([enc.delta for enc in encodings], dtype=np.float32).reshape(self._encoding_shape())
 
-    def _get_offset(self) -> np.ndarray:
+    def _get_offset(self) -> Optional[np.ndarray]:
         encodings = self.get_encodings()
         if encodings is None:
             return None
@@ -808,6 +808,30 @@ class GroupedBlockQuantizeDequantize(QcQuantizeOp):
         self.decompressed_bw = decompressed_bw
         self._enable_blockwise_quantization(block_size)
         self.data_type = QuantizationDataType.int
+
+    def _get_scale(self) -> Optional[np.ndarray]:
+        raw_scale = super()._get_scale()
+        if raw_scale is None:
+            return None
+
+        decompressed_bw = self.decompressed_bw
+        compressed_bw = self.bitwidth
+        per_block_int_scale, per_channel_scale = lpbq_utils.grouped_dynamic_quantize(raw_scale,
+                                                                                     self._block_grouping(),
+                                                                                     decompressed_bw - compressed_bw)
+        return per_block_int_scale * per_channel_scale
+
+    def _get_per_channel_scale(self) -> Optional[np.ndarray]:
+        raw_scale = super()._get_scale()
+        if raw_scale is None:
+            return None
+
+        decompressed_bw = self.decompressed_bw
+        compressed_bw = self.bitwidth
+        _, per_channel_scale = lpbq_utils.grouped_dynamic_quantize(raw_scale,
+                                                                   self._block_grouping(),
+                                                                   decompressed_bw - compressed_bw)
+        return per_channel_scale
 
     def _block_grouping(self):
         grouping = [1 for _ in range(len(self._encoding_shape()))]

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -795,14 +795,23 @@ class QuantizationSimModel:
                     #   * Conv with channel_axis=1
                     #   * ConvTranspose with channel_axis=0
                     #   * Gemm with channel_axis=1
-                    return None
+                    return get_statistical_bias_scale(input_name, weight_name, bias_name)
 
-            weight_scale = weight_qtzr._get_scale()
+            if isinstance(weight_qtzr, GroupedBlockQuantizeDequantize):
+                # NOTE: In LPBQ, bias encodings should be derived from per-channel weight scale
+                weight_scale = weight_qtzr._get_per_channel_scale()
+            else:
+                weight_scale = weight_qtzr._get_scale()
+
             input_scale = input_qtzr._get_scale()
+
+            if weight_scale is None or input_scale is None:
+                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+
             bias_scale = input_scale * weight_scale
 
             if block_size is not None:
-                bias_scale = bias_scale.amax(axis=block_axis)
+                bias_scale = bias_scale.max(axis=block_axis)
 
             if channel_axis is not None:
                 bias_scale = bias_scale.reshape([num_channels])

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -57,7 +57,7 @@ from packaging import version
 from aimet_common import _libpymo as libpymo, quantsim
 from aimet_common import libquant_info
 from aimet_common.defs import QuantScheme, QuantizationDataType
-from aimet_common.quantsim import extract_global_quantizer_args, VALID_ENCODING_VERSIONS, _get_minimum_scale
+from aimet_common.quantsim import extract_global_quantizer_args, VALID_ENCODING_VERSIONS, _INT32_MINIMUM_SCALE
 from aimet_common.utils import save_json_yaml, AimetLogger, _red
 from aimet_common.quant_utils import _convert_encoding_format_0_6_1_to_1_0_0
 from aimet_common.connected_graph.product import Product
@@ -749,8 +749,7 @@ class QuantizationSimModel:
 
             bias = onnx.numpy_helper.to_array(bias_proto)
 
-            int32_minimum_scale = _get_minimum_scale(2**32-1)
-            bias_scale = np.maximum(abs(bias) / 2**31, int32_minimum_scale)
+            bias_scale = np.maximum(abs(bias) / 2**31, _INT32_MINIMUM_SCALE)
 
             if not bias_qtzr.quant_info.usePerChannelMode:
                 bias_scale = bias_scale.max()

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -731,7 +731,7 @@ class QuantizationSimModel:
     def _concretize_int32_bias_quantizers(self):
         # pylint: disable=redefined-builtin, protected-access, too-many-statements
 
-        def get_statistical_bias_scale(_, __, bias_name: str) -> np.ndarray:
+        def get_statistical_bias_scale(_, __, bias: Product) -> np.ndarray:
             r"""
             Compute int32 bias scale statistically, such that
 
@@ -742,12 +742,12 @@ class QuantizationSimModel:
             For better runtime performance, bias encodings should be derived analytically
             whenever possible. (See ``get_analytic_bias_scale``)
             """
-            bias_proto = utils.ParamUtils.get_param_by_name(self.model.model, bias_name)
+            bias_proto = utils.ParamUtils.get_param_by_name(self.model.model, bias.name)
 
             if bias_proto is None:
                 raise RuntimeError(
                     "Failed to calibrate encoding of bias. "
-                    f"Couldn't find the value of \"{bias_name}\" statically from the graph."
+                    f"Couldn't find the value of \"{bias.name}\" statically from the graph."
                 )
 
             bias = onnx.numpy_helper.to_array(bias_proto)
@@ -759,9 +759,7 @@ class QuantizationSimModel:
 
             return bias_scale
 
-        def get_analytic_bias_scale(input_name: str,
-                                    weight_name: str,
-                                    bias_name: str) -> np.ndarray:
+        def get_analytic_bias_scale(input: Product, weight: Product, bias: Product) -> np.ndarray:
             """
             Derive int32 bias scale analytically from input and weight encodings, such that
 
@@ -771,24 +769,17 @@ class QuantizationSimModel:
             since bias-add operation ``(input @ weight) + bias`` becomes trivial when
             both terms share the same quantization scale
             """
-            weight_qtzr = self.qc_quantize_op_dict.get(weight_name)
+            weight_qtzr = self.qc_quantize_op_dict.get(weight.name)
 
             if not (weight_qtzr and weight_qtzr.enabled and weight_qtzr.is_initialized()):
                 # Weight quantizer wasn't created, enabled, or initialized.
                 # Since weight_scale isn't avaiable, fall back to statictical bias scale
-                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+                return get_statistical_bias_scale(input, weight, bias)
 
-            input_qtzr = self.qc_quantize_op_dict.get(input_name)
+            input_qtzr = self._get_closest_enabled_quantizer(input)
 
             if not (input_qtzr and input_qtzr.enabled and input_qtzr.is_initialized()):
-                # TODO: We can handle this better. For example,
-                #
-                #       input ->    Q0     -> Reshape ->    Q1     -> Conv
-                #                (enabled)              (disabled)
-                #
-                # In this case, we can track down Q0 as the effective input quantizer
-                # although Q1 is disabled.
-                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+                return get_statistical_bias_scale(input, weight, bias)
 
             channel_axis = None
             num_channels = None
@@ -808,7 +799,7 @@ class QuantizationSimModel:
                     #   * Conv with channel_axis=1
                     #   * ConvTranspose with channel_axis=0
                     #   * Gemm with channel_axis=1
-                    return get_statistical_bias_scale(input_name, weight_name, bias_name)
+                    return get_statistical_bias_scale(input, weight, bias)
 
             if isinstance(weight_qtzr, GroupedBlockQuantizeDequantize):
                 # NOTE: In LPBQ, bias encodings should be derived from per-channel weight scale
@@ -819,7 +810,7 @@ class QuantizationSimModel:
             input_scale = input_qtzr._get_scale()
 
             if weight_scale is None or input_scale is None:
-                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+                return get_statistical_bias_scale(input, weight, bias)
 
             bias_scale = input_scale * weight_scale
 
@@ -874,7 +865,7 @@ class QuantizationSimModel:
             else:
                 get_bias_scale = switcher.get(op.type, get_statistical_bias_scale)
 
-            bias_scale = get_bias_scale(input.name, weight.name, bias.name)
+            bias_scale = get_bias_scale(input, weight, bias)
 
             encodings = [libpymo.TfEncoding() for _ in range(bias_scale.size)]
 
@@ -1244,21 +1235,35 @@ def set_blockwise_quantization_for_weights(sim: QuantizationSimModel,
         op_types = (op_types, )
 
     for op in sim.connected_graph.ordered_ops:
-        if op.type in op_types:
-            _, _, param_quantizers = sim.get_op_quantizers(op)
+        if op.type not in op_types:
+            continue
 
-            if "weight" in param_quantizers:
-                weight_quantizer: QcQuantizeOp = param_quantizers["weight"]
+        _, _, param_quantizers = sim.get_op_quantizers(op)
 
-                try:
-                    weight_quantizer._enable_blockwise_quantization(block_size) # pylint:disable = protected-access
-                except ValueError as e:
-                    if strict:
-                        raise e
-                else:
-                    weight_quantizer.set_bitwidth(bitwidth)
-                    weight_quantizer.use_symmetric_encodings = symmetric
-                    weight_quantizer.data_type = QuantizationDataType.int
+        weight_quantizer: QcQuantizeOp = param_quantizers.get("weight")
+        bias_quantizer: QcQuantizeOp = param_quantizers.get("bias")
+
+        if not weight_quantizer:
+            continue
+
+        try:
+            weight_quantizer._enable_blockwise_quantization(block_size) # pylint:disable = protected-access
+        except ValueError as e:
+            if strict:
+                raise e
+        else:
+            weight_quantizer.set_bitwidth(bitwidth)
+            weight_quantizer.use_symmetric_encodings = symmetric
+            weight_quantizer.data_type = QuantizationDataType.int
+
+            if bias_quantizer:
+                # Enable per-channel quantization of bias to derive bias_scale analytically as
+                # :math:`bias_scale = weight_scale * input_scale` in export time.
+                # ``bias_scale`` should be per-channel if ``weight_scale`` is per-channel or per-block
+                # to match the shape
+                bias_quantizer.enable_per_channel_quantization()
+                bias_quantizer.use_symmetric_encodings = symmetric
+                bias_quantizer.data_type = QuantizationDataType.int
 
 
 def set_grouped_blockwise_quantization_for_weights(sim: QuantizationSimModel,
@@ -1292,29 +1297,42 @@ def set_grouped_blockwise_quantization_for_weights(sim: QuantizationSimModel,
         op_types = (op_types, )
 
     for op in sim.connected_graph.ordered_ops:
+        if op.type not in op_types:
+            continue
 
-        if op.type in op_types:
-            _, _, param_quantizers = sim.get_op_quantizers(op)
+        _, _, param_quantizers = sim.get_op_quantizers(op)
 
 
-            if "weight" in param_quantizers:
-                weight_quantizer: QcQuantizeOp = param_quantizers["weight"]
+        weight_quantizer: QcQuantizeOp = param_quantizers.get("weight")
+        bias_quantizer: QcQuantizeOp = param_quantizers.get("bias")
 
-                try:
-                    grouped_quantizer = GroupedBlockQuantizeDequantize(weight_quantizer.quant_info,
-                                                                       bitwidth,
-                                                                       decompressed_bw,
-                                                                       block_size,
-                                                                       weight_quantizer.quant_scheme,
-                                                                       weight_quantizer.op_mode,
-                                                                       weight_quantizer.tensor_quantizer_params)
-                except ValueError as e:
-                    if strict:
-                        raise e
-                else:
-                    for name, quantizer in sim.qc_quantize_op_dict.items():
-                        if quantizer is weight_quantizer:
-                            sim.qc_quantize_op_dict[name] = grouped_quantizer
+        if not weight_quantizer:
+            continue
+
+        try:
+            grouped_quantizer = GroupedBlockQuantizeDequantize(weight_quantizer.quant_info,
+                                                               bitwidth,
+                                                               decompressed_bw,
+                                                               block_size,
+                                                               weight_quantizer.quant_scheme,
+                                                               weight_quantizer.op_mode,
+                                                               weight_quantizer.tensor_quantizer_params)
+        except ValueError as e:
+            if strict:
+                raise e
+        else:
+            if bias_quantizer:
+                # Enable per-channel quantization of bias to derive bias_scale analytically as
+                # :math:`bias_scale = weight_scale * input_scale` in export time.
+                # ``bias_scale`` should be per-channel if ``weight_scale`` is per-channel or per-block
+                # to match the shape
+                bias_quantizer.enable_per_channel_quantization()
+                bias_quantizer.use_symmetric_encodings = True
+                bias_quantizer.data_type = QuantizationDataType.int
+
+            for name, quantizer in sim.qc_quantize_op_dict.items():
+                if quantizer is weight_quantizer:
+                    sim.qc_quantize_op_dict[name] = grouped_quantizer
 
 
 # pylint: disable=protected-access

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -57,7 +57,7 @@ from packaging import version
 from aimet_common import _libpymo as libpymo, quantsim
 from aimet_common import libquant_info
 from aimet_common.defs import QuantScheme, QuantizationDataType
-from aimet_common.quantsim import extract_global_quantizer_args, VALID_ENCODING_VERSIONS
+from aimet_common.quantsim import extract_global_quantizer_args, VALID_ENCODING_VERSIONS, _get_minimum_scale
 from aimet_common.utils import save_json_yaml, AimetLogger, _red
 from aimet_common.quant_utils import _convert_encoding_format_0_6_1_to_1_0_0
 from aimet_common.connected_graph.product import Product
@@ -727,6 +727,144 @@ class QuantizationSimModel:
             node.name = node.name.replace('_updated', '')
 
         return model
+
+    def _concretize_int32_bias_quantizers(self):
+        # pylint: disable=redefined-builtin, protected-access, too-many-statements
+        constants = [node for node in self.model.graph().node if node.op_type == "Constant"]
+
+        def get_statistical_bias_scale(_, __, bias_name: str) -> np.ndarray:
+            bias_proto = self.model.get_initializer(bias_name)
+
+            if bias_proto is None:
+                try:
+                    bias_proto = next(iter(
+                        node.attribute[0].t for node in constants
+                        if node.output == [bias_name]
+                    ))
+                except StopIteration as e:
+                    raise RuntimeError(
+                        "Failed to calibrate encoding of bias. "
+                        f"Couldn't find the value of \"{bias_name}\" statically from the graph."
+                    ) from e
+
+            bias = onnx.numpy_helper.to_array(bias_proto)
+
+            int32_minimum_scale = _get_minimum_scale(2**32-1)
+            bias_scale = np.maximum(abs(bias) / 2**31, int32_minimum_scale)
+
+            if not bias_qtzr.quant_info.usePerChannelMode:
+                bias_scale = bias_scale.max()
+
+            return bias_scale
+
+        def get_analytic_bias_scale(input_name: str,
+                                    weight_name: str,
+                                    bias_name: str) -> np.ndarray:
+            weight_qtzr = self.qc_quantize_op_dict.get(weight_name)
+
+            if not (weight_qtzr and weight_qtzr.enabled and weight_qtzr.is_initialized()):
+                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+
+            input_qtzr = self.qc_quantize_op_dict.get(input_name)
+
+            if not (input_qtzr and input_qtzr.enabled and input_qtzr.is_initialized()):
+                # TODO: We can handle this better. For example,
+                #
+                #       input ->    Q0     -> Reshape ->    Q1     -> Conv
+                #                (enabled)              (disabled)
+                #
+                # In this case, we can track down Q0 as the effective input quantizer
+                # although Q1 is disabled.
+                return get_statistical_bias_scale(input_name, weight_name, bias_name)
+
+            channel_axis = None
+            num_channels = None
+            block_axis = None
+            block_size = None
+            if weight_qtzr.quant_info.usePerChannelMode:
+                channel_axis = weight_qtzr.quant_info.channelAxis
+                num_channels = weight_qtzr.tensor_quantizer_params.tensor_shape[channel_axis]
+                block_size = weight_qtzr.quant_info.blockSize or None
+                block_axis = weight_qtzr.quant_info.blockAxis if block_size else None
+
+                expected_channel_axis, expected_block_axis = self._get_quantization_axes(op)
+
+                if channel_axis != expected_channel_axis or \
+                        block_axis not in (expected_block_axis, None):
+                    # For example:
+                    #   * Conv with channel_axis=1
+                    #   * ConvTranspose with channel_axis=0
+                    #   * Gemm with channel_axis=1
+                    return None
+
+            weight_scale = weight_qtzr._get_scale()
+            input_scale = input_qtzr._get_scale()
+            bias_scale = input_scale * weight_scale
+
+            if block_size is not None:
+                bias_scale = bias_scale.amax(axis=block_axis)
+
+            if channel_axis is not None:
+                bias_scale = bias_scale.reshape([num_channels])
+
+            return bias_scale
+
+
+        switcher = {
+            "Conv": get_analytic_bias_scale,
+            "Gemm": get_analytic_bias_scale,
+            "ConvTranspose": get_analytic_bias_scale,
+            "BatchNormalization": get_statistical_bias_scale,
+            "InstanceNormalization": get_statistical_bias_scale,
+            "LayerNormalization": get_statistical_bias_scale,
+            "GroupNormalization": get_statistical_bias_scale,
+        }
+
+        ops_with_bias = {
+            op
+            for op in self.connected_graph.get_all_ops().values()
+            for param_name, (_, param_type) in op.parameters.items()
+            if param_type == "bias"
+        }
+
+        for op in ops_with_bias:
+            input, *_ = op.inputs
+            weight = None
+            bias = None
+
+            for inp in op.inputs:
+                _, param_type = op.parameters.get(inp.name, (None, None))
+                if param_type == "weight":
+                    weight = inp
+                elif param_type == "bias":
+                    bias = inp
+
+            bias_qtzr = self.qc_quantize_op_dict.get(bias.name)
+
+            if bias_qtzr and bias_qtzr.enabled and bias_qtzr.is_initialized():
+                # Edge case: bias encoding already exists.
+                # Always honor the existing bias encoding
+                continue
+
+            if weight is None:
+                # Edge case: Op has no weight. Fall back to statistical bias scale
+                get_bias_scale = get_statistical_bias_scale
+            else:
+                get_bias_scale = switcher.get(op.type, get_statistical_bias_scale)
+
+            bias_scale = get_bias_scale(input.name, weight.name, bias.name)
+
+            encodings = [libpymo.TfEncoding() for _ in range(bias_scale.size)]
+
+            for enc, scale in zip(encodings, bias_scale.flatten()):
+                enc.bw = 32
+                enc.delta = scale
+                enc.offset = -2**31
+                enc.min = scale * -2**31
+                enc.max = scale * (2**31 - 1)
+
+            bias_qtzr.load_encodings(encodings)
+            bias_qtzr.enabled = True
 
     def export(self, path: str, filename_prefix: str):
         """

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -730,7 +730,6 @@ class QuantizationSimModel:
 
     def _concretize_int32_bias_quantizers(self):
         # pylint: disable=redefined-builtin, protected-access, too-many-statements
-        constants = [node for node in self.model.graph().node if node.op_type == "Constant"]
 
         def get_statistical_bias_scale(_, __, bias_name: str) -> np.ndarray:
             r"""
@@ -743,19 +742,13 @@ class QuantizationSimModel:
             For better runtime performance, bias encodings should be derived analytically
             whenever possible. (See ``get_analytic_bias_scale``)
             """
-            bias_proto = self.model.get_initializer(bias_name)
+            bias_proto = utils.ParamUtils.get_param_by_name(self.model.model, bias_name)
 
             if bias_proto is None:
-                try:
-                    bias_proto = next(iter(
-                        node.attribute[0].t for node in constants
-                        if node.output == [bias_name]
-                    ))
-                except StopIteration as e:
-                    raise RuntimeError(
-                        "Failed to calibrate encoding of bias. "
-                        f"Couldn't find the value of \"{bias_name}\" statically from the graph."
-                    ) from e
+                raise RuntimeError(
+                    "Failed to calibrate encoding of bias. "
+                    f"Couldn't find the value of \"{bias_name}\" statically from the graph."
+                )
 
             bias = onnx.numpy_helper.to_array(bias_proto)
 

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -733,6 +733,16 @@ class QuantizationSimModel:
         constants = [node for node in self.model.graph().node if node.op_type == "Constant"]
 
         def get_statistical_bias_scale(_, __, bias_name: str) -> np.ndarray:
+            r"""
+            Compute int32 bias scale statistically, such that
+
+            :math:`scale = abs(max(bias)) / 2**31`
+
+            Note that using statistical bias scale isn't ideal for runtime performance
+            on integer accelerators.
+            For better runtime performance, bias encodings should be derived analytically
+            whenever possible. (See ``get_analytic_bias_scale``)
+            """
             bias_proto = self.model.get_initializer(bias_name)
 
             if bias_proto is None:
@@ -759,9 +769,20 @@ class QuantizationSimModel:
         def get_analytic_bias_scale(input_name: str,
                                     weight_name: str,
                                     bias_name: str) -> np.ndarray:
+            """
+            Derive int32 bias scale analytically from input and weight encodings, such that
+
+            :math:`bias_scale = weight_scale * input_scale`
+
+            This analytic formula is friendly for integer hardware/runtime
+            since bias-add operation ``(input @ weight) + bias`` becomes trivial when
+            both terms share the same quantization scale
+            """
             weight_qtzr = self.qc_quantize_op_dict.get(weight_name)
 
             if not (weight_qtzr and weight_qtzr.enabled and weight_qtzr.is_initialized()):
+                # Weight quantizer wasn't created, enabled, or initialized.
+                # Since weight_scale isn't avaiable, fall back to statictical bias scale
                 return get_statistical_bias_scale(input_name, weight_name, bias_name)
 
             input_qtzr = self.qc_quantize_op_dict.get(input_name)

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/utils.py
@@ -348,7 +348,7 @@ class ParamUtils:
         return None
 
     @staticmethod
-    def get_param_by_name(model: ModelProto, param_name: str):
+    def get_param_by_name(model: ModelProto, param_name: str) -> TensorProto:
         """
         Returns the param tensor
 

--- a/TrainingExtensions/onnx/test/python/models/models_for_tests.py
+++ b/TrainingExtensions/onnx/test/python/models/models_for_tests.py
@@ -1083,7 +1083,7 @@ def build_lstm_gru_dummy_model():
 
 
 def single_residual_model(training=torch.onnx.TrainingMode.EVAL):
-    x = torch.randn(1, 3, 32, 32, requires_grad=True)
+    x = torch.randn(1, 3, 32, 32)
     model = SingleResidualWithAvgPool()
 
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -2124,8 +2124,8 @@ def layernorm_model():
     model = helper.make_model(
         graph=helper.make_graph(
             name='LayerNormModel',
-            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[1, 4, 64, 64])],
-            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[1, 32, 40960])],
+            inputs=[helper.make_tensor_value_info('input', TensorProto.FLOAT, shape=[1, 4, 64, 64])],
+            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, shape=[1, 32, 40960])],
             initializer=[
                 numpy_helper.from_array(np.random.randn(320, 4, 3, 3).astype('float32'), name='conv_in.weight'),
                 numpy_helper.from_array(np.random.randn(320).astype('float32'), name='conv_in.bias'),
@@ -2140,7 +2140,7 @@ def layernorm_model():
             nodes=[
                 helper.make_node(
                     'Conv',
-                    inputs=['model_input', 'conv_in.weight', 'conv_in.bias'],
+                    inputs=['input', 'conv_in.weight', 'conv_in.bias'],
                     outputs=['/conv_in/Conv_output_0'],
                     name='/conv_in/Conv',
                     doc_string='',
@@ -2156,7 +2156,7 @@ def layernorm_model():
                     outputs=['/down_blocks.0/resnets.0/norm1/Constant_output_0'],
                     name='/down_blocks.0/resnets.0/norm1/Constant',
                     doc_string='',
-                    value=numpy_helper.from_array(np.array([0, 32, -1], dtype='int64'), name=''),
+                    value=numpy_helper.from_array(np.array([-1, 32], dtype='int64'), name=''),
                 ),
                 helper.make_node(
                     'Reshape',
@@ -2169,7 +2169,7 @@ def layernorm_model():
                 helper.make_node(
                     'LayerNormalization',
                     inputs=['/down_blocks.0/resnets.0/norm1/Reshape_output_0', 'layernorm.scale', 'layernorm.bias'],
-                    outputs=['model_output'],
+                    outputs=['output'],
                     name='/down_blocks.0/resnets.0/norm1/LayerNormalization',
                     doc_string='',
                     epsilon=9.999999747378752e-06,
@@ -2489,8 +2489,8 @@ def batchnorm_model():
     model = helper.make_model(
         graph=helper.make_graph(
             name='BatchnormModel',
-            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
-            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
+            inputs=[helper.make_tensor_value_info('input', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
+            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
             initializer=[
                 numpy_helper.from_array(np.abs(np.random.randn(10, )).astype('float32'), name='batchnorm.weight'),
                 numpy_helper.from_array(np.random.randn(10, ).astype('float32'), name='batchnorm.bias'),
@@ -2500,8 +2500,8 @@ def batchnorm_model():
             nodes=[
                 helper.make_node(
                     'BatchNormalization',
-                    inputs=['model_input', 'batchnorm.weight', 'batchnorm.bias', 'batchnorm.input_mean', 'batchnorm.input_var'],
-                    outputs=['model_output'],
+                    inputs=['input', 'batchnorm.weight', 'batchnorm.bias', 'batchnorm.input_mean', 'batchnorm.input_var'],
+                    outputs=['output'],
                     name='batchnorm'
                 ),
             ]
@@ -2514,8 +2514,8 @@ def batchnorm_model_constants():
     model = helper.make_model(
         graph=helper.make_graph(
             name='BatchnormModel',
-            inputs=[helper.make_tensor_value_info('model_input', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
-            outputs=[helper.make_tensor_value_info('model_output', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
+            inputs=[helper.make_tensor_value_info('input', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
+            outputs=[helper.make_tensor_value_info('output', TensorProto.FLOAT, shape=[10, 10, 8, 8])],
             initializer=[],
             nodes=[
                 helper.make_node('Constant', inputs=[], outputs=["batchnorm.weight"],
@@ -2528,8 +2528,8 @@ def batchnorm_model_constants():
                                  value=numpy_helper.from_array(np.abs(np.random.randn(10, )).astype('float32')), name='input_var'),
                 helper.make_node(
                     'BatchNormalization',
-                    inputs=['model_input', 'batchnorm.weight', 'batchnorm.bias', 'batchnorm.input_mean', 'batchnorm.input_var'],
-                    outputs=['model_output'],
+                    inputs=['input', 'batchnorm.weight', 'batchnorm.bias', 'batchnorm.input_mean', 'batchnorm.input_var'],
+                    outputs=['output'],
                     name='batchnorm'
                 ),
             ]

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -58,14 +58,36 @@ from aimet_common import libquant_info
 from aimet_common import _libpymo as libpymo
 from aimet_common.defs import QuantScheme, QuantizationDataType, EncodingType
 from aimet_common.quantsim_config.utils import get_path_for_per_channel_config
-from aimet_onnx.quantsim import QuantizationSimModel, load_encodings_to_sim, set_blockwise_quantization_for_weights, _apply_constraints, clamp_activation_encodings, \
-    set_grouped_blockwise_quantization_for_weights
+from aimet_onnx.quantsim import (
+    QuantizationSimModel,
+    load_encodings_to_sim,
+    set_blockwise_quantization_for_weights,
+    _apply_constraints,
+    clamp_activation_encodings,
+    set_grouped_blockwise_quantization_for_weights,
+    _get_minimum_scale,
+)
 from aimet_onnx.qc_quantize_op import OpMode, GroupedBlockQuantizeDequantize
 from aimet_onnx.utils import make_dummy_input
-from .models.models_for_tests import SingleResidual
 from .models import models_for_tests, test_models
-from .models.models_for_tests import build_dummy_model, single_residual_model, BNAfterConv, multi_input_with_constant_model , multi_output_model, custom_add_model, build_lstm_gru_dummy_model, \
-    transposed_conv_model, depthwise_transposed_conv_model, linear_split_into_matmul_add, _convert_to_onnx
+from .models.models_for_tests import (
+    batchnorm_model,
+    batchnorm_model_constants,
+    BNAfterConv,
+    build_dummy_model,
+    build_lstm_gru_dummy_model,
+    custom_add_model,
+    depthwise_transposed_conv_model,
+    instance_norm_model,
+    layernorm_model,
+    linear_split_into_matmul_add,
+    multi_input_with_constant_model,
+    multi_output_model,
+    single_residual_model,
+    SingleResidual,
+    transposed_conv_model,
+    _convert_to_onnx
+)
 
 
 def _compare_encodings(dst, src):
@@ -2016,3 +2038,104 @@ class TestEncodingPropagation:
 
             assert np.allclose(pre_load_out, pre_load_out_2)
             assert np.allclose(post_load_out, post_load_out_2)
+
+
+@pytest.mark.parametrize(
+    "model_factory,             input_shape", [
+    (single_residual_model,     (1, 3, 32, 32)),
+    (transposed_conv_model,     (10, 10, 4, 4)),
+    (batchnorm_model,           (10, 10, 8, 8)),
+    (batchnorm_model_constants, (10, 10, 8, 8)),
+    (instance_norm_model,       (2, 10, 24, 24)),
+    (layernorm_model,           (1, 4, 64, 64)),
+    # TODO: Add tests with GroupNormalization
+])
+def test_bias_export(model_factory, input_shape, tmp_path):
+    model = model_factory()
+    input = np.random.randn(*input_shape).astype(np.float32)
+
+    """
+    When: Call _concretize_int32_bias_quantizers() before export
+    """
+    sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf)
+    sim.compute_encodings(lambda sess, _: sess.run(None, {"input": input}), None)
+    sim._concretize_int32_bias_quantizers()
+    sim.export(tmp_path, "model")
+
+    with open(tmp_path / "model.encodings") as f:
+        encodings = json.load(f)
+
+    exported_encodings = {
+        enc["name"]: enc
+        for enc in itertools.chain(encodings["activation_encodings"], encodings["param_encodings"])
+    }
+
+    """
+    Then: All bias encodings should be exported
+    """
+    all_biases = {
+        param_name
+        for op in sim.connected_graph.get_all_ops().values()
+        for param_name, (_, param_type) in op.parameters.items()
+        if param_type == "bias"
+    }
+    assert exported_encodings.keys() > all_biases
+
+    """
+    Then: For linear ops such as Conv, ConvTranspose, and Gemm,
+          bias encoding should be derived analytically from input and weight encodings
+    """
+    linear_ops_with_bias = {
+        op for op in sim.connected_graph.get_all_ops().values()
+        if op.type in ("Conv", "ConvTranspose", "Gemm") and
+           "bias" in [param_type for _, param_type in op.parameters.values()]
+    }
+
+    for op in linear_ops_with_bias:
+        input, weight, bias = op.inputs
+        assert bias.name in exported_encodings
+        assert all(offset == -2**31 for offset in exported_encodings[bias.name]["offset"])
+
+        weight_scale = np.array(exported_encodings[weight.name]["scale"])
+        bias_scale = np.array(exported_encodings[bias.name]["scale"])
+        try:
+            input_scale = np.array(exported_encodings[input.name]["scale"])
+        except KeyError:
+            continue # TODO: Remove this exception. Find input scale more smartly
+
+        assert np.allclose(bias_scale, input_scale * weight_scale)
+
+    """
+    Then: For non-linear ops such as BatchNormalization, InstanceNormalization, LayerNormalization,
+          and GroupNormalization, bias encoding should be calibrated statistically
+    """
+    nonlinear_ops_with_bias = {
+        op for op in sim.connected_graph.get_all_ops().values()
+        if op.type in ("BatchNormalization", "InstanceNormalization"
+                       "LayerNormalization" "GroupNormalization") and
+           "bias" in [param_type for _, param_type in op.parameters.values()]
+    }
+
+    for op in nonlinear_ops_with_bias:
+        input, weight, bias, *_ = op.inputs
+        if bias.name not in exported_encodings:
+            print()
+            assert False
+        assert all(offset == -2**31 for offset in exported_encodings[bias.name]["offset"])
+
+        weight_scale = np.array(exported_encodings[weight.name]["scale"])
+        bias_scale = np.array(exported_encodings[bias.name]["scale"])
+        try:
+            input_scale = np.array(exported_encodings[input.name]["scale"])
+        except KeyError:
+            continue
+
+        bias_proto = sim.model.get_initializer(bias.name) or \
+            next(iter(
+                node.attribute[0].t for node in sim.model.graph().node
+                if node.output == [bias.name]
+            ))
+
+        bias_value = onnx.numpy_helper.to_array(bias_proto)
+        expected_bias_scale = np.maximum(abs(bias_value) / 2**31, _get_minimum_scale(2**32-1))
+        assert np.allclose(bias_scale, expected_bias_scale)

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -2041,16 +2041,20 @@ class TestEncodingPropagation:
 
 
 @pytest.mark.parametrize(
-    "model_factory,             input_shape", [
-    (single_residual_model,     (1, 3, 32, 32)),
-    (transposed_conv_model,     (10, 10, 4, 4)),
-    (batchnorm_model,           (10, 10, 8, 8)),
-    (batchnorm_model_constants, (10, 10, 8, 8)),
-    (instance_norm_model,       (2, 10, 24, 24)),
-    (layernorm_model,           (1, 4, 64, 64)),
+    "model_factory,             input_shape,     block_size, lpbq", [
+    (single_residual_model,     (1, 3, 32, 32),  None,       False),
+    (single_residual_model,     (1, 3, 32, 32),  4,          False),
+    (single_residual_model,     (1, 3, 32, 32),  4,          True),
+    (transposed_conv_model,     (10, 10, 4, 4),  None,       False),
+    (transposed_conv_model,     (10, 10, 4, 4),  5,          False),
+    (transposed_conv_model,     (10, 10, 4, 4),  5,          True),
+    (batchnorm_model,           (10, 10, 8, 8),  None,       False),
+    (batchnorm_model_constants, (10, 10, 8, 8),  None,       False),
+    (instance_norm_model,       (2, 10, 24, 24), None,       False),
+    (layernorm_model,           (1, 4, 64, 64),  None,       False),
     # TODO: Add tests with GroupNormalization
 ])
-def test_bias_export(model_factory, input_shape, tmp_path):
+def test_bias_export(model_factory, input_shape, block_size, lpbq, tmp_path):
     model = model_factory()
     input = np.random.randn(*input_shape).astype(np.float32)
 
@@ -2058,6 +2062,24 @@ def test_bias_export(model_factory, input_shape, tmp_path):
     When: Call _concretize_int32_bias_quantizers() before export
     """
     sim = QuantizationSimModel(model, quant_scheme=QuantScheme.post_training_tf)
+
+    if block_size:
+        op_types = ("Conv", "ConvTranspose", "Gemm")
+        if lpbq:
+            set_grouped_blockwise_quantization_for_weights(sim,
+                                                           op_types,
+                                                           bitwidth=4,
+                                                           decompressed_bw=8,
+                                                           block_size=block_size,
+                                                           strict=False)
+        else:
+            set_blockwise_quantization_for_weights(sim,
+                                                   op_types,
+                                                   bitwidth=4,
+                                                   symmetric=True,
+                                                   block_size=block_size,
+                                                   strict=False)
+
     sim.compute_encodings(lambda sess, _: sess.run(None, {"input": input}), None)
     sim._concretize_int32_bias_quantizers()
     sim.export(tmp_path, "model")
@@ -2069,6 +2091,11 @@ def test_bias_export(model_factory, input_shape, tmp_path):
         enc["name"]: enc
         for enc in itertools.chain(encodings["activation_encodings"], encodings["param_encodings"])
     }
+
+    # sanity check
+    if block_size:
+        enc_type = "LPBQ" if lpbq else "PER_BLOCK"
+        assert any(enc["enc_type"] == enc_type for enc in exported_encodings.values())
 
     """
     Then: All bias encodings should be exported
@@ -2097,6 +2124,12 @@ def test_bias_export(model_factory, input_shape, tmp_path):
         assert all(offset == -2**31 for offset in exported_encodings[bias.name]["offset"])
 
         weight_scale = np.array(exported_encodings[weight.name]["scale"])
+
+        if exported_encodings[weight.name]["enc_type"] == "PER_BLOCK":
+            weight_scale = weight_scale.reshape(sim.qc_quantize_op_dict[weight.name]._encoding_shape())
+            block_axis = 0 if op.type == "ConvTranspose" else 1
+            weight_scale = weight_scale.max(axis=block_axis).flatten()
+
         bias_scale = np.array(exported_encodings[bias.name]["scale"])
         try:
             input_scale = np.array(exported_encodings[input.name]["scale"])

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -65,7 +65,7 @@ from aimet_onnx.quantsim import (
     _apply_constraints,
     clamp_activation_encodings,
     set_grouped_blockwise_quantization_for_weights,
-    _get_minimum_scale,
+    _INT32_MINIMUM_SCALE,
 )
 from aimet_onnx.qc_quantize_op import OpMode, GroupedBlockQuantizeDequantize
 from aimet_onnx.utils import make_dummy_input
@@ -2170,5 +2170,5 @@ def test_bias_export(model_factory, input_shape, block_size, lpbq, tmp_path):
             ))
 
         bias_value = onnx.numpy_helper.to_array(bias_proto)
-        expected_bias_scale = np.maximum(abs(bias_value) / 2**31, _get_minimum_scale(2**32-1))
+        expected_bias_scale = np.maximum(abs(bias_value) / 2**31, _INT32_MINIMUM_SCALE)
         assert np.allclose(bias_scale, expected_bias_scale)

--- a/TrainingExtensions/onnx/test/python/test_quantsim_configurator.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim_configurator.py
@@ -411,4 +411,4 @@ class TestQuantSimConfig:
         assert not sim.qc_quantize_op_dict["batchnorm.input_var"].enabled
         assert not sim.qc_quantize_op_dict["batchnorm.bias"].enabled
         assert sim.qc_quantize_op_dict["batchnorm.weight"].enabled
-        assert sim.qc_quantize_op_dict["model_output"].enabled
+        assert sim.qc_quantize_op_dict["output"].enabled

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
@@ -46,6 +46,7 @@ from dataclasses import dataclass
 from typing import TypeVar, Generic, Tuple, Optional, List
 import itertools
 import torch
+from aimet_common.quantsim import _get_minimum_scale
 from aimet_torch.v2.utils import reduce, StatisticsNotFoundError, _is_expandable
 
 
@@ -316,28 +317,6 @@ class EncodingAnalyzer(Generic[_Statistics], ABC):
     def compute_encodings_from_stats(self, stats: _Statistics, num_steps: int, is_symmetric: bool)\
             -> Tuple[torch.Tensor, torch.Tensor]:
         pass
-
-
-def _get_minimum_scale(num_steps: int):
-    """
-    Return the minimum scale given the number of steps in the quantization grid.
-
-    We define the minimum scale as the smallest scale
-    that can represent input range [-0.005, 0.005] without clipping error
-
-    Following this rule, the minimum scale in practice will be:
-
-      | dtype | minimum scale |
-      |-------|---------------|
-      |  int4 |    6.67e-04   |
-      |  int8 |    3.92e-05   | (note: float16.eps =  9.7e-04)
-      | int16 |    1.52e-07   | (note: float32.eps = 1.19e-07)
-      | int32 |    2.33e-12   | (note: float64.eps = 2.22e-16)
-
-    """
-    _MINIMUM_RANGE_TO_REPRESENT = (-0.005, 0.005)
-    _min, _max = _MINIMUM_RANGE_TO_REPRESENT
-    return (_max - _min) / num_steps
 
 
 class MinMaxEncodingAnalyzer(EncodingAnalyzer[_MinMaxRange]):


### PR DESCRIPTION
## Main Changes
Implemented int32 bias encoding export mechanism in aimet-onnx.
You can export int32 bias encodings by calling `_concretize_int32_bias_quantizers` right before sim.export
```py
sim._concretize_int32_bias_encodings()
sim.export(...)
```

Once bias encoding export becomes the stable norm between AIMET and QAIRT, we should consider incorporating `_concretize_int32_bias_quantizers` into `sim.export`