### PR TITLE
Make sim.onnx.export capable of exporting LPBQ encodings

### DIFF
--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -543,3 +543,47 @@ class GroupedBlockEncoding(AffineEncoding):
             }
 
         return encoding_dict
+
+    @classmethod
+    def _from_affine_encoding(cls, encoding: AffineEncoding) -> "GroupedBlockEncoding":
+        # pylint: disable=import-outside-toplevel, protected-access
+        from .quantizer import GroupedBlockQuantizeDequantize
+
+        if isinstance(encoding, GroupedBlockEncoding):
+            return encoding
+
+        if not isinstance(encoding, AffineEncoding):
+            raise ValueError(
+                "Only AffineEncoding can be converted to GroupedBlockEncoding; "
+                f"got {type(encoding)}"
+            )
+
+        if encoding.block_size is None:
+            raise ValueError(
+                "Only blockwise AffineEncodings can be converted to GroupedBlockEncoding; "
+                f"got block_size={encoding.block_size}"
+            )
+
+        block_axis = encoding._get_block_axis()
+        block_grouping = tuple(
+            s_dim if axis == block_axis else 1 for axis, s_dim in enumerate(encoding.scale.shape)
+        )
+        qtzr = GroupedBlockQuantizeDequantize(shape=encoding.scale.shape,
+                                              bitwidth=encoding.bitwidth,
+                                              symmetric=encoding.symmetry,
+                                              decompressed_bw=encoding.bitwidth * 2,
+                                              block_size=encoding.block_size,
+                                              block_grouping=block_grouping)
+        with torch.no_grad():
+            qtzr.min.copy_(encoding.min)
+            qtzr.max.copy_(encoding.max)
+
+        lpbq_scale = qtzr.get_scale()
+
+        # If encoding.scale is equal to LPBQ scale, we can interpret it as LPBQ
+        if torch.allclose(encoding.scale, lpbq_scale):
+            return qtzr.get_encodings()
+
+        raise ValueError(
+            "Failed to interpret encoding as GroupedBlockEncoding."
+        )

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantization/affine/encoding.py
@@ -546,7 +546,7 @@ class GroupedBlockEncoding(AffineEncoding):
 
     @classmethod
     def _from_affine_encoding(cls, encoding: AffineEncoding) -> "GroupedBlockEncoding":
-        # pylint: disable=import-outside-toplevel, protected-access
+        # pylint: disable=import-outside-toplevel, protected-access, cyclic-import
         from .quantizer import GroupedBlockQuantizeDequantize
 
         if isinstance(encoding, GroupedBlockEncoding):

--- a/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/config_utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/v2/quantsim/config_utils.py
@@ -325,8 +325,7 @@ def _get_layers_to_quantizer_shapes_for_block_size(sim, condition, block_size):
         for name, shape in invalid_layers_for_block_size:
             error_str = f"Quant layer {name} has shape {shape} which does not align with block_size {block_size}. " \
                         f"Each dimension's shape must divide evenly with the corresponding block size."
-            logger.error(error_str)
-            raise RuntimeError('Quant layers found whose weights do not align with block size.')
+            raise RuntimeError(error_str)
 
     return layer_to_quantizer_shape_dict
 


### PR DESCRIPTION
## Problem
`sim.onnx.export` reduces LPBQ encodings into equivalent affine encodings.

## Main Changes
Made `sim.onnx.export` capable of exporting LPBQ encodings
![image](https://github.com/user-attachments/assets/6c8ba512-e6cf-4066-ba57-26d0b5b1eeae)