### PR TITLE
Extend compute_encodings API of aimet-onnx

### DIFF
--- a/Docs/apiref/onnx/quantsim.rst
+++ b/Docs/apiref/onnx/quantsim.rst
@@ -10,18 +10,8 @@ aimet_onnx.quantsim
 .. note::
     It is recommended to use onnx-simplifier before creating quantsim model.
 
-.. autoclass:: aimet_onnx.quantsim.QuantizationSimModel
-
-**The following API can be used to compute encodings for calibration.**
-
-.. automethod:: aimet_onnx.quantsim.QuantizationSimModel.compute_encodings
-
-**The following API can be used to export the quantized model to target.**
-
-.. automethod:: aimet_onnx.quantsim.QuantizationSimModel.export
-
-Enum Definition
-===============
+.. autoclass:: aimet_torch.QuantizationSimModel
+   :members: compute_encodings, export
 
 **Quant Scheme Enum**
 


### PR DESCRIPTION
## Main Changes
Extended comptue_encodings API similar to aimet_torch quantsim.
Now we don't need the redundant second argument "forward_pass_callback_args" anymore
```pycon
>>> sim = QuantizationSimModel(...)
>>> def run_forward_pass(session: ort.InferenceSession):
...     for input in dataset:
...         _ = sess.run(None, {"input": input})

>>> sim.compute_encodings(run_forward_pass)
```