### PR TITLE
Add v1-style TfEnhancedEncodingAnalyzer in aimet_torch.v2

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/_builder.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/_builder.py
@@ -46,7 +46,11 @@ from aimet_torch.quantsim_config.builder import LazyQuantizeWrapper, LazyQuantiz
 import aimet_torch.fp_quantization as v1_fp_quantization
 from aimet_torch.v2.quantization.float import FloatQuantizeDequantize
 from aimet_torch.v2.quantization.affine import QuantizeDequantize
-from aimet_torch.v2.quantization.encoding_analyzer import MinMaxEncodingAnalyzer, PercentileEncodingAnalyzer, SqnrEncodingAnalyzer
+from aimet_torch.v2.quantization.encoding_analyzer import (
+    MinMaxEncodingAnalyzer,
+    PercentileEncodingAnalyzer,
+    TfEnhancedEncodingAnalyzer,
+)
 
 
 class _V2LazyQuantizer(LazyQuantizer):
@@ -118,7 +122,7 @@ class _V2LazyQuantizer(LazyQuantizer):
             return PercentileEncodingAnalyzer(shape)
         if self.quant_scheme in (QuantScheme.post_training_tf_enhanced,
                                  QuantScheme.training_range_learning_with_tf_enhanced_init):
-            return SqnrEncodingAnalyzer(shape)
+            return TfEnhancedEncodingAnalyzer(shape)
         raise NotImplementedError(f"Quant scheme {self.quant_scheme} in old quantsim is not supported yet in quantsim v1.5")
 
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/encoding_analyzer.py
@@ -565,7 +565,7 @@ class SqnrEncodingAnalyzer(EncodingAnalyzer[_Histogram]):
         self.max_parallelism = max_parallelism
 
     @torch.no_grad()
-    def update_stats(self, input_tensor: torch.Tensor) -> _Statistics:
+    def update_stats(self, input_tensor: torch.Tensor) -> _Histogram:
         """
         :meta private:
         """
@@ -726,3 +726,46 @@ class SqnrEncodingAnalyzer(EncodingAnalyzer[_Histogram]):
             # Apply the gamma "fudge factor" to the clipped errors
             square_error = torch.where(clipped, square_error * gamma, square_error)
         return torch.sum(square_error, dim=-1)
+
+
+class TfEnhancedEncodingAnalyzer(SqnrEncodingAnalyzer):
+    """
+    Subclass of SQNR encoding analyzer which mimics the behavior of v1 tf-enhanced encodng analyzer
+
+    This class is only meant to encourage aimet_torch.v1 users to switch to v2
+    without accuracy degradation, since some of the models of the v1 users
+    are reliant on the hardcoded hyperparameters (and even some bugs) of v1 tf-enhanced.
+    """
+
+    # Hardcoded hyperparameters in v1 tf-enhanced
+    _V1_HISTOGRAM_NUM_BINS = 512
+    _V1_ASYMMETRIC_DELTA_CANDIDATES = 17
+    _V1_SYMMETRIC_DELTA_CANDIDATES = 101
+    _V1_OFFSET_CANDIDATES = 21
+    _V1_GAMMA = 3.0 # a.k.a "fudge factor"
+
+    def __init__(self, shape: tuple):
+        super().__init__(shape=shape,
+                         num_bins=self._V1_HISTOGRAM_NUM_BINS,
+                         asymmetric_delta_candidates=self._V1_ASYMMETRIC_DELTA_CANDIDATES,
+                         symmetric_delta_candidates=self._V1_SYMMETRIC_DELTA_CANDIDATES,
+                         offset_candidates=self._V1_OFFSET_CANDIDATES,
+                         gamma=self._V1_GAMMA)
+        self._range_of_first_input: Tuple[torch.Tensor, torch.Tensor] = None
+
+    @torch.no_grad()
+    def update_stats(self, input_tensor: torch.Tensor) -> _Histogram:
+        if self._range_of_first_input is None:
+            input0_min = reduce(input_tensor, shape=self.observer.shape, reduce_op=torch.min).values
+            input0_max = reduce(input_tensor, shape=self.observer.shape, reduce_op=torch.max).values
+            self._range_of_first_input = (input0_min, input0_max)
+
+        input0_min, input0_max = self._range_of_first_input
+        input0_centroid = (input0_min + input0_max) / 2
+        # NOTE: The range of v1 histogram is fixed with 3x range of the first input.
+        #       Unfortunately, many existing user models in v1 are heavily reliant
+        #       to this static nature of v1 histogram. To mimic this behavior in v2,
+        #       we clip the all inputs with 3x range of the first input
+        input_tensor = input_tensor.clamp(min=input0_centroid - (input0_centroid - input0_min) * 3,
+                                          max=input0_centroid + (input0_max - input0_centroid) * 3)
+        return super().update_stats(input_tensor)


### PR DESCRIPTION
## Main Changes
Restored the critical hyperparameters/limitations of v1 tf-enhanced. More specifically,
|                  |    current    |        this PR        |
|:-----------:|:-------------:|:-------------------:|
| num_bins |    2048         |              512          |
| histogram range | dynamically adjusted | fixed with 3x range of the first input |

Theoretically, this is a clear devolution from the correct behavior to the bad/wrong v1-style behavior.
But I think improving tf-enhanced (thus behaving differently from v1 tf-enhanced) is not worth the trouble.
Many v1 users are relying their model's accuracy on tf-enhanced, and some of them are even fine-tuned for tf-enhanced. When they switch to v2, they'll have to deal with their model accuracies either improving or degrading quite randomly and significantly.

That said, I'd like to propose reverting the behavior of tf-enhanced to v1-style implementation (as buggy as it is), and reintroduce a bug-free version of tf-enhanced with a new label, such as "mse" or "sqnr" (to be discussed further)