### PR TITLE
Let bias encoding follow the granularity of weight encoding

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -721,7 +721,16 @@ class BaseQuantizationMixin(abc.ABC):
         bias = self.bias
         qmin = -2**31
         qmax = 2**31 - 1
-        bias_qtzr = QuantizeDequantize(shape=bias_scale.shape if bias_scale is not None else bias.shape,
+
+        if bias_scale is not None:
+            bias_encoding_shape = bias_scale.shape
+        elif weight_scale is not None and weight_scale.shape == ():
+            # If weight is per-tensor quantized, bias should be also per-tensor quantized
+            bias_encoding_shape = ()
+        else:
+            bias_encoding_shape = bias.shape
+
+        bias_qtzr = QuantizeDequantize(shape=bias_encoding_shape,
                                        qmin=qmin,
                                        qmax=qmax,
                                        symmetric=True)

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/nn/base.py
@@ -696,16 +696,6 @@ class BaseQuantizationMixin(abc.ABC):
         assert hasattr(self, "bias")
         assert isinstance(self.bias, torch.Tensor)
 
-        bias = self.bias
-        qmin = -2**31
-        qmax = 2**31 - 1
-        bias_qtzr = QuantizeDequantize(shape=bias.shape,
-                                       qmin=qmin,
-                                       qmax=qmax,
-                                       symmetric=True)
-        bias_qtzr.to(dtype=bias.dtype, device=bias.device)
-        self.param_quantizers["bias"] = bias_qtzr
-
         if isinstance(self.param_quantizers["weight"], GroupedBlockQuantizeDequantize):
             # NOTE: In LPBQ, bias encodings should be derived from per-channel weight scale
             weight_scale = self.param_quantizers["weight"].get_per_channel_scale()
@@ -727,6 +717,16 @@ class BaseQuantizationMixin(abc.ABC):
             bias_scale = self._derive_bias_scale(input_scale, weight_scale)
         except NotImplementedError:
             bias_scale = None
+
+        bias = self.bias
+        qmin = -2**31
+        qmax = 2**31 - 1
+        bias_qtzr = QuantizeDequantize(shape=bias_scale.shape if bias_scale is not None else bias.shape,
+                                       qmin=qmin,
+                                       qmax=qmax,
+                                       symmetric=True)
+        bias_qtzr.to(dtype=bias.dtype, device=bias.device)
+        self.param_quantizers["bias"] = bias_qtzr
 
         if bias_scale is not None:
             bias_qtzr.set_range(bias_scale * qmin, bias_scale * qmax)

--- a/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
+++ b/TrainingExtensions/torch/test/python/v2/nn/test_true_quant.py
@@ -1253,12 +1253,13 @@ def test_create_int32_bias_quantizer_analytic(qmodule_factory, scale_shape, bloc
 
     expected_bias_scale = input_scale * weight_scale
     if block_size is None:
-        expected_bias_scale = expected_bias_scale.flatten()
+        expected_bias_scale = expected_bias_scale.squeeze()
     else:
         channel_axis = 1 if isinstance(qmodule, nn.modules.conv._ConvTransposeNd) else 0
         non_channel_axes = [axis for axis, _ in enumerate(qmodule.weight.shape) if axis != channel_axis]
         expected_bias_scale = expected_bias_scale.amax(dim=non_channel_axes)
 
+    assert bias_qtzr.get_scale().shape == expected_bias_scale.shape
     assert torch.allclose(bias_qtzr.get_scale(), expected_bias_scale)
 
     """


### PR DESCRIPTION
I noticed that aimet-torch is exporting bias encodings in per-channel format even when it can/should be represented as a per-tensor encoding. For example

```json
{
  "name": "fc.bias",
  "y_scale": [
    0.00017230639059562236,
    0.00017230639059562236,
    0.00017230639059562236,
    0.00017230639059562236,
    0.00017230639059562236
  ]
  "y_zero_point": null,
  "axis": 0,
  "block_size": null,
  "output_dtype": "int32"
}
```

## Main Changes
Fixed bias encoding export logic to represent bias encodings as per-tensor encodings when possible.  For example
```json
{
  "name": "fc.bias",
  "y_scale": 0.00017230639059562236
  "y_zero_point": null,
  "axis": null,
  "block_size": null,
  "output_dtype": "int32"
}
```