### PR TITLE
Add :no-index: roles to onnx and tensorflow api reference.

### DIFF
--- a/Docs/apiref/onnx/adaround.rst
+++ b/Docs/apiref/onnx/adaround.rst
@@ -13,9 +13,11 @@ aimet_onnx.adaround
 **Top-level API**
 
 .. autofunction:: aimet_onnx.adaround.adaround_weight.Adaround.apply_adaround
+   :no-index:
 
 **Adaround Parameters**
 
 .. autoclass:: aimet_onnx.adaround.adaround_weight.AdaroundParameters
     :members:
+    :no-index:
 

--- a/Docs/apiref/onnx/amp.rst
+++ b/Docs/apiref/onnx/amp.rst
@@ -10,7 +10,7 @@ aimet_onnx.mixed_precision
 **Top-level API**
 
 .. autofunction:: aimet_onnx.mixed_precision.choose_mixed_precision
-
+   :no-index:
 
 .. note::
 
@@ -21,14 +21,17 @@ aimet_onnx.mixed_precision
 
 .. autoclass:: aimet_onnx.amp.quantizer_groups.QuantizerGroup
    :members:
+   :no-index:
 
 **CallbackFunc Definition**
 
 .. autoclass:: aimet_common.defs.CallbackFunc
    :members:
+   :no-index:
 
 .. autoclass:: aimet_onnx.amp.mixed_precision_algo.EvalCallbackFactory
    :members:
+   :no-index:
 
 ..
   # end-before

--- a/Docs/apiref/onnx/bnf.rst
+++ b/Docs/apiref/onnx/bnf.rst
@@ -10,3 +10,4 @@ aimet_onnx.batch_norm_fold
 **Top-level API**
 
 .. autofunction:: aimet_onnx.batch_norm_fold.fold_all_batch_norms_to_weight
+   :no-index:

--- a/Docs/apiref/onnx/cle.rst
+++ b/Docs/apiref/onnx/cle.rst
@@ -10,3 +10,4 @@ aimet_onnx.cross_layer_equalization
 **Top-level API**
 
 .. autofunction:: aimet_onnx.cross_layer_equalization.equalize_model
+   :no-index:

--- a/Docs/apiref/onnx/layer_output_generation.rst
+++ b/Docs/apiref/onnx/layer_output_generation.rst
@@ -8,11 +8,12 @@ aimet_onnx.layer_output_utils
   # start-after
 
 .. autoclass:: aimet_onnx.layer_output_utils.LayerOutputUtil
-
+   :no-index:
 
 **The following API can be used to Generate Layer Outputs**
 
 .. automethod:: aimet_onnx.layer_output_utils.LayerOutputUtil.generate_layer_outputs
+   :no-index:
 
 ..
   # end-before

--- a/Docs/apiref/onnx/quant_analyzer.rst
+++ b/Docs/apiref/onnx/quant_analyzer.rst
@@ -13,10 +13,13 @@ aimet_onnx.quant_analyzer
     It is recommended to use onnx-simplifier before applying quant-analyzer.
 
 .. autoclass:: aimet_onnx.quant_analyzer.QuantAnalyzer
+   :no-index:
 
 .. automethod:: aimet_onnx.quant_analyzer.QuantAnalyzer.enable_per_layer_mse_loss
+   :no-index:
 
 .. automethod:: aimet_onnx.quant_analyzer.QuantAnalyzer.analyze
+   :no-index:
 
 **Alternatively, you can run specific utility**
 

--- a/Docs/apiref/onnx/quantsim.rst
+++ b/Docs/apiref/onnx/quantsim.rst
@@ -11,14 +11,17 @@ aimet_onnx.quantsim
     It is recommended to use onnx-simplifier before creating quantsim model.
 
 .. autoclass:: aimet_onnx.quantsim.QuantizationSimModel
+   :no-index:
 
 **The following API can be used to compute encodings for calibration.**
 
 .. automethod:: aimet_onnx.quantsim.QuantizationSimModel.compute_encodings
+   :no-index:
 
 **The following API can be used to export the quantized model to target.**
 
 .. automethod:: aimet_onnx.quantsim.QuantizationSimModel.export
+   :no-index:
 
 Enum Definition
 ===============
@@ -27,3 +30,4 @@ Enum Definition
 
 .. autoclass:: aimet_common.defs.QuantScheme
     :members:
+    :no-index:

--- a/Docs/apiref/onnx/seq_mse.rst
+++ b/Docs/apiref/onnx/seq_mse.rst
@@ -10,11 +10,13 @@ aimet_onnx.seq_mse
 **Top level APIs**
 
 .. autofunction:: aimet_onnx.sequential_mse.seq_mse.SequentialMse.apply_seq_mse
+   :no-index:
 
 **Sequential MSE parameters**
 
 .. autoclass:: aimet_onnx.sequential_mse.seq_mse.SeqMseParams
     :members:
+    :no-index:
 
 ..
   # end-before

--- a/Docs/apiref/tensorflow/adaround.rst
+++ b/Docs/apiref/tensorflow/adaround.rst
@@ -10,8 +10,10 @@ aimet_tensorflow.adaround
 **Top-level API**
 
 .. autofunction:: aimet_tensorflow.keras.adaround_weight.Adaround.apply_adaround
+   :no-index:
 
 **Adaround Parameters**
 
 .. autoclass:: aimet_tensorflow.keras.adaround_weight.AdaroundParameters
     :members:
+    :no-index:

