### PR TITLE
Define quantsim config file aliases

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/json_config_importer.py
@@ -36,7 +36,6 @@
 # =============================================================================
 """ Utilities for importing and validating json configuration file """
 
-import os
 import json
 from typing import Dict, List, Union
 from jsonschema import validate
@@ -94,16 +93,8 @@ class JsonConfigImporter:
         :param config_file: Config file to parse
         :return: Quantsim configs dictionary
         """
-        if not config_file:
-            config_file = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'default_config_per_channel.json')
-            logger.info('No config file provided, defaulting to config file at %s', config_file)
-
         with open(config_file) as configs:
-            try:
-                quantsim_configs = json.load(configs)
-            except json.decoder.JSONDecodeError as e:
-                logger.error('Error parsing json config file')
-                raise RuntimeError('Error parsing json config file') from e
+            quantsim_configs = json.load(configs)
 
         _validate_syntax(quantsim_configs)
         convert_configs_values_to_bool(quantsim_configs)

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
@@ -139,33 +139,51 @@ class OnnxConnectedGraphTypeMapper:
         return self._conn_graph_to_onnx_dict.get(conn_graph_type)
 
 
+_config_file_aliases = {
+    "default": "default_config_per_channel.json",
+    "htp_v66": "htp_quantsim_config_v66.json",
+    "htp_v68": "htp_quantsim_config_v68.json",
+    "htp_v69": "htp_quantsim_config_v69.json",
+    "htp_v73": "htp_quantsim_config_v73.json",
+    "htp_v75": "htp_quantsim_config_v75.json",
+    "htp_v79": "htp_quantsim_config_v79.json",
+    "htp_v81": "htp_quantsim_config_v81.json",
+}
+
+def _get_config_file(alias_or_filename: Optional[str]) -> str:
+    if alias_or_filename is None:
+        alias_or_filename = "default"
+
+    if os.path.exists(alias_or_filename):
+        return os.path.abspath(alias_or_filename)
+
+    config_file = _config_file_aliases.get(alias_or_filename, alias_or_filename)
+    config_file = os.path.join(os.path.dirname(__file__), config_file)
+
+    if not os.path.exists(config_file):
+        raise FileNotFoundError(
+            f"Config file not found: {alias_or_filename}."
+            "Expected a file path or an alias to the standard config files.\n"
+
+            "Config file aliases consist of:"
+            "\n".join([
+                f"* {key}: {value}"
+                for key, value in _config_file_aliases.items()
+            ])
+        )
+
+    return config_file
+
+
 class QuantSimConfigurator(ABC):
     """ Class for parsing and applying quantsim configurations from json config file """
-
-    currdir = os.path.dirname(__file__)
-
-    _aliases = {
-        "default": os.path.join(currdir, "default_config_per_channel.json"),
-        "htp_v66": os.path.join(currdir, "htp_quantsim_config_v66.json"),
-        "htp_v68": os.path.join(currdir, "htp_quantsim_config_v68.json"),
-        "htp_v69": os.path.join(currdir, "htp_quantsim_config_v69.json"),
-        "htp_v73": os.path.join(currdir, "htp_quantsim_config_v73.json"),
-        "htp_v75": os.path.join(currdir, "htp_quantsim_config_v75.json"),
-        "htp_v79": os.path.join(currdir, "htp_quantsim_config_v79.json"),
-        "htp_v81": os.path.join(currdir, "htp_quantsim_config_v81.json"),
-    }
-    del currdir
 
     def __init__(self,
                  config_file: Optional[str],
                  default_data_type: QuantizationDataType,
                  default_output_bw: int,
                  default_param_bw: int):
-        if config_file is None:
-            config_file = "default"
-
-        if config_file in self._aliases:
-            config_file = self._aliases[config_file]
+        config_file = _get_config_file(config_file)
 
         self._quantsim_configs = JsonConfigImporter.import_json_config_file(config_file)
         self._supported_kernels = {}

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
@@ -162,12 +162,11 @@ def _get_config_file(alias_or_filename: Optional[str]) -> str:
 
     if not os.path.exists(config_file):
         raise FileNotFoundError(
-            f"Config file not found: {alias_or_filename}."
-            "Expected a file path or an alias to the standard config files.\n"
-
-            "Config file aliases consist of:"
+            f"Config file not found: {alias_or_filename}. " +
+            "Expected a file path or an alias to the standard config files.\n" +
+            "Config file aliases consist of:\n" +
             "\n".join([
-                f"* {key}: {value}"
+                f"  * \"{key}\": {value}"
                 for key, value in _config_file_aliases.items()
             ])
         )

--- a/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
+++ b/TrainingExtensions/common/src/python/aimet_common/quantsim_config/quantsim_config.py
@@ -37,7 +37,8 @@
 """ Utilities for parsing and applying quantsim configurations from json config file """
 
 from abc import ABC, abstractmethod
-from typing import Dict, List
+import os
+from typing import Dict, List, Optional
 from aimet_common.defs import QuantizationDataType, QuantDtypeBwInfo
 from aimet_common.connected_graph.operation import Op
 from aimet_common.graph_pattern_matcher import PatternType
@@ -140,14 +141,37 @@ class OnnxConnectedGraphTypeMapper:
 
 class QuantSimConfigurator(ABC):
     """ Class for parsing and applying quantsim configurations from json config file """
-    def __init__(self, config_file: str, default_data_type: QuantizationDataType, default_output_bw: int, default_param_bw: int):
+
+    currdir = os.path.dirname(__file__)
+
+    _aliases = {
+        "default": os.path.join(currdir, "default_config_per_channel.json"),
+        "htp_v66": os.path.join(currdir, "htp_quantsim_config_v66.json"),
+        "htp_v68": os.path.join(currdir, "htp_quantsim_config_v68.json"),
+        "htp_v69": os.path.join(currdir, "htp_quantsim_config_v69.json"),
+        "htp_v73": os.path.join(currdir, "htp_quantsim_config_v73.json"),
+        "htp_v75": os.path.join(currdir, "htp_quantsim_config_v75.json"),
+        "htp_v79": os.path.join(currdir, "htp_quantsim_config_v79.json"),
+        "htp_v81": os.path.join(currdir, "htp_quantsim_config_v81.json"),
+    }
+    del currdir
+
+    def __init__(self,
+                 config_file: Optional[str],
+                 default_data_type: QuantizationDataType,
+                 default_output_bw: int,
+                 default_param_bw: int):
+        if config_file is None:
+            config_file = "default"
+
+        if config_file in self._aliases:
+            config_file = self._aliases[config_file]
+
         self._quantsim_configs = JsonConfigImporter.import_json_config_file(config_file)
         self._supported_kernels = {}
         self._default_data_type = default_data_type
         self._default_output_bw = default_output_bw
         self._default_param_bw = default_param_bw
-
-
 
     def _set_quantsim_configs(self):
         """

