### PR TITLE
Add min_max quant scheme as a new name of tf 

### DIFF
--- a/TrainingExtensions/common/src/python/aimet_common/defs.py
+++ b/TrainingExtensions/common/src/python/aimet_common/defs.py
@@ -46,26 +46,40 @@ from aimet_common.layer_database import Layer
 from aimet_common import libpymo
 
 
-# supported quantization schemes
 class QuantScheme(Enum):
-    """ Enumeration of Quant schemes"""
-
-    post_training_tf = 1
-    """ For a Tensor, the absolute minimum and maximum value of the Tensor are used to compute the Quantization
-    encodings. """
+    """Quantization schemes"""
+    min_max = 1
+    post_training_tf = min_max
     post_training_tf_enhanced = 2
-    """ For a Tensor, searches and selects the optimal minimum and maximum value that minimizes the Quantization Noise.
-    The Quantization encodings are calculated using the selected minimum and maximum value. """
+
+    ### Below are deprecated ###
     training_range_learning_with_tf_init = 3
-    """ For a Tensor, the encoding values are initialized with the post_training_tf scheme. Then, the encodings are
-    learned during training. """
     training_range_learning_with_tf_enhanced_init = 4
-    """ For a Tensor, the encoding values are initialized with the post_training_tf_enhanced scheme. Then, the encodings
-    are learned during training. """
     training_range_learning = 5
     post_training_percentile = 6
-    """ For a Tensor, adjusted minimum and maximum values are selected based on the percentile value passed.
-    The Quantization encodings are calculated using the adjusted minimum and maximum value."""
+    #############################
+
+    @classmethod
+    def from_str(cls, alias: str) -> "QuantScheme":
+        """
+        Returns QuantScheme object from string alias
+        """
+        try:
+            return _quant_scheme_aliases[alias]
+        except KeyError as e:
+            raise ValueError(
+                f"Invalid string literal {alias}"
+                f"Expected one of {list(_quant_scheme_aliases.keys())}"
+            ) from e
+
+
+_quant_scheme_aliases = {
+    "min_max": QuantScheme.min_max,
+    "tf": QuantScheme.min_max,
+    "tf_enhanced": QuantScheme.post_training_tf_enhanced,
+    "percentile": QuantScheme.post_training_percentile,
+}
+
 
 MAP_QUANT_SCHEME_TO_PYMO = {QuantScheme.post_training_tf: libpymo.QuantizationMode.QUANTIZATION_TF,
                             QuantScheme.post_training_tf_enhanced:

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -140,7 +140,7 @@ class QuantizationSimModel:
     def __init__(self,
                  model: ModelProto,
                  dummy_input: Dict[str, np.ndarray] = None,
-                 quant_scheme: QuantScheme = QuantScheme.post_training_tf,
+                 quant_scheme: QuantScheme = QuantScheme.min_max,
                  rounding_mode: str = 'nearest',
                  default_param_bw: int = 8,
                  default_activation_bw: int = 8,
@@ -148,11 +148,15 @@ class QuantizationSimModel:
                  device: int = 0, config_file: str = None,
                  default_data_type: QuantizationDataType = QuantizationDataType.int,
                  user_onnx_libs: List[str] = None, path: str = None):
+        if isinstance(quant_scheme, str):
+            quant_scheme = QuantScheme.from_str(quant_scheme)
+
         self.model = model
         if not isinstance(model, ONNXModel):
             self.model = ONNXModel(model)
         if not dummy_input:
             dummy_input = make_dummy_input(self.model.model)
+
         self.qc_quantize_op_dict = {}
         self.connected_graph = ConnectedGraph(self.model)
         self._quant_scheme = quant_scheme

--- a/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/_base/quantsim.py
@@ -303,12 +303,8 @@ class _QuantizationSimModelBase(_QuantizationSimModelInterface):
             self.connected_graph = None
 
         if isinstance(quant_scheme, str):
-            if quant_scheme == 'tf':
-                quant_scheme = QuantScheme.post_training_tf
-            elif quant_scheme == 'tf_enhanced':
-                quant_scheme = QuantScheme.post_training_tf_enhanced
-            elif quant_scheme == 'percentile':
-                quant_scheme = QuantScheme.post_training_percentile
+            quant_scheme = QuantScheme.from_str(quant_scheme)
+
         self._quant_scheme = quant_scheme
         self._rounding_mode = rounding_mode
         self._default_output_bw = default_output_bw

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/quantsim.py
@@ -244,7 +244,7 @@ class QuantizationSimModel(_QuantizationSimModelBase): # pylint: disable=missing
                  default_data_type: QuantizationDataType = QuantizationDataType.int):
         if not quant_scheme:
             old_default = QuantScheme.post_training_tf_enhanced
-            new_default = QuantScheme.training_range_learning_with_tf_init
+            new_default = QuantScheme.min_max
             msg = _red(f"The default value of 'quant_scheme' has changed from '{old_default}' "
                        f"to '{new_default}' since aimet-torch==2.0.0. "
                        "If you wish to maintain the legacy default behavior, "


### PR DESCRIPTION
## Main Changes
1. Added "min_max" as a new name for post_training_tf
```py
class QuantScheme(Enum):
    """Quantization schemes"""
    min_max = 1
    post_training_tf = min_max
```

2. Added string literal aliases
```py
_quant_scheme_aliases = {
    "min_max": QuantScheme.min_max,
    "tf": QuantScheme.min_max,
    "tf_enhanced": QuantScheme.post_training_tf_enhanced,
    "percentile": QuantScheme.post_training_percentile,
}
```