### PR TITLE
Vecotorize sequential MSE blockwise loss calculation of nn.Linear

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/seq_mse.py
@@ -94,6 +94,19 @@ class SeqMseParams:
     loss_fn: str = 'mse'
     forward_fn: Callable = default_forward_fn
 
+    def __post_init__(self):
+        if self.loss_fn == "mse":
+            self._loss_fn = functional.mse_loss
+        elif self.loss_fn == "l1":
+            self._loss_fn = functional.l1_loss
+        elif self.loss_fn == "sqnr":
+            self._loss_fn = neg_sqnr
+        else:
+            raise ValueError(f"Invalid loss function: {self.loss_fn}")
+
+    def get_loss_fn(self):
+        return self._loss_fn
+
 
 class SequentialMseBase(ABC):
     """
@@ -400,18 +413,10 @@ class SequentialMseBase(ABC):
         :param params: Sequential MSE parameters
         :return: loss
         """
-        if params.loss_fn == "mse":
-            loss_fn = functional.mse_loss
-        elif params.loss_fn == "l1":
-            loss_fn = functional.l1_loss
-        elif params.loss_fn == "sqnr":
-            loss_fn = neg_sqnr
-        else:
-            raise ValueError(f"Invalid loss function: {params.loss_fn}")
-
+        loss_fn = params.get_loss_fn()
         channel_dim = xqwq.shape[-1]
-        xqwq = xqwq.reshape(-1, channel_dim)
-        xw = xw.reshape(-1, channel_dim)
+        xqwq = xqwq.reshape(-1,  xqwq.shape[-1])
+        xw = xw.reshape(-1, xw.shape[-1])
         loss = loss_fn(xqwq, xw, reduction="none").sum(0)
         assert loss.size() == torch.Size([channel_dim])
         return loss

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/seq_mse.py
@@ -95,6 +95,7 @@ class SeqMseParams:
     forward_fn: Callable = default_forward_fn
 
     def __post_init__(self):
+        # pylint: disable=attribute-defined-outside-init
         if self.loss_fn == "mse":
             self._loss_fn = functional.mse_loss
         elif self.loss_fn == "l1":
@@ -104,7 +105,8 @@ class SeqMseParams:
         else:
             raise ValueError(f"Invalid loss function: {self.loss_fn}")
 
-    def get_loss_fn(self):
+    def get_loss_fn(self) -> Callable:
+        """ Returns loss function """
         return self._loss_fn
 
 