--- a/TrainingExtensions/common/test/python/test_quantsim_config.py
+++ b/TrainingExtensions/common/test/python/test_quantsim_config.py
@@ -49,21 +49,6 @@ from aimet_common.quantsim_config.quantsim_config import _build_list_of_permutat
 
 class TestJsonConfigImporter(unittest.TestCase):
     """ Class containing unit tests for json config importer feature """
-    def test_import_file(self):
-        """ Test that asserts are raised if config file does not exist or is not parsable by json """
-        with self.assertRaises(FileNotFoundError):
-            JsonConfigImporter.import_json_config_file('./missing_file')
-
-
-        with open('./temp.py', 'w') as f:
-            f.write('print("hello world")')
-
-        with self.assertRaises(RuntimeError):
-            JsonConfigImporter.import_json_config_file('./temp.py')
-
-        if os.path.exists('./temp.py'):
-            os.remove('./temp.py')
-
     def test_validate_syntax(self):
         """ Test syntactic validation for config files """
         # No defaults

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -60,6 +60,7 @@ from aimet_common.defs import QuantScheme, QuantizationDataType
 from aimet_common.quantsim import extract_global_quantizer_args, VALID_ENCODING_VERSIONS, _INT32_MINIMUM_SCALE
 from aimet_common.utils import save_json_yaml, AimetLogger, _red
 from aimet_common.quant_utils import _convert_encoding_format_0_6_1_to_1_0_0
+from aimet_common.quantsim_config.quantsim_config import _config_file_aliases
 from aimet_common.connected_graph.product import Product
 from aimet_onnx import utils
 from aimet_onnx.meta.operations import Op
@@ -114,7 +115,26 @@ def _apply_constraints(flag: bool):
 
 
 class QuantizationSimModel:
-    """ Creates a QuantizationSimModel model by adding quantization simulations ops to a given model """
+    __doc__ = f"""
+    Class that simulates the quantized model execution on a target hardware backend.
+
+    :param model: ONNX model
+    :param dummy_input: Dummy input to the model. If None, will attempt to auto-generate a dummy input
+    :param quant_scheme: Quantization scheme (e.g. QuantScheme.post_training_tf)
+    :param rounding_mode: Rounding mode (e.g. nearest)
+    :param default_param_bw: Quantization bitwidth for parameter
+    :param default_activation_bw: Quantization bitwidth for activation
+    :param use_symmetric_encodings: True if symmetric encoding is used.  False otherwise.
+    :param use_cuda: True if using CUDA to run quantization op. False otherwise.
+    :param config_file: File path or alias of the configuration file.
+                        Alias can be one of {{ {', '.join(_config_file_aliases.keys())} }} (Default: `"default"`)
+    :param default_data_type: Default data type to use for quantizing all layer inputs, outputs and parameters.
+                             Possible options are QuantizationDataType.int and QuantizationDataType.float.
+                             Note that the mode default_data_type=QuantizationDataType.float is only supported with
+                             default_output_bw=16 and default_param_bw=16
+    :param user_onnx_libs: List of paths to all compiled ONNX custom ops libraries
+    :param path: Directory to save the artifacts.
+    """
 
     # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes
     def __init__(self,
@@ -128,25 +148,6 @@ class QuantizationSimModel:
                  device: int = 0, config_file: str = None,
                  default_data_type: QuantizationDataType = QuantizationDataType.int,
                  user_onnx_libs: List[str] = None, path: str = None):
-        """
-        Constructor
-
-        :param model: ONNX model
-        :param dummy_input: Dummy input to the model. If None, will attempt to auto-generate a dummy input
-        :param quant_scheme: Quantization scheme (e.g. QuantScheme.post_training_tf)
-        :param rounding_mode: Rounding mode (e.g. nearest)
-        :param default_param_bw: Quantization bitwidth for parameter
-        :param default_activation_bw: Quantization bitwidth for activation
-        :param use_symmetric_encodings: True if symmetric encoding is used.  False otherwise.
-        :param use_cuda: True if using CUDA to run quantization op. False otherwise.
-        :param config_file: Path to Configuration file for model quantizers
-        :param default_data_type: Default data type to use for quantizing all layer inputs, outputs and parameters.
-                                 Possible options are QuantizationDataType.int and QuantizationDataType.float.
-                                 Note that the mode default_data_type=QuantizationDataType.float is only supported with
-                                 default_output_bw=16 and default_param_bw=16
-        :param user_onnx_libs: List of paths to all compiled ONNX custom ops libraries
-        :param path: Directory to save the artifacts.
-        """
         self.model = model
         if not isinstance(model, ONNXModel):
             self.model = ONNXModel(model)

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -114,6 +114,7 @@ def _apply_constraints(flag: bool):
         _tie_qtzrs = orig_flag
 
 
+# pylint: disable=missing-class-docstring, too-many-arguments, too-many-locals, too-many-instance-attributes
 class QuantizationSimModel:
     __doc__ = f"""
     Class that simulates the quantized model execution on a target hardware backend.
@@ -136,7 +137,6 @@ class QuantizationSimModel:
     :param path: Directory to save the artifacts.
     """
 
