### PR TITLE
Use CPU when getting act shapes in AMP to avoid OOM

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/amp/utils.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/amp/utils.py
@@ -61,7 +61,7 @@ def get_activation_shapes(sim: QuantizationSimModel) -> Dict[str, Any]:
         hooks.append(utils.add_hook_to_get_activation(sim.model.model, name))
     dummy_input = utils.make_dummy_input(sim.model.model)
     # pylint: disable=protected-access
-    sess = QuantizationSimModel.build_session(sim.model.model, sim.providers, sim._user_onnx_libs)
+    sess = QuantizationSimModel.build_session(sim.model.model, ["CPUExecutionProvider"], sim._user_onnx_libs)
     outputs = sess.run(None, dummy_input)
     activation_shapes = {}
     for idx, node in enumerate(sim.model.graph().output):


### PR DESCRIPTION
AMP runs the model while returning all intermediate tensors to determine activation shapes. This uses a ton of memory resulting in OOM for large models.

Short-term fix is to only use CPU execution provider so we at least dont get CUDA OOM errors, long term fix will be to replace this function with onnx shape inference.