--- a/Docs/apiref/tensorflow/amp.rst
+++ b/Docs/apiref/tensorflow/amp.rst
@@ -10,11 +10,13 @@ aimet_tensorflow.mixed_precision
 **Top-level API for Regular AMP**
 
 .. autofunction:: aimet_tensorflow.keras.mixed_precision.choose_mixed_precision
+   :no-index:
 
 
 **Top-level API for Fast AMP (AMP 2.0)**
 
 .. autofunction:: aimet_tensorflow.keras.mixed_precision.choose_fast_mixed_precision
+   :no-index:
 
 .. note::
 
@@ -26,11 +28,13 @@ Currently only two candidates are supported - ((8,int), (8,int)) & ((16,int), (8
 
 .. autoclass:: aimet_tensorflow.keras.amp.quantizer_groups.QuantizerGroup
    :members:
+   :no-index:
 
 **CallbackFunc Definition**
 
 .. autoclass:: aimet_common.defs.CallbackFunc
    :members:
+   :no-index:
 
 ..
   # end-before

--- a/Docs/apiref/tensorflow/autoquant.rst
+++ b/Docs/apiref/tensorflow/autoquant.rst
@@ -12,3 +12,4 @@ aimet_tensorflow.auto_quant_v2
 .. autoclass:: aimet_tensorflow.keras.auto_quant_v2.AutoQuantWithAutoMixedPrecision
     :members:
     :member-order: bysource
+    :no-index:

--- a/Docs/apiref/tensorflow/bn.rst
+++ b/Docs/apiref/tensorflow/bn.rst
@@ -10,5 +10,7 @@ aimet_tensorflow.keras.bn_reestimation
 **Top-level API**
 
 .. autofunction:: aimet_tensorflow.keras.bn_reestimation.reestimate_bn_stats
+   :no-index:
 
 .. autofunction:: aimet_tensorflow.keras.batch_norm_fold.fold_all_batch_norms_to_scale
+   :no-index:

--- a/Docs/apiref/tensorflow/bnf.rst
+++ b/Docs/apiref/tensorflow/bnf.rst
@@ -10,3 +10,4 @@ aimet_tensorflow.batch_norm_fold
 **Top-level API**
 
 .. autofunction:: aimet_tensorflow.keras.batch_norm_fold.fold_all_batch_norms
+   :no-index:

--- a/Docs/apiref/tensorflow/cle.rst
+++ b/Docs/apiref/tensorflow/cle.rst
@@ -10,3 +10,4 @@ aimet_tensorflow.cross_layer_equalization
 **Top-level API**
 
 .. autofunction:: aimet_tensorflow.keras.cross_layer_equalization.equalize_model
+   :no-index:

--- a/Docs/apiref/tensorflow/compress.rst
+++ b/Docs/apiref/tensorflow/compress.rst
@@ -10,15 +10,19 @@ aimet_tensorflow.compress
 **Top-level API for Compression**
 
 .. autoclass:: aimet_tensorflow.keras.compress.ModelCompressor
+   :no-index:
 
 .. automethod:: aimet_tensorflow.keras.compress.ModelCompressor.compress_model
+   :no-index:
 
 **Greedy Selection Parameters**
 
 .. autoclass:: aimet_common.defs.GreedySelectionParameters
    :members:
+   :no-index:
 
 **Spatial SVD Configuration**
 
 .. autoclass:: aimet_tensorflow.keras.defs.SpatialSvdParameters
    :members:
+   :no-index:

--- a/Docs/apiref/tensorflow/layer_output_generation.rst
+++ b/Docs/apiref/tensorflow/layer_output_generation.rst
@@ -8,11 +8,13 @@ aimet_tensorflow.layer_output_utils
   # start-after
 
 .. autoclass:: aimet_tensorflow.keras.layer_output_utils.LayerOutputUtil
+   :no-index:
 
 
 **The following API can be used to Generate Layer Outputs**
 
 .. automethod:: aimet_tensorflow.keras.layer_output_utils.LayerOutputUtil.generate_layer_outputs
+   :no-index:
 
 ..
   # end-before

--- a/Docs/apiref/tensorflow/model_preparer.rst
+++ b/Docs/apiref/tensorflow/model_preparer.rst
@@ -165,3 +165,4 @@ API
 ===
 
 .. autofunction:: aimet_tensorflow.keras.model_preparer.prepare_model
+   :no-index:

--- a/Docs/apiref/tensorflow/quantsim.rst
+++ b/Docs/apiref/tensorflow/quantsim.rst
@@ -8,14 +8,17 @@ aimet_tensorflow.quantsim
   # start-after
 
 .. autoclass:: aimet_tensorflow.keras.quantsim.QuantizationSimModel
+   :no-index:
 
 **The following API can be used to Compute Encodings for Model**
 
 .. automethod:: aimet_tensorflow.keras.quantsim.QuantizationSimModel.compute_encodings
+   :no-index:
 
 **The following API can be used to Export the Model to target**
 
 .. automethod:: aimet_tensorflow.keras.quantsim.QuantizationSimModel.export
+   :no-index:
 
 Enum Definition
 ===============
@@ -24,3 +27,4 @@ Enum Definition
 
 .. autoclass:: aimet_common.defs.QuantScheme
     :members:
+    :no-index:


### PR DESCRIPTION
 Reduces the number of warnings in the documentation build.

Eliminates ONNX and TensorFlow class and function entries from search results. Top-level API references are still indexed and appear in search results.