@@ -415,8 +417,8 @@ class SequentialMseBase(ABC):
         """
         loss_fn = params.get_loss_fn()
         channel_dim = xqwq.shape[-1]
-        xqwq = xqwq.reshape(-1,  xqwq.shape[-1])
-        xw = xw.reshape(-1, xw.shape[-1])
+        xqwq = xqwq.reshape(-1, channel_dim)
+        xw = xw.reshape(-1, channel_dim)
         loss = loss_fn(xqwq, xw, reduction="none").sum(0)
         assert loss.size() == torch.Size([channel_dim])
         return loss

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -41,7 +41,6 @@ from typing import List, Optional, Tuple
 import contextlib
 import torch
 from torch import nn
-import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from aimet_common.utils import AimetLogger

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -41,6 +41,7 @@ from typing import List, Optional, Tuple
 import contextlib
 import torch
 from torch import nn
+import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
 from aimet_common.utils import AimetLogger
@@ -277,33 +278,55 @@ class SequentialMse(SequentialMseBase):
                       xq: torch.Tensor,
                       w: torch.Tensor,
                       wq: torch.Tensor,
-                      params) -> torch.Tensor:
+                      params: SeqMseParams) -> torch.Tensor:
         """
         Compute loss for the given (x, w) and (xq, wq) input/weight pairs. Assumes that block size will be on
         input_channel dimension.
         """
         # pylint: disable=too-many-locals
-        # General strategy: split weights and input per block, and run a separate forward pass for each split.
-        # In the case of per tensor and per channel, the entire input channel is treated as one block.
-        block_size = cls._get_input_channel_block_size(quant_module)
-        w_blocks = torch.split(w, block_size, dim=1)
-        wq_blocks = torch.split(wq, block_size, dim=1)
-        if isinstance(quant_module, torch.nn.Linear):
-            x_blocks = torch.split(x, block_size, dim=-1)
-            xq_blocks = torch.split(xq, block_size, dim=-1)
-        else:
-            assert isinstance(quant_module, torch.nn.Conv2d)
-            groups = quant_module.groups
-            x_blocks = torch.split(x, block_size * groups, dim=-3)
-            xq_blocks = torch.split(xq, block_size * groups, dim=-3)
+        assert isinstance(quant_module, (nn.Linear, nn.Conv2d))
 
-        block_losses = []
-        for idx, x_block in enumerate(x_blocks):
-            xqwq, xw = cls.compute_outputs(quant_module, x_block, xq_blocks[idx], w_blocks[idx], wq_blocks[idx])
-            block_losses.append(cls.compute_recon_loss(xqwq, xw, params))
-        # Stack losses in the input channel dimension
-        block_losses = torch.stack(block_losses, dim=-1)
-        return block_losses
+        block_size = cls._get_input_channel_block_size(quant_module)
+        out_channels = quant_module.weight.shape[0]
+        in_channels = quant_module.weight.shape[1]
+        num_blocks = in_channels // block_size
+
+        if isinstance(quant_module, torch.nn.Linear):
+            x = x.view(-1, num_blocks, block_size).permute(1, 0, 2)
+            w = w.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
+            xw = torch.bmm(x, w)
+
+            xq = xq.view(-1, num_blocks, block_size).permute(1, 0, 2)
+            wq = wq.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
+            xqwq = torch.bmm(xq, wq)
+
+            xw = xw.permute(1, 0, 2).sum(0, keepdim=True)
+            xqwq = xqwq.permute(1, 0, 2).sum(0, keepdim=True)
+
+        else:
+            w = w.transpose(0, 1).reshape(out_channels * in_channels, 1, *w.shape[-2:])
+            wq = wq.transpose(0, 1).reshape(out_channels * in_channels, 1, *wq.shape[2:])
+
+            xw = F.conv2d(x, w,
+                          stride=quant_module.stride,
+                          dilation=quant_module.dilation,
+                          padding=quant_module.padding,
+                          groups=quant_module.groups * in_channels)
+
+            xqwq = F.conv2d(xq, wq,
+                            stride=quant_module.stride,
+                            dilation=quant_module.dilation,
+                            padding=quant_module.padding,
+                            groups=quant_module.groups * in_channels)
+
+            xw = xw.view(-1, num_blocks, block_size, out_channels, *xw.shape[-2:]) \
+                   .sum([0, 2, 4, 5], keepdim=True)
+            xqwq = xqwq.view(-1, num_blocks, block_size, out_channels, *xqwq.shape[-2:]) \
+                       .sum([0, 2, 4, 5], keepdim=True)
+
+        loss = params.get_loss_fn()(xw, xqwq, reduction="none").view(num_blocks, out_channels)
+
+        return loss.T
 
     @classmethod
     def optimize_module(cls,

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -296,10 +296,10 @@ class SequentialMse(SequentialMseBase):
             #                  reshape                     permute
             #   * x: (N,    Cin) -> (N,    NUM_BLK, BLK_SIZE) -> (NUM_BLK, N, BLK_SIZE)
             #   * w: (Cout, Cin) -> (Cout, NUM_BLK, BLK_SIZE) -> (NUM_BLK, BLK_SIZE, Cout)
-            x = x.view(-1, num_blocks, block_size).permute(1, 0, 2)
-            w = w.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
-            xq = xq.view(-1, num_blocks, block_size).permute(1, 0, 2)
-            wq = wq.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
+            x = x.reshape(-1, num_blocks, block_size).permute(1, 0, 2)
+            w = w.reshape(out_channels, num_blocks, block_size).permute(1, 2, 0)
+            xq = xq.reshape(-1, num_blocks, block_size).permute(1, 0, 2)
+            wq = wq.reshape(out_channels, num_blocks, block_size).permute(1, 2, 0)
 
             # Blockwise batched matmul
             #           xw        =           x            @           w

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -284,49 +284,44 @@ class SequentialMse(SequentialMseBase):
         input_channel dimension.
         """
         # pylint: disable=too-many-locals
-        assert isinstance(quant_module, (nn.Linear, nn.Conv2d))
-
         block_size = cls._get_input_channel_block_size(quant_module)
-        out_channels = quant_module.weight.shape[0]
-        in_channels = quant_module.weight.shape[1]
-        num_blocks = in_channels // block_size
 
         if isinstance(quant_module, torch.nn.Linear):
+            out_channels = quant_module.weight.shape[0]
+            in_channels = quant_module.weight.shape[1]
+            num_blocks = in_channels // block_size
+
             x = x.view(-1, num_blocks, block_size).permute(1, 0, 2)
             w = w.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
-            xw = torch.bmm(x, w)
 
             xq = xq.view(-1, num_blocks, block_size).permute(1, 0, 2)
             wq = wq.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
+
+            xw = torch.bmm(x, w)
             xqwq = torch.bmm(xq, wq)
 
             xw = xw.permute(1, 0, 2).sum(0, keepdim=True)
             xqwq = xqwq.permute(1, 0, 2).sum(0, keepdim=True)
 
-        else:
-            w = w.transpose(0, 1).reshape(out_channels * in_channels, 1, *w.shape[-2:])
-            wq = wq.transpose(0, 1).reshape(out_channels * in_channels, 1, *wq.shape[2:])
+            loss = params.get_loss_fn()(xw, xqwq, reduction="none").view(num_blocks, out_channels)
+            return loss.T
 
