### PR TITLE
Fix bias-correction for multi-input model

### DIFF
--- a/Docs/legacy/torch_code_examples/post_training_techniques_examples.py
+++ b/Docs/legacy/torch_code_examples/post_training_techniques_examples.py
@@ -186,13 +186,14 @@ def bias_correction_analytical_and_empirical():
 
     dataset_size = 2000
     batch_size = 64
+    dummy_input = torch.rand((1, 3, 224, 224))
 
     # Load the model analytical_empirical
     model = MobileNetV2()
     model.eval()
 
     # Find BNs
-    module_prop_dict = bias_correction.find_all_conv_bn_with_activation(model, input_shape=(1, 3, 224, 224))
+    module_prop_dict = bias_correction.find_all_conv_bn_with_activation(model, dummy_input)
 
     # Apply Analytical and Empirical Bias Correction
     from aimet_torch import bias_correction

--- a/NightlyTests/torch/test_bias_correction.py
+++ b/NightlyTests/torch/test_bias_correction.py
@@ -101,7 +101,7 @@ class TestBiasCorrection:
         model = MobileNetV2().to(torch.device('cpu'))
         model.eval()
         module_prop_list = aimet_torch.bias_correction.find_all_conv_bn_with_activation(model,
-                                                                                        input_shape=(1, 3, 224, 224))
+                                                                                        dummy_input=torch.rand((1, 3, 224, 224)))
         batch_norm_fold.fold_all_batch_norms(model, (1, 3, 224, 224))
         model_copy = copy.deepcopy(model)
         model.eval()

--- a/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
@@ -262,7 +262,7 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
         # forward pass for given number of batches for model
         data_loader_n_samples_quant = itertools.islice(data_loader, n_batches_quantization)
 
-        for model_input in data_loader_n_samples_quant:
+        for model_input, _ in data_loader_n_samples_quant:
             forward_pass(model, model_input)
 
     ordered_conv_linear_nodes = get_ordered_lists_of_conv_fc(model, dummy_input=dummy_input)
@@ -340,7 +340,7 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
                     quantized_outputs = []
                     data_loader_n_samples_bias_corr = itertools.islice(data_loader, n_batches_bias_correction)
 
-                    for images_in_one_batch in data_loader_n_samples_bias_corr:
+                    for images_in_one_batch, _ in data_loader_n_samples_bias_corr:
                         reference_output_batch = get_output_data(reference_layer, model_copy, images_in_one_batch)
                         quantized_model_output_batch = get_output_data(quantize_layer, model, images_in_one_batch)
 

--- a/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
@@ -40,6 +40,7 @@
 import itertools
 from typing import Callable, Tuple, List, Union, Dict
 import copy
+import warnings
 
 import torch
 import torch.nn
@@ -47,7 +48,7 @@ import numpy as np
 
 from aimet_common.graph_pattern_matcher import PatternType
 from aimet_common.graph_searcher import GraphSearcher
-from aimet_common.utils import AimetLogger
+from aimet_common.utils import AimetLogger, _red
 from aimet_common.bias_correction import (
     ConvBnInfoType,
     ConvBnPatternHandler,
@@ -221,8 +222,9 @@ def call_analytical_correct_bias(layer: torch.nn.Module,
                                                                             dtype=layer.bias.dtype)
 
 
+# pylint: disable=too-many-arguments
 def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_samples: int,
-                 dummy_input: Union[torch.Tensor, Tuple], data_loader, num_bias_correct_samples: int,
+                 data_loader, num_bias_correct_samples: int, dummy_input: Union[torch.Tensor, Tuple] = None,
                  conv_bn_dict: Union[Dict[torch.nn.Module, ConvBnInfoType], None] = None,
                  perform_only_empirical_bias_corr: bool = True,
                  layers_to_ignore: List[torch.nn.Module] = None):
@@ -251,6 +253,13 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
     # Find batch size
     batch_size = data_loader.batch_size
 
