### PR TITLE
Skip unit test for documentation-only PRs

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -33,6 +33,7 @@ jobs:
           AIMET_TORCH_SRC_CODE: "TrainingExtensions/torch/*"
           AIMET_ONNX_SRC_CODE:  "TrainingExtensions/onnx/*"
           AIMET_TF_SRC_CODE:    "TrainingExtensions/tensorflow/*"
+          DOC_SRC_CODE:         "Docs/*"
         shell: bash
         run: |
           set -x
@@ -48,6 +49,8 @@ jobs:
               ONNX_TEST_REQUIRED='true'
             elif [[ $file == $AIMET_TF_SRC_CODE ]]; then
               TF_TEST_REQUIRED='true'
+            elif [[ $file == $DOC_SRC_CODE ]]; then
+              : # Documentation change doesn't require running unit tests; only doc rebuild is needed
             else
               TORCH_TEST_REQUIRED='true'
               ONNX_TEST_REQUIRED='true'

--- a/Jenkins/fast-release/Dockerfile.ci
+++ b/Jenkins/fast-release/Dockerfile.ci
@@ -71,7 +71,14 @@ RUN --mount=type=bind,target=/workspace \
         -DENABLE_CUDA=$([ -z ${VER_CUDA} ]; echo $?) \
        " \
     && ${CONDA} run --name ${CONDA_DEFAULT_ENV} --live-stream \
-        bash -c 'python3 -m piptools compile --output-file=- --resolver=backtracking --constraint=/tmp/constraints.txt --extra=.,dev,test,docs /workspace/pyproject.toml | python3 -m pip install -r /dev/stdin'
+        python3 -m piptools compile -vv \
+                                    --output-file=/tmp/requirements.txt \
+                                    --resolver=backtracking \
+                                    --constraint=/tmp/constraints.txt \
+                                    --extra=.,dev,test,docs \
+                                    /workspace/pyproject.toml \
+    && ${CONDA} run --name ${CONDA_DEFAULT_ENV} --live-stream \
+        python3 -m pip install -r /tmp/requirements.txt
 
 ENV PYTHONPYCACHEPREFIX=/tmp
 


### PR DESCRIPTION
## Main Changes
Allowed skipping unit tests for documentation-only PRs to save a little more CI/CD compute resources