-            xw = F.conv2d(x, w,
-                          stride=quant_module.stride,
-                          dilation=quant_module.dilation,
-                          padding=quant_module.padding,
-                          groups=quant_module.groups * in_channels)
+        # General strategy: split weights and input per block, and run a separate forward pass for each split.
+        # In the case of per tensor and per channel, the entire input channel is treated as one block.
+        assert isinstance(quant_module, torch.nn.Conv2d)
+        w_blocks = torch.split(w, block_size, dim=1)
+        wq_blocks = torch.split(wq, block_size, dim=1)
+        groups = quant_module.groups
+        x_blocks = torch.split(x, block_size * groups, dim=-3)
+        xq_blocks = torch.split(xq, block_size * groups, dim=-3)
 
-            xqwq = F.conv2d(xq, wq,
-                            stride=quant_module.stride,
-                            dilation=quant_module.dilation,
-                            padding=quant_module.padding,
-                            groups=quant_module.groups * in_channels)
-
-            xw = xw.view(-1, num_blocks, block_size, out_channels, *xw.shape[-2:]) \
-                   .sum([0, 2, 4, 5], keepdim=True)
-            xqwq = xqwq.view(-1, num_blocks, block_size, out_channels, *xqwq.shape[-2:]) \
-                       .sum([0, 2, 4, 5], keepdim=True)
-
-        loss = params.get_loss_fn()(xw, xqwq, reduction="none").view(num_blocks, out_channels)
-
-        return loss.T
+        block_losses = []
+        for idx, x_block in enumerate(x_blocks):
+            xqwq, xw = cls.compute_outputs(quant_module, x_block, xq_blocks[idx], w_blocks[idx], wq_blocks[idx])
+            block_losses.append(cls.compute_recon_loss(xqwq, xw, params))
+        # Stack losses in the input channel dimension
+        block_losses = torch.stack(block_losses, dim=-1)
+        return block_losses
 
     @classmethod
     def optimize_module(cls,

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/seq_mse.py
@@ -287,27 +287,43 @@ class SequentialMse(SequentialMseBase):
         block_size = cls._get_input_channel_block_size(quant_module)
 
         if isinstance(quant_module, torch.nn.Linear):
+            # General strategy (Linear):
+            # Compute blockwise reconstruction loss using batched matrix multiplication
             out_channels = quant_module.weight.shape[0]
             in_channels = quant_module.weight.shape[1]
             num_blocks = in_channels // block_size
 
+            # Reshape and permute x and w
+            #                  reshape                     permute
+            #   * x: (N,    Cin) -> (N,    NUM_BLK, BLK_SIZE) -> (NUM_BLK, N, BLK_SIZE)
+            #   * w: (Cout, Cin) -> (Cout, NUM_BLK, BLK_SIZE) -> (NUM_BLK, BLK_SIZE, Cout)
             x = x.view(-1, num_blocks, block_size).permute(1, 0, 2)
             w = w.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
-
             xq = xq.view(-1, num_blocks, block_size).permute(1, 0, 2)
             wq = wq.view(out_channels, num_blocks, block_size).permute(1, 2, 0)
 
+            # Blockwise batched matmul
+            #           xw        =           x            @           w
+            #  (NUM_BLK, N, Cout)   (NUM_BLK, N, BLK_SIZE)   (NUM_BLK, BLK_SIZE, Cout)
             xw = torch.bmm(x, w)
             xqwq = torch.bmm(xq, wq)
 
-            xw = xw.permute(1, 0, 2).sum(0, keepdim=True)
-            xqwq = xqwq.permute(1, 0, 2).sum(0, keepdim=True)
+            # Permute to restore axis 0 back to batch dimension
+            #                          permute
+            #   * xw: (NUM_BLK, N, Cout) -> (N, Cout, NUM_BLK)
+            xw = xw.permute(1, 2, 0)
+            xqwq = xqwq.permute(1, 2, 0)
 
-            loss = params.get_loss_fn()(xw, xqwq, reduction="none").view(num_blocks, out_channels)
-            return loss.T
+            loss = params.get_loss_fn()(xw, xqwq, reduction="none").sum(0).view(out_channels, num_blocks)
+            return loss
 
-        # General strategy: split weights and input per block, and run a separate forward pass for each split.
+        # General strategy (Conv):
+        # Split weights and input per block, and run a separate forward pass for each split.
         # In the case of per tensor and per channel, the entire input channel is treated as one block.
+
+        # NOTE: Similar to Linear, convolution can be also vectorized with depthwise grouped conv.
+        #       However, vectorizing convolution in this manner harms the performance
+        #       because PyTorch grouped convolution kernels are much slower than regular convolution
         assert isinstance(quant_module, torch.nn.Conv2d)
         w_blocks = torch.split(w, block_size, dim=1)
         wq_blocks = torch.split(wq, block_size, dim=1)


### PR DESCRIPTION
## Main Changes
Vectorized blockwise sequential MSE

Toy benchmark:
![image](https://github.com/user-attachments/assets/dec81185-dd91-4886-85d5-af071af5fdc7)