+    # Create dummy input
+    if dummy_input is None:
+        input_shape = utils.get_input_shape(data_loader)
+        dummy_input = utils.create_rand_tensors_given_shapes(input_shape, utils.get_device(model))
+        msg = _red("Please provide dummy input argument. From next release it will be made compulsory")
+        warnings.warn(msg, UserWarning, stacklevel=2)
+
     # Rounding up number of samples to batch size
     n_batches_bias_correction = int(np.ceil(num_bias_correct_samples / batch_size))
     n_batches_quantization = int(np.ceil(num_quant_samples / batch_size))
@@ -265,7 +274,7 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
         for model_input, _ in data_loader_n_samples_quant:
             forward_pass(model, model_input)
 
-    ordered_conv_linear_nodes = get_ordered_lists_of_conv_fc(model, dummy_input=dummy_input)
+    ordered_conv_linear_nodes = get_ordered_lists_of_conv_fc(model, dummy_input)
 
     if conv_bn_dict is None:
         conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)

--- a/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
@@ -70,7 +70,7 @@ class StopForwardException(Exception):
     """ Dummy exception to early-terminate forward-pass """
 
 
-def forward_pass(model: torch.nn.Module, batch: torch.Tensor):
+def forward_pass(model: torch.nn.Module, batch: Union[torch.Tensor, Tuple]):
     """
     forward pass depending model allocation on CPU / GPU till StopForwardException
     :param model: model
@@ -78,11 +78,15 @@ def forward_pass(model: torch.nn.Module, batch: torch.Tensor):
     :return: Nothing
     """
     # first check if the model is on GPU or not
+    if isinstance(batch, torch.Tensor):
+        batch = [batch]
+
     if utils.is_model_on_gpu(model):
-        batch = batch.cuda()
+        batch = [i.cuda() for i in batch]
+
     try:
         with utils.in_eval_mode(model), torch.no_grad():
-            _ = model(batch)
+            _ = model(*batch)
     except StopForwardException:
         pass
 
@@ -116,7 +120,7 @@ def register_fwd_hook_for_layer(layer: torch.nn.Module, hook: Callable) -> torch
     return hook_handle
 
 