-    # pylint: disable=too-many-arguments, too-many-locals, too-many-instance-attributes
     def __init__(self,
                  model: ModelProto,
                  dummy_input: Dict[str, np.ndarray] = None,

--- a/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/adaround_weight.py
+++ b/TrainingExtensions/tensorflow/src/python/aimet_tensorflow/keras/adaround_weight.py
@@ -48,6 +48,7 @@ from aimet_common import _libpymo as libpymo
 from aimet_common.utils import AimetLogger
 from aimet_common.defs import QuantScheme
 from aimet_common.quantsim_config.json_config_importer import JsonConfigImporter, ConfigDictKeys, ConfigDictType
+from aimet_common.quantsim_config.quantsim_config import _get_config_file
 from aimet_tensorflow.keras.adaround.activation_sampler import ActivationSampler
 from aimet_tensorflow.keras.adaround.adaround_loss import AdaroundHyperParameters
 from aimet_tensorflow.keras.adaround.adaround_wrapper import AdaroundWrapper
@@ -118,6 +119,7 @@ class Adaround:
         :param config_file: Configuration file for model quantizers
         :return: Model with Adarounded weights
         """
+        config_file = _get_config_file(config_file)
 
         # Get parameters from config file. To allow one central place for Adaround and Quantsim
         configs, strict_symmetric, unsigned_symmetric, per_channel_enabled = cls.get_config_dict_keys(config_file)

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -69,6 +69,7 @@ from safetensors.numpy import save_file as save_safetensor_file
 from aimet_common.utils import AimetLogger, save_json_yaml, log_with_error_and_assert_if_false, Handle
 from aimet_common.defs import QuantScheme, QuantizationDataType, SupportedKernelsAction, QuantDtypeBwInfo
 from aimet_common.quantsim import validate_quantsim_inputs, extract_global_quantizer_args, VALID_ENCODING_VERSIONS
+from aimet_common.quantsim_config.quantsim_config import _get_config_file
 from aimet_common.quant_utils import get_conv_accum_bounds
 from aimet_common.utils import deprecated, _red
 from aimet_common import quantsim
@@ -277,6 +278,8 @@ class _QuantizationSimModelBase(_QuantizationSimModelInterface):
                                  Note that the mode default_data_type=QuantizationDataType.float is only supported with
                                  default_output_bw=16 or 32 and default_param_bw=16 or 32.
         """
+        config_file = _get_config_file(config_file)
+
         if not isinstance(dummy_input, (tuple, list)):
             dummy_input = (dummy_input,)
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -69,7 +69,7 @@ from safetensors.numpy import save_file as save_safetensor_file
 from aimet_common.utils import AimetLogger, save_json_yaml, log_with_error_and_assert_if_false, Handle
 from aimet_common.defs import QuantScheme, QuantizationDataType, SupportedKernelsAction, QuantDtypeBwInfo
 from aimet_common.quantsim import validate_quantsim_inputs, extract_global_quantizer_args, VALID_ENCODING_VERSIONS
-from aimet_common.quantsim_config.quantsim_config import _get_config_file
+from aimet_common.quantsim_config.quantsim_config import _get_config_file, _config_file_aliases
 from aimet_common.quant_utils import get_conv_accum_bounds
 from aimet_common.utils import deprecated, _red
 from aimet_common import quantsim
@@ -250,34 +250,35 @@ class _QuantizationSimModelInterface(ABC):
 
 class _QuantizationSimModelBase(_QuantizationSimModelInterface):
     # pylint: disable=too-many-arguments, too-many-instance-attributes, too-many-locals, too-many-public-methods, too-many-statements
+    __doc__ = f"""
+    Class that simulates the quantized model execution on a target hardware backend.
+
+    :param model: Model to add simulation ops to
+    :param dummy_input: Dummy input to the model. Used to parse model graph. If the model has more than one input,
+                        pass a tuple. User is expected to place the tensors on the appropriate device.
+    :param quant_scheme: Quantization scheme. The Quantization scheme is used to compute the Quantization encodings.
+                         There are multiple schemes available. Please refer the QuantScheme enum definition.
+    :param rounding_mode: Rounding mode. Supported options are 'nearest' or 'stochastic'
+    :param default_output_bw: Default bitwidth (4-31) to use for quantizing all layer inputs and outputs
+            unless otherwise specified in the config file.
+    :param default_param_bw: Default bitwidth (4-31) to use for quantizing all layer parameters
+            unless otherwise specified in the config file.
+    :param in_place: If True, then the given 'model' is modified in-place to add quant-sim nodes.
+            Only suggested use of this option is when the user wants to avoid creating a copy of the model
+    :param config_file: File path or alias of the configuration file.
+                        Alias can be one of {{ {', '.join(_config_file_aliases.keys())} }} (Default: `"default"`)
+    :param default_data_type: Default data type to use for quantizing all inputs, outputs and parameters.
+                             unless otherwise specified in the config file.
+                             Possible options are QuantizationDataType.int and QuantizationDataType.float.
+                             Note that the mode default_data_type=QuantizationDataType.float is only supported with
+                             default_output_bw=16 or 32 and default_param_bw=16 or 32.
+    """
     def __init__(self, model: torch.nn.Module, dummy_input: Union[torch.Tensor, Tuple],
                  quant_scheme: Union[str, QuantScheme] = QuantScheme.post_training_tf_enhanced,
                  rounding_mode: str = 'nearest', default_output_bw: int = 8, default_param_bw: int = 8,
                  in_place: bool = False, config_file: str = None,
                  default_data_type: QuantizationDataType = QuantizationDataType.int):
 
-        """
-        Constructor for QuantizationSimModel.
-
-        :param model: Model to add simulation ops to
-        :param dummy_input: Dummy input to the model. Used to parse model graph. If the model has more than one input,
-                            pass a tuple. User is expected to place the tensors on the appropriate device.
-        :param quant_scheme: Quantization scheme. The Quantization scheme is used to compute the Quantization encodings.
-                             There are multiple schemes available. Please refer the QuantScheme enum definition.
-        :param rounding_mode: Rounding mode. Supported options are 'nearest' or 'stochastic'
-        :param default_output_bw: Default bitwidth (4-31) to use for quantizing all layer inputs and outputs
-                unless otherwise specified in the config file.
-        :param default_param_bw: Default bitwidth (4-31) to use for quantizing all layer parameters
-                unless otherwise specified in the config file.
-        :param in_place: If True, then the given 'model' is modified in-place to add quant-sim nodes.
-                Only suggested use of this option is when the user wants to avoid creating a copy of the model
-        :param config_file: Path to Configuration file for model quantizers
-        :param default_data_type: Default data type to use for quantizing all inputs, outputs and parameters.
-                                 unless otherwise specified in the config file.
-                                 Possible options are QuantizationDataType.int and QuantizationDataType.float.
-                                 Note that the mode default_data_type=QuantizationDataType.float is only supported with
-                                 default_output_bw=16 or 32 and default_param_bw=16 or 32.
-        """
         config_file = _get_config_file(config_file)
 
         if not isinstance(dummy_input, (tuple, list)):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -100,7 +100,7 @@ quantized_modules = (
 )
 
 
-class QuantizationSimModel(_QuantizationSimModelBase):
+class QuantizationSimModel(_QuantizationSimModelBase): # pylint: disable=missing-class-docstring
     __doc__ = _QuantizationSimModelBase.__doc__
 
     # pylint: disable=too-many-arguments, too-many-locals, too-many-public-methods

--- a/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v1/quantsim.py
@@ -101,10 +101,8 @@ quantized_modules = (
 
 
 class QuantizationSimModel(_QuantizationSimModelBase):
-    """
-    Implements mechanism to add quantization simulations ops to a model. This allows for off-target simulation of
-    inference accuracy. Also allows the model to be fine-tuned to counter the effects of quantization.
-    """
+    __doc__ = _QuantizationSimModelBase.__doc__
+
     # pylint: disable=too-many-arguments, too-many-locals, too-many-public-methods
     _quantized_modules = quantized_modules
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -50,6 +50,7 @@ import onnx
 
 from aimet_common import quantsim
 from aimet_common.defs import QuantScheme, QuantizationDataType
+from aimet_common.quantsim_config.quantsim_config import _config_file_aliases
 from aimet_torch._base.quantsim import (
     _QuantizationSimModelBase,
     logger,
@@ -162,7 +163,7 @@ def _convert_to_qmodel(model: torch.nn.Module):
 
 
 class QuantizationSimModel(_QuantizationSimModelBase):
-    """
+    __doc__ = f"""
     Class that simulates the quantized model execution on a target hardware backend.
 
     QuantizationSimModel simulates quantization of a given model by converting
@@ -197,7 +198,38 @@ class QuantizationSimModel(_QuantizationSimModelBase):
           )
           ...
         )
+
+    .. warning::
+       `rounding_mode` parameter is deprecated.
+       Passing `rounding_mode` will throw runtime error in >=1.35.
+
+    .. warning::
+       The default value of `quant_scheme` has changed
+       from `QuantScheme.post_training_tf_enhanced` to `QuantScheme.training_range_learning_with_tf_init`
+       since 2.0.0, and will be deprecated in the longer term.
+
+    Args:
+        model (torch.nn.Module): Model to simulate the quantized execution of
+        dummy_input (Tensor | Sequence[Tensor]): Dummy input to be used to capture
+            the computational graph of the model. All input tensors are expected to be
+            already placed on the appropriate devices to run forward pass of the model.
+        quant_scheme (QuantScheme, optional): Quantization scheme that indicates
+            how to observe and calibrate the quantization encodings (Default: `QuantScheme.post_training_tf_enhanced`)
+        rounding_mode: Deprecated
+        default_output_bw (int, optional): Default bitwidth (4-31) to use for quantizing all layer inputs and outputs
+            unless otherwise specified in the config file. (Default: 8)
+        default_param_bw (int, optional): Default bitwidth (4-31) to use for quantizing all layer parameters
+            unless otherwise specified in the config file. (Default: 8)
+        in_place (bool, optional): If True, then the given model is modified in-place into a quantized model. (Default: `False`)
+        config_file (str, optional): File path or alias of the configuration file.
+            Alias can be one of {{ {', '.join(_config_file_aliases.keys())} }} (Default: `"default"`)
+        default_data_type (QuantizationDataType, optional): Default data type to use for quantizing all
+            inputs, outputs and parameters unless otherwise specified in the config file.
+            Possible options are QuantizationDataType.int and QuantizationDataType.float.
+            Note that the mode default_data_type=QuantizationDataType.float is only supported with
+            default_output_bw=16 or 32 and default_param_bw=16 or 32. (Default: `QuantizationDataType.int`)
     """
+
     _quantized_modules = quantized_modules
 
     def __init__(self, # pylint: disable=too-many-arguments, too-many-locals, too-many-branches
@@ -208,38 +240,8 @@ class QuantizationSimModel(_QuantizationSimModelBase):
                  default_output_bw: int = 8,
                  default_param_bw: int = 8,
                  in_place: bool = False,
-                 config_file: Optional[str] = None,
+                 config_file: str = None,
                  default_data_type: QuantizationDataType = QuantizationDataType.int):
-        """
-        .. warning::
-           `rounding_mode` parameter is deprecated.
-           Passing `rounding_mode` will throw runtime error in >=1.35.
-
-        .. warning::
-           The default value of `quant_scheme` has changed
-           from `QuantScheme.post_training_tf_enhanced` to `QuantScheme.training_range_learning_with_tf_init`
-           since 2.0.0, and will be deprecated in the longer term.
-
-        Args:
-            model (torch.nn.Module): Model to simulate the quantized execution of
-            dummy_input (Tensor | Sequence[Tensor]): Dummy input to be used to capture
-                the computational graph of the model. All input tensors are expected to be
-                already placed on the appropriate devices to run forward pass of the model.
-            quant_scheme (QuantScheme, optional): Quantization scheme that indicates
-                how to observe and calibrate the quantization encodings (Default: `QuantScheme.post_training_tf_enhanced`)
-            rounding_mode: Deprecated
-            default_output_bw (int, optional): Default bitwidth (4-31) to use for quantizing all layer inputs and outputs
-                unless otherwise specified in the config file. (Default: 8)
-            default_param_bw (int, optional): Default bitwidth (4-31) to use for quantizing all layer parameters
-                unless otherwise specified in the config file. (Default: 8)
-            in_place (bool, optional): If True, then the given model is modified in-place into a quantized model. (Default: `False`)
-            config_file (str, optional): Path to the quantization simulation config file (Default: `None`)
-            default_data_type (QuantizationDataType, optional): Default data type to use for quantizing all
-                inputs, outputs and parameters unless otherwise specified in the config file.
-                Possible options are QuantizationDataType.int and QuantizationDataType.float.
-                Note that the mode default_data_type=QuantizationDataType.float is only supported with
-                default_output_bw=16 or 32 and default_param_bw=16 or 32. (Default: `QuantizationDataType.int`)
-        """
         if not quant_scheme:
             old_default = QuantScheme.post_training_tf_enhanced
             new_default = QuantScheme.training_range_learning_with_tf_init

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -162,7 +162,7 @@ def _convert_to_qmodel(model: torch.nn.Module):
     ]))
 
 
-class QuantizationSimModel(_QuantizationSimModelBase):
+class QuantizationSimModel(_QuantizationSimModelBase): # pylint: disable=missing-class-docstring
     __doc__ = f"""
     Class that simulates the quantized model execution on a target hardware backend.
 


### PR DESCRIPTION
## Main Changes
Added config file aliases
```py
_config_file_aliases = {
    "default": "default_config_per_channel.json",
    "htp_v66": "htp_quantsim_config_v66.json",
    "htp_v68": "htp_quantsim_config_v68.json",
    "htp_v69": "htp_quantsim_config_v69.json",
    "htp_v73": "htp_quantsim_config_v73.json",
    "htp_v75": "htp_quantsim_config_v75.json",
    "htp_v79": "htp_quantsim_config_v79.json",
    "htp_v81": "htp_quantsim_config_v81.json",
}
```

### Usage
1. Use config file alias as a shortcut for the standard config files
```py
sim = QuantizationSimModel(..., config_file="htp_v81")
```
2. You can also only use base names (not full file path) to use standard configs
```py
sim = QuantizationSimModel(..., config_file="htp_quantsim_config_v81.json")
```