### PR TITLE
Implement onnx QDQ graph export prototype in aimet-onnx

### DIFF
--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -1026,8 +1026,19 @@ class QuantizationSimModel:
 
         if onnx_opset_version < 10:
             raise RuntimeError(
-                "onnx::QuantizeLinaer and DequantizeLinear are only supported in opset >= 10; "
+                "onnx::QuantizeLinear and DequantizeLinear are only supported in opset >= 10; "
                 f"got {onnx_opset_version}"
+            )
+
+        if onnx_opset_version < 13 and any(
+            qtzr.quant_info.usePerChannelMode and
+            qtzr.tensor_quantizer_params and
+            qtzr.tensor_quantizer_params.channel_axis is not None
+            for qtzr in self.qc_quantize_op_dict.values()
+        ):
+            raise RuntimeError(
+                "onnx::QuantizeLinear and DequantizeLinear only supports "
+                f"per-channel quantization in opset >= 13; got {onnx_opset_version}"
             )
 
         if onnx_opset_version < 21 and any(
@@ -1037,7 +1048,7 @@ class QuantizationSimModel:
             for qtzr in self.qc_quantize_op_dict.values()
         ):
             raise RuntimeError(
-                "onnx::QuantizeLinaer and DequantizeLinear only supports "
+                "onnx::QuantizeLinear and DequantizeLinear only supports "
                 f"blockwise quantization in opset >= 21; got {onnx_opset_version}"
             )
 