-def get_output_data(layer: torch.nn.Module, model: torch.nn.Module, images_in_one_batch: torch.Tensor) -> np.ndarray:
+def get_output_data(layer: torch.nn.Module, model: torch.nn.Module, images_in_one_batch: Union[torch.Tensor, Tuple]) -> np.ndarray:
     """
     Function to get output values of a layer
     :param layer: layer
@@ -217,8 +221,8 @@ def call_analytical_correct_bias(layer: torch.nn.Module,
                                                                             dtype=layer.bias.dtype)
 
 
-def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
-                 num_quant_samples: int, data_loader, num_bias_correct_samples: int,
+def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_samples: int,
+                 dummy_input: Union[torch.Tensor, Tuple], data_loader, num_bias_correct_samples: int,
                  conv_bn_dict: Union[Dict[torch.nn.Module, ConvBnInfoType], None] = None,
                  perform_only_empirical_bias_corr: bool = True,
                  layers_to_ignore: List[torch.nn.Module] = None):
@@ -232,6 +236,7 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
     :param model: Model to be corrected
     :param quant_params: Named tuple for quantization simulation for bias correction
     :param num_quant_samples: number of samples of images to pass through quantization sim for bias correction.
+    :param dummy_input: Dummy input to the model.
     :param data_loader: data loader for the model
     :param num_bias_correct_samples: number of samples for Bias correction
     :param conv_bn_dict: Dict of conv and bn with information related to activation. If None, the function calc it
@@ -243,10 +248,8 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
     if layers_to_ignore is None:
         layers_to_ignore = []
 
-    # Find batch size and shape of input tensor
-    x, *_ = next(iter(data_loader))
-    batch_size = x.shape[0]
-    input_shape = (1, *x.shape[1:])
+    # Find batch size
+    batch_size = data_loader.batch_size
 
     # Rounding up number of samples to batch size
     n_batches_bias_correction = int(np.ceil(num_bias_correct_samples / batch_size))
@@ -259,13 +262,13 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
         # forward pass for given number of batches for model
         data_loader_n_samples_quant = itertools.islice(data_loader, n_batches_quantization)
 
-        for (images_in_one_batch, *_) in data_loader_n_samples_quant:
-            forward_pass(model, images_in_one_batch)
+        for model_input in data_loader_n_samples_quant:
+            forward_pass(model, model_input)
 
-    ordered_conv_linear_nodes = get_ordered_lists_of_conv_fc(model, input_shape)
+    ordered_conv_linear_nodes = get_ordered_lists_of_conv_fc(model, dummy_input=dummy_input)
 
     if conv_bn_dict is None:
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape)
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
 
     # Create a copy of the model as reference model
     model_copy = copy.deepcopy(model)
@@ -281,13 +284,12 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
             module.bias.data = module.bias.data.to(device=module.weight.device)
 
     # Quantize full model
-    dummy_tensors = utils.create_rand_tensors_given_shapes(input_shape, utils.get_device(model))
     q = QuantizationSimModel(model=model, quant_scheme=quant_params.quant_scheme,
                              rounding_mode=quant_params.round_mode,
                              default_output_bw=quant_params.act_bw,
                              default_param_bw=quant_params.weight_bw,
                              in_place=True,
-                             dummy_input=dummy_tensors, config_file=quant_params.config_file)
+                             dummy_input=dummy_input, config_file=quant_params.config_file)
 
     # make sure  model got updated in-place before we use it for bc updates
     assert q.model is model
@@ -338,7 +340,7 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
                     quantized_outputs = []
                     data_loader_n_samples_bias_corr = itertools.islice(data_loader, n_batches_bias_correction)
 
-                    for images_in_one_batch, *_ in data_loader_n_samples_bias_corr:
+                    for images_in_one_batch in data_loader_n_samples_bias_corr:
                         reference_output_batch = get_output_data(reference_layer, model_copy, images_in_one_batch)
                         quantized_model_output_batch = get_output_data(quantize_layer, model, images_in_one_batch)
 
@@ -365,11 +367,11 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams,
     logger.info('Completed bias correction')
 
 
-def find_all_conv_bn_with_activation(model: torch.nn.Module, input_shape: Tuple) -> Dict:
+def find_all_conv_bn_with_activation(model: torch.nn.Module, dummy_input: Union[torch.Tensor, Tuple]) -> Dict:
     """
     Uses searcher to find preceding and next bn layers for a conv/linear layer
     :param model: PyTorch model
-    :param input_shape: shape of input to the model
+    :param dummy_input: Dummy input to the model
     :return: dictionary of conv/linear layers with associated bn op / activation info
     """
 
@@ -397,8 +399,7 @@ def find_all_conv_bn_with_activation(model: torch.nn.Module, input_shape: Tuple)
         patterns_with_callbacks.append(PatternType(pattern=['BatchNormalization', activation, 'ConvTranspose'],
                                                    action=layer_select_handler))
 
-    device = utils.get_device(model)
-    connected_graph = ConnectedGraph(model, (torch.rand(input_shape).to(device),))
+    connected_graph = ConnectedGraph(model, dummy_input)
 
     # create graph searcher instance with connected graph and patterns to search
     graph_searcher = GraphSearcher(connected_graph, patterns_with_callbacks)

--- a/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/bias_correction.py
@@ -40,7 +40,6 @@
 import itertools
 from typing import Callable, Tuple, List, Union, Dict
 import copy
-import warnings
 
 import torch
 import torch.nn
@@ -48,7 +47,7 @@ import numpy as np
 
 from aimet_common.graph_pattern_matcher import PatternType
 from aimet_common.graph_searcher import GraphSearcher
-from aimet_common.utils import AimetLogger, _red
+from aimet_common.utils import AimetLogger
 from aimet_common.bias_correction import (
     ConvBnInfoType,
     ConvBnPatternHandler,
@@ -71,23 +70,23 @@ class StopForwardException(Exception):
     """ Dummy exception to early-terminate forward-pass """
 
 
-def forward_pass(model: torch.nn.Module, batch: Union[torch.Tensor, Tuple]):
+def forward_pass(model: torch.nn.Module, input_batch: Union[torch.Tensor, Tuple, List]):
     """
     forward pass depending model allocation on CPU / GPU till StopForwardException
     :param model: model
-    :param batch: batch
+    :param input_batch: model input
     :return: Nothing
     """
-    # first check if the model is on GPU or not
-    if isinstance(batch, torch.Tensor):
-        batch = [batch]
+    if isinstance(input_batch, torch.Tensor):
+        input_batch = [input_batch]
 
+    input_batch = list(input_batch)
     if utils.is_model_on_gpu(model):
-        batch = [i.cuda() for i in batch]
+        input_batch = [input.cuda() for input in input_batch]
 
     try:
         with utils.in_eval_mode(model), torch.no_grad():
-            _ = model(*batch)
+            _ = model(*input_batch)
     except StopForwardException:
         pass
 
@@ -121,7 +120,7 @@ def register_fwd_hook_for_layer(layer: torch.nn.Module, hook: Callable) -> torch
     return hook_handle
 
 
-def get_output_data(layer: torch.nn.Module, model: torch.nn.Module, images_in_one_batch: Union[torch.Tensor, Tuple]) -> np.ndarray:
+def get_output_data(layer: torch.nn.Module, model: torch.nn.Module, images_in_one_batch: Union[torch.Tensor, Tuple, List]) -> np.ndarray:
     """
     Function to get output values of a layer
     :param layer: layer
@@ -224,7 +223,7 @@ def call_analytical_correct_bias(layer: torch.nn.Module,
 
 # pylint: disable=too-many-arguments
 def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_samples: int,
-                 data_loader, num_bias_correct_samples: int, dummy_input: Union[torch.Tensor, Tuple] = None,
+                 data_loader, num_bias_correct_samples: int,
                  conv_bn_dict: Union[Dict[torch.nn.Module, ConvBnInfoType], None] = None,
                  perform_only_empirical_bias_corr: bool = True,
                  layers_to_ignore: List[torch.nn.Module] = None):
@@ -238,7 +237,6 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
     :param model: Model to be corrected
     :param quant_params: Named tuple for quantization simulation for bias correction
     :param num_quant_samples: number of samples of images to pass through quantization sim for bias correction.
-    :param dummy_input: Dummy input to the model.
     :param data_loader: data loader for the model
     :param num_bias_correct_samples: number of samples for Bias correction
     :param conv_bn_dict: Dict of conv and bn with information related to activation. If None, the function calc it