@@ -1166,7 +1177,7 @@ def _add_onnx_qdq_node(model: onnx.ModelProto,
             model.graph.initializer.remove(t)
         except ValueError:
             for node in model.graph.node:
-                if node.op_type == "Constant" and node.output[0] == t:
+                if node.op_type == "Constant" and node.output[0] == t.name:
                     model.graph.node.remove(node)
                     break
             else:

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -1102,6 +1102,7 @@ def _add_onnx_qdq_node(model: onnx.ModelProto,
     (bias_int)                           (bias_qdq)
 
     """
+    # pylint: disable=too-many-branches
     output_dtype = encodings["output_dtype"]
     axis = encodings["axis"]
     block_size = encodings["block_size"]
@@ -1159,8 +1160,18 @@ def _add_onnx_qdq_node(model: onnx.ModelProto,
 
     for n in nodes_to_add:
         model.graph.node.append(n)
+
     for t in tensors_to_remove:
-        model.graph.initializer.remove(t)
+        try:
+            model.graph.initializer.remove(t)
+        except ValueError:
+            for node in model.graph.node:
+                if node.op_type == "Constant" and node.output[0] == t:
+                    model.graph.node.remove(node)
+                    break
+            else:
+                raise
+
     for t in tensors_to_add:
         model.graph.initializer.append(t)
 

--- a/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
+++ b/TrainingExtensions/onnx/src/python/aimet_onnx/quantsim.py
@@ -49,6 +49,7 @@ import numpy as np
 import onnx
 
 from onnx import helper
+from onnx.numpy_helper import from_array, to_array
 import onnxruntime as ort
 from onnxruntime import SessionOptions, InferenceSession
 from onnxruntime.quantization.onnx_quantizer import ONNXModel
@@ -138,7 +139,7 @@ class QuantizationSimModel:
     """
 
     def __init__(self,
-                 model: ModelProto,
+                 model: Union[ModelProto, ONNXModel],
                  dummy_input: Dict[str, np.ndarray] = None,
                  quant_scheme: QuantScheme = QuantScheme.min_max,
                  rounding_mode: str = 'nearest',
@@ -151,9 +152,11 @@ class QuantizationSimModel:
         if isinstance(quant_scheme, str):
             quant_scheme = QuantScheme.from_str(quant_scheme)
 
+        if isinstance(model, ModelProto):
+            model = ONNXModel(model)
+
         self.model = model
-        if not isinstance(model, ONNXModel):
-            self.model = ONNXModel(model)
+
         if not dummy_input:
             dummy_input = make_dummy_input(self.model.model)
 
@@ -755,7 +758,7 @@ class QuantizationSimModel:
                     f"Couldn't find the value of \"{bias.name}\" statically from the graph."
                 )
 
-            bias = onnx.numpy_helper.to_array(bias_proto)
+            bias = to_array(bias_proto)
 
             bias_scale = np.maximum(abs(bias) / 2**31, _INT32_MINIMUM_SCALE)
 
@@ -1011,6 +1014,155 @@ class QuantizationSimModel:
 
             for inp in op.inputs:
                 _set_src_qtzr(inp, src_qtzr=out_qtzr[0])
+
+    def _to_onnx_qdq(self) -> onnx.ModelProto:
+        """
+        Return a copy of ModelProto with all QcQuantizeOp replaced with
+        onnx::QuantizeLinear and/or DequantizeLinear
+        """
+        onnx_opset_version = next(
+            opset.version for opset in self.model.opset_import() if opset.domain == ""
+        )
+
+        if onnx_opset_version < 10:
+            raise RuntimeError(
+                "onnx::QuantizeLinaer and DequantizeLinear are only supported in opset >= 10; "
+                f"got {onnx_opset_version}"
+            )
+
+        if onnx_opset_version < 21 and any(
+            qtzr.quant_info.usePerChannelMode and
+            qtzr.tensor_quantizer_params and
+            qtzr.quant_info.blockSize > 0
+            for qtzr in self.qc_quantize_op_dict.values()
+        ):
+            raise RuntimeError(
+                "onnx::QuantizeLinaer and DequantizeLinear only supports "
+                f"blockwise quantization in opset >= 21; got {onnx_opset_version}"
+            )
+
+        model_copy = onnx.ModelProto()
+        model_copy.CopyFrom(self.model.model)
+
+        aimet_qc_quantize_nodes = [
+            node for node in model_copy.graph.node
+            if node.op_type == "QcQuantizeOp"
+            and node.domain in ("aimet.customop.cpu", "aimet.customop.cuda")
+        ]
+
+        for aimet_node in aimet_qc_quantize_nodes:
+            model_copy.graph.node.remove(aimet_node)
+
+            qtzr = self.qc_quantize_op_dict[aimet_node.input[0]]
+            encodings = qtzr._export_2_0_0_encodings() # pylint: disable=protected-access
+
+            if encodings:
+                # Affine quantizer
+                # Replace QcQuantizeOp with onnx::QuantizeLinear and DequantizeLinear
+                _add_onnx_qdq_node(model_copy,
+                                   input_name=aimet_node.input[0],
+                                   output_name=aimet_node.output[0],
+                                   node_name_prefix=aimet_node.name,
+                                   encodings=encodings)
+            else:
+                # Float or disabled quantizer.
+                # In this case, we don't add any QuantizeLinear or DequantizeLinear,
+                # but we should perform extra graph surgery to relay
+                # the producer of QcQuantizerOp's input and
+                # the consumer of QcQuantizerOp's output
+                for node in model_copy.graph.node:
+                    for i, _ in enumerate(node.input):
+                        if node.input[i] == aimet_node.output[0]:
+                            node.input[i] = aimet_node.input[0]
+
+        # TODO: Unfortunately, this sanity check doesn't pass yet because the
+        #       QcQuantizeOp nodes inserted during QuantizationSimModel.__init__
+        #       aren't topologically sorted, but onnx.checker asserts topological
+        #       order of all nodes. Needs to be fixed asap.
+        # onnx.checker.check_model(model_copy, True)
+        return model_copy
+
+
+def _add_onnx_qdq_node(model: onnx.ModelProto,
+                       input_name: str,
+                       output_name: str,
+                       node_name_prefix: str,
+                       encodings: dict):
+    """
+    Add onnx::QuantizeLinear and/or onnx::DequantizeLinear as below
+
+     -------> onnx::QuantizeLinear -------------> onnx::DequantizeLinear ----->
+    (input)                        (input_int)                           (output)
+
+
+    except for int32 bias encodings, for which we take alternative representation as below
+    since onnx::QuantizeLinear doesn't allow int32 outputs.
+
+    -------------> onnx::DequantizeLinear ----->
+    (bias_int)                           (bias_qdq)
+
+    """
+    output_dtype = encodings["output_dtype"]
+    axis = encodings["axis"]
+    block_size = encodings["block_size"]
+
+    y_scale = np.array(encodings["y_scale"]).astype(np.float32)
+    if encodings["y_zero_point"]:
+        y_zero_point = np.array(encodings["y_zero_point"]).astype(output_dtype)
+    else:
+        y_zero_point = np.zeros(y_scale.shape).astype(output_dtype)
+
+    if output_dtype in ("int32", "uint32"):
+        nodes_to_add = [
+            helper.make_node('DequantizeLinear',
+                      name=f"{node_name_prefix}_dq",
+                      inputs=[f"{input_name}_int", f"{input_name}_scale", f"{input_name}_zero_point"],
+                      outputs=[output_name],
+                      axis=axis,
+                      block_size=block_size)
+        ]
+
+        bias = utils.ParamUtils.get_param_by_name(model, input_name)
+        tensors_to_remove = [bias]
+
+        bias_int32 = (to_array(bias) / y_scale).round()
+        if output_dtype == "int32":
+            bias_int32 = bias_int32.clip(-2**31, 2**31-1)
+        else:
+            bias_int32 = bias_int32.clip(0, 2**32-1)
+
+        tensors_to_add = [
+            from_array(bias_int32.astype(output_dtype), name=f"{input_name}_int"),
+            from_array(y_scale, name=f"{input_name}_scale"),
+            from_array(y_zero_point, name=f"{input_name}_zero_point"),
+        ]
+    else:
+        nodes_to_add = [
+            helper.make_node('QuantizeLinear',
+                      name=f"{node_name_prefix}_q",
+                      inputs=[input_name, f"{input_name}_scale", f"{input_name}_zero_point"],
+                      outputs=[f"{input_name}_int"],
+                      axis=axis,
+                      block_size=block_size),
+            helper.make_node('DequantizeLinear',
+                      name=f"{node_name_prefix}_dq",
+                      inputs=[f"{input_name}_int", f"{input_name}_scale", f"{input_name}_zero_point"],
+                      outputs=[output_name],
+                      axis=axis,
+                      block_size=block_size)
+        ]
+        tensors_to_remove = []
+        tensors_to_add = [
+            from_array(y_scale, name=f"{input_name}_scale"),
+            from_array(y_zero_point, name=f"{input_name}_zero_point"),
+        ]
+
+    for n in nodes_to_add:
+        model.graph.node.append(n)
+    for t in tensors_to_remove:
+        model.graph.initializer.remove(t)
+    for t in tensors_to_add:
+        model.graph.initializer.append(t)
 
 
 # pylint: disable=too-many-locals, too-many-branches

--- a/TrainingExtensions/onnx/test/python/models/models_for_tests.py
+++ b/TrainingExtensions/onnx/test/python/models/models_for_tests.py
@@ -57,6 +57,8 @@ from onnxruntime_extensions import PyOp, onnx_op
 from aimet_common import libquant_info
 from .mobilenet import MockMobileNetV1, MockMobileNetV11
 
+_DEFAULT_OPSET_VERSION = 13
+
 
 class Add(torch.nn.Module):
     """ Add module for a functional add"""
@@ -1082,7 +1084,8 @@ def build_lstm_gru_dummy_model():
     return model
 
 
-def single_residual_model(training=torch.onnx.TrainingMode.EVAL):
+def single_residual_model(training=torch.onnx.TrainingMode.EVAL,
+                          opset_version=_DEFAULT_OPSET_VERSION):
     x = torch.randn(1, 3, 32, 32)
     model = SingleResidualWithAvgPool()
 
@@ -1094,14 +1097,14 @@ def single_residual_model(training=torch.onnx.TrainingMode.EVAL):
                           save_path,  # where to save the model (can be a file or file-like object)
                           training=training,
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
         model_onnx = ONNXModel(load_model(save_path))
     return model_onnx
 
-def multi_input_model():
+def multi_input_model(opset_version=_DEFAULT_OPSET_VERSION):
     x = (torch.rand(32, 1, 28, 28, requires_grad=True), torch.rand(32, 1, 28, 28, requires_grad=True))
     model = ModelWithTwoInputs()
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1111,7 +1114,7 @@ def multi_input_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1132,7 +1135,7 @@ def multi_output_model():
         model = ONNXModel(load_model(onnx_filename))
     return model
 
-def transposed_conv_model():
+def transposed_conv_model(opset_version=_DEFAULT_OPSET_VERSION):
     with tempfile.TemporaryDirectory() as save_dir:
         x = torch.randn(10, 10, 4, 4, requires_grad=True)
         model = TransposedConvModel()
@@ -1142,7 +1145,7 @@ def transposed_conv_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1150,7 +1153,7 @@ def transposed_conv_model():
     return model
 
 
-def depthwise_transposed_conv_model():
+def depthwise_transposed_conv_model(opset_version=_DEFAULT_OPSET_VERSION):
     with tempfile.TemporaryDirectory() as save_dir:
         x = torch.randn(10, 10, 4, 4, requires_grad=True)
         model = DepthwiseTransposedConvModel()
@@ -1160,7 +1163,7 @@ def depthwise_transposed_conv_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1168,7 +1171,7 @@ def depthwise_transposed_conv_model():
     return model
 
 
-def transposed_conv_model_without_bn():
+def transposed_conv_model_without_bn(opset_version=_DEFAULT_OPSET_VERSION):
     x = torch.randn(10, 10, 4, 4, requires_grad=True)
     model = TransposedConvModelWithoutBN()
 
@@ -1179,7 +1182,7 @@ def transposed_conv_model_without_bn():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1187,7 +1190,7 @@ def transposed_conv_model_without_bn():
     return model
 
 
-def linear_split_into_matmul_add():
+def linear_split_into_matmul_add(opset_version=_DEFAULT_OPSET_VERSION):
     with tempfile.TemporaryDirectory() as save_dir:
         # 3D input will split the linear layer in MatMul + Add in ONNX graph.
         dummy_input = torch.randn(1, 2, 4)
@@ -1208,7 +1211,7 @@ def linear_split_into_matmul_add():
                           dummy_input,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1216,7 +1219,7 @@ def linear_split_into_matmul_add():
     return model
 
 
-def depthwise_conv_model():
+def depthwise_conv_model(opset_version=_DEFAULT_OPSET_VERSION):
     x = torch.randn(1, 3, 224, 224, requires_grad=True)
     model = MockMobileNetV1()
 
@@ -1227,14 +1230,14 @@ def depthwise_conv_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
         model = ONNXModel(load_model(save_path))
     return model
 
-def depthwise_conv_model_with_relu6():
+def depthwise_conv_model_with_relu6(opset_version=_DEFAULT_OPSET_VERSION):
     x = torch.randn(1, 3, 224, 224, requires_grad=True)
     model = MockMobileNetV11()
 
@@ -1245,14 +1248,14 @@ def depthwise_conv_model_with_relu6():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
         model = ONNXModel(load_model(save_path))
     return model
 
-def concat_model():
+def concat_model(opset_version=_DEFAULT_OPSET_VERSION):
     x = (torch.rand(1, 3, 8, 8, requires_grad=True), torch.rand(1, 3, 8, 8, requires_grad=True),
          torch.rand(1, 3, 8, 8, requires_grad=True))
     model = ConcatModel()
@@ -1264,14 +1267,14 @@ def concat_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
         model = ONNXModel(load_model(save_path))
     return model
 
-def hierarchical_model():
+def hierarchical_model(opset_version=_DEFAULT_OPSET_VERSION):
     conv_shape = (1, 64, 32, 32)
     inp_shape = (1, 3, 32, 32)
     seq_shape = (1, 3, 8, 8)
@@ -1288,7 +1291,7 @@ def hierarchical_model():
                           x,  # model input (or a tuple for multiple inputs)
                           save_path,  # where to save the model (can be a file or file-like object)
                           export_params=True,  # store the trained parameter weights inside the model file
-                          opset_version=12,  # the ONNX version to export the model to
+                          opset_version=opset_version,  # the ONNX version to export the model to
                           do_constant_folding=True,  # whether to execute constant folding for optimization
                           input_names=['input'],  # the model's input names
                           output_names=['output'])
@@ -1622,7 +1625,8 @@ class MultipleOutputModel(SingleResidual):
         return x, y
 
 
-def _convert_to_onnx_no_fold(model: torch.nn.Module, dummy_input, filename='temp_model.onnx'):
+def _convert_to_onnx_no_fold(model: torch.nn.Module, dummy_input, filename='temp_model.onnx',
+                             opset_version=_DEFAULT_OPSET_VERSION):
     with tempfile.TemporaryDirectory() as tmp_dir:
         save_path = os.path.join(tmp_dir, filename)
         torch.onnx.export(model.eval(),
@@ -1630,7 +1634,7 @@ def _convert_to_onnx_no_fold(model: torch.nn.Module, dummy_input, filename='temp
                           save_path,
                           training=torch.onnx.TrainingMode.PRESERVE,
                           export_params=True,
-                          opset_version=12,
+                          opset_version=opset_version,
                           do_constant_folding=False,
                           input_names=['input'],
                           output_names=['output'])
@@ -1638,7 +1642,8 @@ def _convert_to_onnx_no_fold(model: torch.nn.Module, dummy_input, filename='temp
     return model
 
 
-def _convert_to_onnx(model: torch.nn.Module, dummy_input, filename='temp_model.onnx'):
+def _convert_to_onnx(model: torch.nn.Module, dummy_input, filename='temp_model.onnx',
+                     opset_version=_DEFAULT_OPSET_VERSION):
     with tempfile.TemporaryDirectory() as tmp_dir:
         save_path = os.path.join(tmp_dir, filename)
         torch.onnx.export(model.eval(),
@@ -1646,7 +1651,7 @@ def _convert_to_onnx(model: torch.nn.Module, dummy_input, filename='temp_model.o
                           save_path,
                           training=torch.onnx.TrainingMode.EVAL,
                           export_params=True,
-                          opset_version=12,
+                          opset_version=opset_version,
                           do_constant_folding=True,
                           input_names=['input'],
                           output_names=['output'])
@@ -1654,7 +1659,7 @@ def _convert_to_onnx(model: torch.nn.Module, dummy_input, filename='temp_model.o
     return model
 
 
-def my_model_with_bns():
+def my_model_with_bns(opset_version=_DEFAULT_OPSET_VERSION):
     torch.manual_seed(10)
     model = MyModelFoldFoward().eval()
     initialize_bn_params(model)
@@ -1669,7 +1674,7 @@ def my_model_with_bns():
                       # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.TRAINING,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'])
@@ -1686,7 +1691,7 @@ def initialize_bn_params(model: torch.nn.Module):
                 module.running_mean.copy_(torch.randn_like(module.bias))
                 module.running_var.add_(torch.randn_like(module.bias).abs())
 
-def elementwise_op_model():
+def elementwise_op_model(opset_version=_DEFAULT_OPSET_VERSION):
     torch.manual_seed(10)
     model = ConstantElementwiseInputModel().eval()
 
@@ -1700,7 +1705,7 @@ def elementwise_op_model():
                       # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.EVAL,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'])
@@ -1729,7 +1734,7 @@ class MultiInputWithConstant(torch.nn.Module):
         x = self.add2(x, torch.tensor(2.0))
         return x
 
-def multi_input_with_constant_model():
+def multi_input_with_constant_model(opset_version=_DEFAULT_OPSET_VERSION):
     torch.manual_seed(10)
     model = MultiInputWithConstant().eval()
 
@@ -1742,7 +1747,7 @@ def multi_input_with_constant_model():
                       # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.EVAL,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'])
@@ -1800,7 +1805,7 @@ def build_dummy_model_with_dynamic_input():
     return model
 
 
-def simple_relu_model():
+def simple_relu_model(opset_version=_DEFAULT_OPSET_VERSION):
     class ReLUModel(torch.nn.Module):
         def __init__(self):
             super(ReLUModel, self).__init__()
@@ -1823,14 +1828,14 @@ def simple_relu_model():
                       # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.TRAINING,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'])
     model_onnx = ONNXModel(load_model('./simple_relu.onnx'))
     return model_onnx
 
-def instance_norm_model():
+def instance_norm_model(opset_version=_DEFAULT_OPSET_VERSION):
     model = InstanceNormModel().eval()
     for module in model.modules():
         if isinstance(module, _InstanceNorm) and not module.affine:
@@ -1848,7 +1853,7 @@ def instance_norm_model():
                       # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.TRAINING,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'])
@@ -1892,7 +1897,7 @@ def custom_add_model():
     return model_onnx
 
 
-def conv_relu_model():
+def conv_relu_model(opset_version=_DEFAULT_OPSET_VERSION):
     class ConvReluModel(torch.nn.Module):
         def __init__(self):
             super(ConvReluModel, self).__init__()
@@ -1911,7 +1916,7 @@ def conv_relu_model():
                       "./conv_relu.onnx", # where to save the model (can be a file or file-like object),
                       training=torch.onnx.TrainingMode.EVAL,
                       export_params=True,  # store the trained parameter weights inside the model file
-                      opset_version=12,  # the ONNX version to export the model to
+                      opset_version=opset_version,  # the ONNX version to export the model to
                       do_constant_folding=False,  # whether to execute constant folding for optimization
                       input_names=['input'],  # the model's input names
                       output_names=['output'],

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -2202,42 +2202,45 @@ def test_bias_export(model_factory, input_shape, block_size, lpbq, tmp_path):
         assert np.allclose(bias_scale, expected_bias_scale)
 
 
-@pytest.mark.parametrize("export_int32_bias_encodings", [
-    False,
-    # TODO: Simulating int32 bias quantize-dequantize in AIMET doesn't
-    #       produce output close enough to equivalent onnx QDQ graph
-    #       due to numerical instability
-    # True,
+@pytest.mark.parametrize("export_int32_bias_encodings", [False, True])
+@pytest.mark.parametrize(
+    "model_factory,                                   input_shape", [
+    (lambda: single_residual_model(opset_version=13), (1, 3, 32, 32)),
+    (lambda: transposed_conv_model(opset_version=13), (10, 10, 4, 4)),
+    (batchnorm_model,                                 (10, 10, 8, 8)),
+    (batchnorm_model_constants,                       (10, 10, 8, 8)),
+    (lambda: instance_norm_model(opset_version=13),   (2, 10, 24, 24)),
+    (layernorm_model,                                 (1, 4, 64, 64)),
 ])
-def test_onnx_qdq(export_int32_bias_encodings):
-    """
-    Given: Resnet18
-    """
-    model = torchvision.models.resnet18(pretrained=False)
-    input = torch.randn(32, 3, 224, 224)
-
-    with tempfile.TemporaryDirectory() as tmpdir:
-        path = os.path.join(tmpdir, "model.onnx")
-        torch.onnx.export(model, input, path, input_names=["input"], output_names=["output"])
-        sim = QuantizationSimModel(onnx.load_model(path))
+def test_onnx_qdq(model_factory, input_shape, export_int32_bias_encodings):
+    model = model_factory()
+    sim = QuantizationSimModel(model)
+    input = np.random.randn(*input_shape).astype(np.float32)
 
     """
     When: Create a pure onnx model with sim._to_onnx_qdq()
     Then: Output of the pure onnx model should be equal to that of sim.session
     """
-    sim.compute_encodings(lambda sess, _: sess.run(None, {"input": input.numpy()}), None)
+    sim.compute_encodings(lambda sess, _: sess.run(None, {"input": input}), None)
 
     if export_int32_bias_encodings:
         sim._concretize_int32_bias_quantizers()
 
-    out_sim, = sim.session.run(None, {"input": input.numpy()})
+    out_sim, = sim.session.run(None, {"input": input})
 
     onnx_qdq_model = sim._to_onnx_qdq()
     sess = ort.InferenceSession(onnx_qdq_model.SerializeToString(), providers=['CPUExecutionProvider'])
-    out_onnx_qdq, = sess.run(None, {"input": input.numpy()})
+    out_onnx_qdq, = sess.run(None, {"input": input})
 
     # Tolerate off-by-three error.
     # Off-by-N error can occur due to slight numerical differences between
     # AIMET QcQuantizOp and onnx::QuantizeLinear/DequantizeLinear
     atol = 3 * sim.qc_quantize_op_dict["output"].get_encodings()[0].delta
+
+    if export_int32_bias_encodings:
+        pytest.skip(
+            "Simulating int32 bias quantize-dequantize in AIMET doesn't "
+            "produce output close enough to equivalent onnx QDQ graph "
+            "due to numerical instability"
+        )
     assert np.allclose(out_sim, out_onnx_qdq, atol=atol)

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -46,6 +46,7 @@ import functools
 
 import onnx.numpy_helper
 import torch
+import torchvision
 import numpy as np
 from onnx import load_model
 import onnx
@@ -2199,3 +2200,43 @@ def test_bias_export(model_factory, input_shape, block_size, lpbq, tmp_path):
         bias_value = onnx.numpy_helper.to_array(bias_proto)
         expected_bias_scale = np.maximum(abs(bias_value) / 2**31, _INT32_MINIMUM_SCALE)
         assert np.allclose(bias_scale, expected_bias_scale)
+
+
+@pytest.mark.parametrize("export_int32_bias_encodings", [
+    False,
+    # TODO: Simulating int32 bias quantize-dequantize in AIMET doesn't
+    #       produce output close enough to equivalent onnx QDQ graph.
+    # True,
+])
+def test_onnx_qdq(export_int32_bias_encodings):
+    """
+    Given: Resnet18
+    """
+    model = torchvision.models.resnet18(pretrained=False)
+    input = torch.randn(32, 3, 224, 224)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        path = os.path.join(tmpdir, "model.onnx")
+        torch.onnx.export(model, input, path, input_names=["input"], output_names=["output"])
+        sim = QuantizationSimModel(onnx.load_model(path))
+
+    """
+    When: Create a pure onnx model with sim._to_onnx_qdq()
+    Then: Output of the pure onnx model should be equal to that of sim.session
+    """
+    sim.compute_encodings(lambda sess, _: sess.run(None, {"input": input.numpy()}), None)
+
+    if export_int32_bias_encodings:
+        sim._concretize_int32_bias_quantizers()
+
+    out_sim, = sim.session.run(None, {"input": input.numpy()})
+
+    onnx_qdq_model = sim._to_onnx_qdq()
+    sess = ort.InferenceSession(onnx_qdq_model.SerializeToString(), providers=['CPUExecutionProvider'])
+    out_onnx_qdq, = sess.run(None, {"input": input.numpy()})
+
+    # Tolerate off-by-three error.
+    # Off-by-N error can occur due to slight numerical differences between
+    # AIMET QcQuantizOp and onnx::QuantizeLinear/DequantizeLinear
+    atol = 3 * sim.qc_quantize_op_dict["output"].get_encodings()[0].delta
+    assert np.allclose(out_sim, out_onnx_qdq, atol=atol)

--- a/TrainingExtensions/onnx/test/python/test_quantsim.py
+++ b/TrainingExtensions/onnx/test/python/test_quantsim.py
@@ -2205,7 +2205,8 @@ def test_bias_export(model_factory, input_shape, block_size, lpbq, tmp_path):
 @pytest.mark.parametrize("export_int32_bias_encodings", [
     False,
     # TODO: Simulating int32 bias quantize-dequantize in AIMET doesn't
-    #       produce output close enough to equivalent onnx QDQ graph.
+    #       produce output close enough to equivalent onnx QDQ graph
+    #       due to numerical instability
     # True,
 ])
 def test_onnx_qdq(export_int32_bias_encodings):


### PR DESCRIPTION
## Main Changes
Implemented `_to_onnx_qdq` method which returns a pure onnx QDQ model which you can run on ort or save as .onnx file.
```py
onnx_qdq_model = sim._to_onnx_qdq()

# Save to file
with open("onnx_qdq.onnx", "wb") as f:
    f.write(onnx_qdq_model.SerializeToString())

# Run with ORT
sess = ort.InferenceSession(onnx_qdq_model.SerializeToString(), providers=['CPUExecutionProvider'])
out, = sess.run(None, {"input": input.numpy()})
```