@@ -253,12 +251,8 @@ def correct_bias(model: torch.nn.Module, quant_params: QuantParams, num_quant_sa
     # Find batch size
     batch_size = data_loader.batch_size
 
-    # Create dummy input
-    if dummy_input is None:
-        input_shape = utils.get_input_shape(data_loader)
-        dummy_input = utils.create_rand_tensors_given_shapes(input_shape, utils.get_device(model))
-        msg = _red("Please provide dummy input argument. From next release it will be made compulsory")
-        warnings.warn(msg, UserWarning, stacklevel=2)
+    dummy_input, _ = next(iter(data_loader))
+    dummy_input = dummy_input.to(utils.get_device(model))
 
     # Rounding up number of samples to batch size
     n_batches_bias_correction = int(np.ceil(num_bias_correct_samples / batch_size))

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -439,18 +439,6 @@ def is_leaf_module(module):
            (CustomSparseConv3DLayer is not None and isinstance(module, CustomSparseConv3DLayer))
 
 
-def get_input_shape(data_loader):
-    """
-    Returns shape of input tensors
-    :param data_loader: labelled dataloader
-    :return: shape or tuple of shapes
-    """
-    data, _ = next(iter(data_loader))
-    if isinstance(data, (tuple, list)):
-        input_shapes = [torch.Tensor.size(inst) for inst in data]
-        return input_shapes
-    return torch.Tensor.size(data)
-
 def has_hooks(module: torch.nn.Module):
     """ Returns True if the module uses hooks. """
     # pylint: disable=protected-access
@@ -530,7 +518,7 @@ def create_rand_tensors_given_shapes(input_shape, device: torch.device):
     return rand_tensors
 
 
-def get_ordered_lists_of_conv_fc(model: torch.nn.Module, dummy_input: Union[torch.Tensor, Tuple]) -> List:
+def get_ordered_lists_of_conv_fc(model: torch.nn.Module, dummy_input: Union[torch.Tensor, Tuple, List]) -> List:
     """
     Finds order of nodes in graph
     :param model: model

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -518,7 +518,7 @@ def create_rand_tensors_given_shapes(input_shape, device: torch.device):
     return rand_tensors
 
 
-def get_ordered_lists_of_conv_fc(model: torch.nn.Module, input_shapes: Tuple,
+def get_ordered_lists_of_conv_fc(model: torch.nn.Module, input_shapes: Union[Tuple, List] = None,
                                  dummy_input: Union[torch.Tensor, Tuple] = None) -> List:
     """
     Finds order of nodes in graph

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -439,6 +439,18 @@ def is_leaf_module(module):
            (CustomSparseConv3DLayer is not None and isinstance(module, CustomSparseConv3DLayer))
 
 
+def get_input_shape(data_loader):
+    """
+    Returns shape of input tensors
+    :param data_loader: labelled dataloader
+    :return: shape or tuple of shapes
+    """
+    data, _ = next(iter(data_loader))
+    if isinstance(data, (tuple, list)):
+        input_shapes = [torch.Tensor.size(inst) for inst in data]
+        return input_shapes
+    return torch.Tensor.size(data)
+
 def has_hooks(module: torch.nn.Module):
     """ Returns True if the module uses hooks. """
     # pylint: disable=protected-access
@@ -518,23 +530,13 @@ def create_rand_tensors_given_shapes(input_shape, device: torch.device):
     return rand_tensors
 
 
-def get_ordered_lists_of_conv_fc(model: torch.nn.Module, input_shapes: Union[Tuple, List] = None,
-                                 dummy_input: Union[torch.Tensor, Tuple] = None) -> List:
+def get_ordered_lists_of_conv_fc(model: torch.nn.Module, dummy_input: Union[torch.Tensor, Tuple]) -> List:
     """
     Finds order of nodes in graph
     :param model: model
-    :param input_shapes: input shape to model
     :param dummy_input: A dummy input to the model. Can be a Tensor or a Tuple of Tensors
     :return: List of names in graph in order
     """
-    if input_shapes is None and dummy_input is None:
-        raise ValueError('Both input shapes and dummy input cannot be None')
-
-    if dummy_input is None:
-        dummy_input = create_rand_tensors_given_shapes(input_shapes, get_device(model))
-        msg = _red("Input shapes argument will be deprecated in a future release. Start using dummy input argument instead")
-        warnings.warn(msg, DeprecationWarning, stacklevel=2)
-
     module_list = get_ordered_list_of_modules(model, dummy_input)
     module_list = [[name, module] for name, module in module_list if
                    isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Linear, torch.nn.ConvTranspose2d,

--- a/TrainingExtensions/torch/src/python/aimet_torch/utils.py
+++ b/TrainingExtensions/torch/src/python/aimet_torch/utils.py
@@ -527,10 +527,14 @@ def get_ordered_lists_of_conv_fc(model: torch.nn.Module, input_shapes: Union[Tup
     :param dummy_input: A dummy input to the model. Can be a Tensor or a Tuple of Tensors
     :return: List of names in graph in order
     """
+    if input_shapes is None and dummy_input is None:
+        raise ValueError('Both input shapes and dummy input cannot be None')
 
-    device = get_device(model)
     if dummy_input is None:
-        dummy_input = create_rand_tensors_given_shapes(input_shapes, device)
+        dummy_input = create_rand_tensors_given_shapes(input_shapes, get_device(model))
+        msg = _red("Input shapes argument will be deprecated in a future release. Start using dummy input argument instead")
+        warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
     module_list = get_ordered_list_of_modules(model, dummy_input)
     module_list = [[name, module] for name, module in module_list if
                    isinstance(module, (torch.nn.Conv1d, torch.nn.Conv2d, torch.nn.Linear, torch.nn.ConvTranspose2d,

--- a/TrainingExtensions/torch/test/python/test_bias_correction.py
+++ b/TrainingExtensions/torch/test/python/test_bias_correction.py
@@ -157,7 +157,7 @@ class TestTrainingExtensionBnFold:
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
                 bias_correction.correct_bias(model, params, 2, data_loader, 2,
-                                             dummy_input, conv_bn_dict, perform_only_empirical_bias_corr=False)
+                                             conv_bn_dict, perform_only_empirical_bias_corr=False)
         assert analytical_mock.call_count == 9
         assert empirical_mock.call_count == 9
         assert model.model[1][0].bias.detach().cpu().numpy() is not None
@@ -178,7 +178,7 @@ class TestTrainingExtensionBnFold:
                                   quant_scheme=QuantScheme.post_training_tf, config_file=None
                                   )
         with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-            bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input)
+            bias_correction.correct_bias(model, params, 2, data_loader, 2)
 
         assert empirical_mock.call_count == 4
         assert np.allclose(model.conv1.bias.detach().cpu().numpy(),
@@ -231,8 +231,8 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
-                                             conv_bn_dict, perform_only_empirical_bias_corr=False, layers_to_ignore = layers_to_ignore)
+                bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
+                                             perform_only_empirical_bias_corr=False, layers_to_ignore = layers_to_ignore)
 
         assert analytical_mock.call_count == 8 # one layer ignored
         assert empirical_mock.call_count == 9
@@ -251,7 +251,7 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
+                bias_correction.correct_bias(model, params, 2, data_loader, 2,
                                              conv_bn_dict, perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
@@ -278,7 +278,7 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
+                bias_correction.correct_bias(model, params, 2, data_loader, 2,
                                              conv_bn_dict, perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
@@ -314,7 +314,7 @@ class TestTrainingExtensionBnFold:
 
         conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
                                      perform_only_empirical_bias_corr=perform_empirical)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))
@@ -349,7 +349,7 @@ class TestTrainingExtensionBnFold:
 
         conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
                                      perform_only_empirical_bias_corr=False)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))

--- a/TrainingExtensions/torch/test/python/test_bias_correction.py
+++ b/TrainingExtensions/torch/test/python/test_bias_correction.py
@@ -76,6 +76,7 @@ class TestNet(nn.Module):
 class BatchIterator:
     def __init__(self, img_size):
         self.image_size = img_size
+        self.batch_size = img_size[0]
 
     def __iter__(self):
         img = torch.randn(*self.image_size)
@@ -144,17 +145,18 @@ class TestTrainingExtensionBnFold:
         model = model.eval()
         dataset_size = 2
         batch_size = 1
+        dummy_input=torch.randn((1, 3, 224, 224))
 
         data_loader = create_fake_data_loader(dataset_size=dataset_size, batch_size=batch_size, image_size=(3, 224, 224))
 
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf
                                  )
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 3, 224, 224))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input=dummy_input)
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2,
+                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2,
                                              conv_bn_dict, perform_only_empirical_bias_corr=False)
         assert analytical_mock.call_count == 9
         assert empirical_mock.call_count == 9
@@ -167,6 +169,7 @@ class TestTrainingExtensionBnFold:
         model_copy = copy.deepcopy(model)
         dataset_size = 2
         batch_size = 1
+        dummy_input = torch.randn((1, 1, 28, 28))
 
         data_loader = create_fake_data_loader(dataset_size=dataset_size, batch_size=batch_size, image_size=(1, 28, 28))
 
@@ -175,7 +178,7 @@ class TestTrainingExtensionBnFold:
                                   quant_scheme=QuantScheme.post_training_tf, config_file=None
                                   )
         with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-            bias_correction.correct_bias(model, params, 2, data_loader, 2)
+            bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2)
 
         assert empirical_mock.call_count == 4
         assert np.allclose(model.conv1.bias.detach().cpu().numpy(),
@@ -187,7 +190,7 @@ class TestTrainingExtensionBnFold:
     def test_layer_selection_bn_based_bc_no_residual(self):
         model = MockMobileNetV1()
         model = model.eval()
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 3, 224, 224))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input=torch.randn((1, 3, 224, 224)))
         conv_2 = model.model[1][0]
         assert conv_bn_dict[conv_2].output_bn is None
         assert len(conv_bn_dict) == 18
@@ -215,21 +218,21 @@ class TestTrainingExtensionBnFold:
         model = model.eval()
         dataset_size = 2
         batch_size = 1
+        dummy_input=torch.randn((1, 3, 224, 224))
 
         data_loader = create_fake_data_loader(dataset_size=dataset_size, batch_size=batch_size, image_size=(3, 224, 224))
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf
                                   )
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 3, 224, 224))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input=dummy_input)
 
         layer = model.model[0][0]
         layers_to_ignore = [layer]
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
-                                             perform_only_empirical_bias_corr=False,
-                                             layers_to_ignore = layers_to_ignore)
+                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2,
+                                             conv_bn_dict, perform_only_empirical_bias_corr=False, layers_to_ignore = layers_to_ignore)
 
         assert analytical_mock.call_count == 8 # one layer ignored
         assert empirical_mock.call_count == 9
@@ -239,15 +242,16 @@ class TestTrainingExtensionBnFold:
         torch.manual_seed(10)
         model = TransposedConvModel()
         model = model.eval()
+        dummy_input=torch.randn((1, 10, 4, 4))
         data_loader = BatchIterator((1, 10, 4, 4))
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf
                                   )
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(10, 10, 4, 4))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input=dummy_input)
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
+                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
                                              perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
@@ -265,15 +269,16 @@ class TestTrainingExtensionBnFold:
         )
         model = model.eval()
 
+        dummy_input=torch.randn((1, 10, 4, 4))
         data_loader = BatchIterator((1, 10, 4, 4))
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf
                                   )
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 10, 4, 4))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
+                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
                                              perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
@@ -302,13 +307,14 @@ class TestTrainingExtensionBnFold:
         model = model.eval().to(device)
         dataset_size = 2
         batch_size = 1
+        dummy_input=torch.randn((1, 3, 32, 32)).to(device)
         data_loader = create_fake_data_loader(dataset_size=dataset_size, batch_size=batch_size, image_size=(3, 32, 32))
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf)
 
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 3, 32, 32))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
                                      perform_only_empirical_bias_corr=perform_empirical)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))
@@ -335,14 +341,15 @@ class TestTrainingExtensionBnFold:
         model = model.eval().to(device)
         dataset_size = 2
         batch_size = 1
+        dummy_input=torch.randn((1, 3, 32, 32)).to(device)
         data_loader = create_fake_data_loader(dataset_size=dataset_size, batch_size=batch_size,
                                               image_size=(3, 32, 32))
         params = qsim.QuantParams(weight_bw=8, act_bw=8, round_mode="nearest",
                                   quant_scheme=QuantScheme.post_training_tf)
 
-        conv_bn_dict = find_all_conv_bn_with_activation(model, input_shape=(1, 3, 32, 32))
+        conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, data_loader, 2, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
                                      perform_only_empirical_bias_corr=False)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))

--- a/TrainingExtensions/torch/test/python/test_bias_correction.py
+++ b/TrainingExtensions/torch/test/python/test_bias_correction.py
@@ -156,8 +156,8 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2,
-                                             conv_bn_dict, perform_only_empirical_bias_corr=False)
+                bias_correction.correct_bias(model, params, 2, data_loader, 2,
+                                             dummy_input, conv_bn_dict, perform_only_empirical_bias_corr=False)
         assert analytical_mock.call_count == 9
         assert empirical_mock.call_count == 9
         assert model.model[1][0].bias.detach().cpu().numpy() is not None
@@ -178,7 +178,7 @@ class TestTrainingExtensionBnFold:
                                   quant_scheme=QuantScheme.post_training_tf, config_file=None
                                   )
         with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-            bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2)
+            bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input)
 
         assert empirical_mock.call_count == 4
         assert np.allclose(model.conv1.bias.detach().cpu().numpy(),
@@ -231,7 +231,7 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2,
+                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
                                              conv_bn_dict, perform_only_empirical_bias_corr=False, layers_to_ignore = layers_to_ignore)
 
         assert analytical_mock.call_count == 8 # one layer ignored
@@ -251,8 +251,8 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
-                                             perform_only_empirical_bias_corr=False,
+                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
+                                             conv_bn_dict, perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
         assert analytical_mock.call_count == 2 # one layer ignored
@@ -278,8 +278,8 @@ class TestTrainingExtensionBnFold:
 
         with unittest.mock.patch('aimet_torch.bias_correction.call_analytical_correct_bias') as analytical_mock:
             with unittest.mock.patch('aimet_torch.bias_correction.call_empirical_correct_bias') as empirical_mock:
-                bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
-                                             perform_only_empirical_bias_corr=False,
+                bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input,
+                                             conv_bn_dict, perform_only_empirical_bias_corr=False,
                                              layers_to_ignore=[])
 
         assert analytical_mock.call_count == 2 # one layer ignored
@@ -314,7 +314,7 @@ class TestTrainingExtensionBnFold:
 
         conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input, conv_bn_dict,
                                      perform_only_empirical_bias_corr=perform_empirical)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))
@@ -349,7 +349,7 @@ class TestTrainingExtensionBnFold:
 
         conv_bn_dict = find_all_conv_bn_with_activation(model, dummy_input)
         params_before = [m.bias.clone() for m in conv_bn_dict.keys()]
-        bias_correction.correct_bias(model, params, 2, dummy_input, data_loader, 2, conv_bn_dict,
+        bias_correction.correct_bias(model, params, 2, data_loader, 2, dummy_input, conv_bn_dict,
                                      perform_only_empirical_bias_corr=False)
         params_after = [m.bias.clone() for m in conv_bn_dict.keys()]
         assert not all(torch.equal(b_prev, b_after) for b_prev, b_after in zip(params_before, params_after))

--- a/TrainingExtensions/torch/test/python/v1/test_model_preparer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_model_preparer.py
@@ -521,12 +521,12 @@ class TestFX:
         data_loader = create_fake_data_loader(dataset_size=16, batch_size=16, image_size=input_shape[1:])
         params = QuantParams(weight_bw=4, act_bw=4, round_mode="nearest",
                              quant_scheme=QuantScheme.post_training_tf)
-        bias_correction.correct_bias(model, params, num_quant_samples=1, data_loader=data_loader,
+        bias_correction.correct_bias(model, params, num_quant_samples=1, dummy_input=dummy_input, data_loader=data_loader,
                                      num_bias_correct_samples=1, perform_only_empirical_bias_corr=True)
 
         # Apply Bias correction for transformed model
         model_transformed = prepare_model(model_copy)
-        bias_correction.correct_bias(model_transformed, params, num_quant_samples=1, data_loader=data_loader,
+        bias_correction.correct_bias(model_transformed, params, num_quant_samples=1, dummy_input=dummy_input, data_loader=data_loader,
                                      num_bias_correct_samples=1, perform_only_empirical_bias_corr=True)
 
         # forward pass for bias corrected original and modified model

--- a/TrainingExtensions/torch/test/python/v1/test_model_preparer.py
+++ b/TrainingExtensions/torch/test/python/v1/test_model_preparer.py
@@ -521,12 +521,12 @@ class TestFX:
         data_loader = create_fake_data_loader(dataset_size=16, batch_size=16, image_size=input_shape[1:])
         params = QuantParams(weight_bw=4, act_bw=4, round_mode="nearest",
                              quant_scheme=QuantScheme.post_training_tf)
-        bias_correction.correct_bias(model, params, num_quant_samples=1, dummy_input=dummy_input, data_loader=data_loader,
+        bias_correction.correct_bias(model, params, num_quant_samples=1, data_loader=data_loader,
                                      num_bias_correct_samples=1, perform_only_empirical_bias_corr=True)
 
         # Apply Bias correction for transformed model
         model_transformed = prepare_model(model_copy)
-        bias_correction.correct_bias(model_transformed, params, num_quant_samples=1, dummy_input=dummy_input, data_loader=data_loader,
+        bias_correction.correct_bias(model_transformed, params, num_quant_samples=1, data_loader=data_loader,
                                      num_bias_correct_samples=1, perform_only_empirical_bias_corr=True)
 
         # forward pass for bias corrected original and modified model


### PR DESCRIPTION
- Added dummy input parameter. This is cleaner rather than deriving input-shape from dataloader and then constructing dummy input tensors. Edit: Removed it as we can always derive dummy input from dataloader.
- Updated the dataloader usage for multi-input case.