### PR TITLE
Fix cnt overflow issue

### DIFF
--- a/ModelOptimizations/DlQuantization/include/DlQuantization/Fp16Quantization.hpp
+++ b/ModelOptimizations/DlQuantization/include/DlQuantization/Fp16Quantization.hpp
@@ -40,6 +40,7 @@
 #define FP16_QUANTIZATION_HPP
 
 #include "DlQuantization/Quantization.hpp"
+#include <cstdint>
 
 namespace DlQuantization
 {
@@ -49,7 +50,7 @@ namespace DlQuantization
  * @param cnt total size of input tensor
  * @param out pointer to the output tensor
  */
-void quantizeDequantizeFp16Gpu(const float* in, int cnt, float* out, void* stream = nullptr);
+void quantizeDequantizeFp16Gpu(const float* in, uint64_t cnt, float* out, void* stream = nullptr);
 
 }   // namespace DlQuantization
 

--- a/ModelOptimizations/DlQuantization/src/Fp16Quantization.cpp
+++ b/ModelOptimizations/DlQuantization/src/Fp16Quantization.cpp
@@ -39,11 +39,12 @@
 #include "DlQuantization/Fp16Quantization.hpp"
 #include "trim_functions.hpp"
 #include <stdexcept>
+#include <cstdint>
 
 namespace DlQuantization
 {
 
-void quantizeDequantizeFp16Gpu(const float* in, int cnt, float* out, void* stream)
+void quantizeDequantizeFp16Gpu(const float* in, uint64_t cnt, float* out, void* stream)
 {
 #ifdef GPU_QUANTIZATION_ENABLED
     quantizeDequantizeFp16ForGPU(in, cnt, out, stream);

--- a/ModelOptimizations/DlQuantization/src/math_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cpp
@@ -59,7 +59,7 @@ namespace DlQuantization
 using namespace std;
 
 template <typename DTYPE>
-DTYPE GetMax(const DTYPE* data, int cnt, ComputationMode cpuGpuMode)
+DTYPE GetMax(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode)
 {
     switch (cpuGpuMode)
     {
@@ -81,7 +81,7 @@ DTYPE GetMax(const DTYPE* data, int cnt, ComputationMode cpuGpuMode)
 }
 
 template <typename DTYPE>
-DTYPE GetMin(const DTYPE* data, int cnt, ComputationMode cpuGpuMode)
+DTYPE GetMin(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode)
 {
     switch (cpuGpuMode)
     {
@@ -100,7 +100,7 @@ DTYPE GetMin(const DTYPE* data, int cnt, ComputationMode cpuGpuMode)
 }
 
 template <typename DTYPE>
-std::tuple<DTYPE, DTYPE> GetMinMax(const DTYPE* data, int cnt, ComputationMode cpuGpuMode)
+std::tuple<DTYPE, DTYPE> GetMinMax(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode)
 {
     switch (cpuGpuMode)
     {
@@ -235,7 +235,7 @@ void InitializePdf(PDF& pdf, DTYPE min_val, DTYPE max_val, bool signed_vals)
 }
 
 template <typename DTYPE>
-void UpdatePdf(const DTYPE* data, int cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
+void UpdatePdf(const DTYPE* data, uint64_t cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
                IAllocator* allocator)
 {
     // Check if we need to initialize the PDF.
@@ -282,7 +282,7 @@ void UpdatePdf(const DTYPE* data, int cnt, ComputationMode mode_cpu_gpu, bool si
 }
 
 template <typename DTYPE>
-void GetHistogram(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
+void GetHistogram(const DTYPE* data, uint64_t cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
                   const DTYPE pdf_offset, const ComputationMode mode_cpu_gpu, const bool is_signed,
                   IAllocator* allocator)
 {
@@ -319,10 +319,10 @@ void GetHistogram(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], cons
 // CPU mode implementations
 
 template <typename DTYPE>
-DTYPE GetMax_cpu(const DTYPE* data, int cnt)
+DTYPE GetMax_cpu(const DTYPE* data, uint64_t cnt)
 {
     DTYPE val = -numeric_limits<double>::max();
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         val = max(val, data[i]);
     }
@@ -330,10 +330,10 @@ DTYPE GetMax_cpu(const DTYPE* data, int cnt)
 }
 
 template <typename DTYPE>
-DTYPE GetMin_cpu(const DTYPE* data, int cnt)
+DTYPE GetMin_cpu(const DTYPE* data, uint64_t cnt)
 {
     DTYPE val = numeric_limits<double>::max();
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         val = min(val, data[i]);
     }
@@ -359,11 +359,11 @@ void MemoryFree_cpu(void* data)
 }
 
 template <typename DTYPE>
-void GetHistogram_cpu(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
+void GetHistogram_cpu(const DTYPE* data, uint64_t cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
                       const DTYPE pdf_offset, const bool is_signed)
 {
     // Go through all data points and add them to the histogram.
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // Map a floating point number to the appropriate bucket.
         int index =
@@ -433,7 +433,7 @@ std::tuple<DTYPE, DTYPE> findOriginalRange(const PDF& pdf)
 }
 
 template <typename DTYPE>
-void updateTensorHistogram(const DTYPE* data, int tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp)
+void updateTensorHistogram(const DTYPE* data, uint64_t tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp)
 {
     switch (mode_cpu_gpu)
     {
@@ -468,7 +468,7 @@ static size_t getBin(size_t nBins, float binWidth, float minValue, float value)
 }
 
 template <typename DTYPE>
-void updateTensorHistogram_cpu(const DTYPE* data, int tensorSize, TensorProfilingParams& tpp)
+void updateTensorHistogram_cpu(const DTYPE* data, uint64_t tensorSize, TensorProfilingParams& tpp)
 {
     double minInput = GetMin(data, tensorSize, COMP_MODE_CPU);
     double maxInput = GetMax(data, tensorSize, COMP_MODE_CPU);
@@ -637,32 +637,32 @@ std::vector<double> rescaleHistogram(const std::vector<double>& srcHist, const d
 }
 
 // Explicit instantiations
-template double GetMax(const double* data, int cnt, ComputationMode mode_cpu_gpu);
+template double GetMax(const double* data, uint64_t cnt, ComputationMode mode_cpu_gpu);
 
-template float GetMax(const float* data, int cnt, ComputationMode mode_cpu_gpu);
+template float GetMax(const float* data, uint64_t cnt, ComputationMode mode_cpu_gpu);
 
-template double GetMin(const double* data, int cnt, ComputationMode mode_cpu_gpu);
+template double GetMin(const double* data, uint64_t cnt, ComputationMode mode_cpu_gpu);
 
-template float GetMin(const float* data, int cnt, ComputationMode mode_cpu_gpu);
+template float GetMin(const float* data, uint64_t cnt, ComputationMode mode_cpu_gpu);
 
-template std::tuple<float, float> GetMinMax(const float* data, int cnt, ComputationMode cpuGpuMode);
+template std::tuple<float, float> GetMinMax(const float* data, uint64_t cnt, ComputationMode cpuGpuMode);
 
-template std::tuple<double, double> GetMinMax(const double* data, int cnt, ComputationMode cpuGpuMode);
+template std::tuple<double, double> GetMinMax(const double* data, uint64_t cnt, ComputationMode cpuGpuMode);
 
-template void UpdatePdf(const double* data, int cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
+template void UpdatePdf(const double* data, uint64_t cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
                         IAllocator* allocator);
 
-template void UpdatePdf(const float* data, int cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
+template void UpdatePdf(const float* data, uint64_t cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
                         IAllocator* allocator);
 
 template std::tuple<double, double> findOriginalRange(const PDF& pdf);
 
 template std::tuple<float, float> findOriginalRange(const PDF& pdf);
 
-template void updateTensorHistogram(const double* data, int tensorSize, ComputationMode mode_cpu_gpu,
+template void updateTensorHistogram(const double* data, uint64_t tensorSize, ComputationMode mode_cpu_gpu,
                                     TensorProfilingParams& tpp);
 
-template void updateTensorHistogram(const float* data, int tensorSize, ComputationMode mode_cpu_gpu,
+template void updateTensorHistogram(const float* data, uint64_t tensorSize, ComputationMode mode_cpu_gpu,
                                     TensorProfilingParams& tpp);
 
 }   // End of namespace DlQuantization

--- a/ModelOptimizations/DlQuantization/src/math_functions.cu
+++ b/ModelOptimizations/DlQuantization/src/math_functions.cu
@@ -42,6 +42,7 @@
 #include <thrust/functional.h>
 #include <thrust/reduce.h>
 #include <cub/cub.cuh>
+#include <cstdint>
 
 #include "cuda_util.hpp"
 #include "math_functions.hpp"
@@ -50,14 +51,14 @@
 namespace DlQuantization
 {
 template <typename DTYPE>
-DTYPE GetMax_gpu(const DTYPE* data, int cnt)
+DTYPE GetMax_gpu(const DTYPE* data, uint64_t cnt)
 {
     const thrust::device_ptr<const DTYPE> ptr = thrust::device_pointer_cast(data);
     return thrust::reduce(ptr, ptr + cnt, std::numeric_limits<DTYPE>::lowest(), thrust::maximum<DTYPE>());
 }
 
 template <typename DTYPE>
-DTYPE GetMin_gpu(const DTYPE* data, int cnt)
+DTYPE GetMin_gpu(const DTYPE* data, uint64_t cnt)
 {
     const thrust::device_ptr<const DTYPE> ptr = thrust::device_pointer_cast(data);
     return thrust::reduce(ptr, ptr + cnt, std::numeric_limits<DTYPE>::max(), thrust::minimum<DTYPE>());
@@ -65,7 +66,7 @@ DTYPE GetMin_gpu(const DTYPE* data, int cnt)
 
 
 template <typename DTYPE>
-std::tuple<DTYPE, DTYPE> GetMinMax_gpu(const DTYPE* data, int cnt)
+std::tuple<DTYPE, DTYPE> GetMinMax_gpu(const DTYPE* data, uint64_t cnt)
 {
     DTYPE minMaxOut[2];
     DTYPE *dMinMaxOut;
@@ -132,17 +133,17 @@ bool MemoryFree_gpu(void* data)
 }
 
 // Explicit instantiations
-template double GetMax_gpu(const double* data, int cnt);
+template double GetMax_gpu(const double* data, uint64_t cnt);
 
-template float GetMax_gpu(const float* data, int cnt);
+template float GetMax_gpu(const float* data, uint64_t cnt);
 
-template double GetMin_gpu(const double* data, int cnt);
+template double GetMin_gpu(const double* data, uint64_t cnt);
 
-template float GetMin_gpu(const float* data, int cnt);
+template float GetMin_gpu(const float* data, uint64_t cnt);
 
-template std::tuple<float, float> GetMinMax_gpu(const float* data, int cnt);
+template std::tuple<float, float> GetMinMax_gpu(const float* data, uint64_t cnt);
 
-template std::tuple<double, double> GetMinMax_gpu(const double* data, int cnt);
+template std::tuple<double, double> GetMinMax_gpu(const double* data, uint64_t cnt);
 
 template <typename DTYPE>
 __global__ static void histogramCountKernel(const DTYPE* data,
@@ -195,7 +196,7 @@ static const int PDF_MAX_BUFF_BYTES = (1 << 25); // 32MB
 
 template <typename DTYPE>
 void GetHistogram_gpu(const DTYPE* data,
-                      int cnt,
+                      uint64_t cnt,
                       uint32_t histogram[PDF_SIZE],
                       const DTYPE bucket_size,
                       const DTYPE pdf_offset,
@@ -233,14 +234,14 @@ void GetHistogram_gpu(const DTYPE* data,
 }
 
 template void GetHistogram_gpu(const float* data,
-                               int cnt,
+                               uint64_t cnt,
                                uint32_t histogram[PDF_SIZE],
                                const float bucket_size,
                                const float pdf_offset,
                                const bool is_signed,
                                IAllocator* allocator);
 template void GetHistogram_gpu(const double* data,
-                               int cnt,
+                               uint64_t cnt,
                                uint32_t histogram[PDF_SIZE],
                                const double bucket_size,
                                const double pdf_offset,

--- a/ModelOptimizations/DlQuantization/src/math_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/math_functions.hpp
@@ -88,13 +88,13 @@ struct StatsLayerPdf
 };
 
 template <typename DTYPE>
-DTYPE GetMax(const DTYPE* data, int cnt, ComputationMode cpuGpuMode);
+DTYPE GetMax(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode);
 
 template <typename DTYPE>
-DTYPE GetMin(const DTYPE* data, int cnt, ComputationMode cpuGpuMode);
+DTYPE GetMin(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode);
 
 template <typename DTYPE>
-std::tuple<DTYPE, DTYPE> GetMinMax(const DTYPE* data, int cnt, ComputationMode cpuGpuMode);
+std::tuple<DTYPE, DTYPE> GetMinMax(const DTYPE* data, uint64_t cnt, ComputationMode cpuGpuMode);
 
 // Android compiler doesn't have std::log2, so define it here
 double logBase2(double d);
@@ -114,7 +114,7 @@ double logBase2(double d);
  * memory allocator available.
  */
 template <typename DTYPE>
-void UpdatePdf(const DTYPE* data, int cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
+void UpdatePdf(const DTYPE* data, uint64_t cnt, ComputationMode mode_cpu_gpu, bool signed_vals, PDF& pdf,
                IAllocator* allocator);
 
 /**
@@ -130,7 +130,7 @@ void UpdatePdf(const DTYPE* data, int cnt, ComputationMode mode_cpu_gpu, bool si
  * memory allocator available.
  */
 template <typename DTYPE>
-void GetHistogram(const DTYPE* data, const int cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
+void GetHistogram(const DTYPE* data, const uint64_t cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
                   const DTYPE pdf_offset, const ComputationMode mode_cpu_gpu, const bool is_signed,
                   IAllocator* allocator);
 
@@ -160,10 +160,10 @@ void ElementwiseMult(ComputationMode modeCpuGpu, const float* in, size_t cnt, fl
 
 // CPU implementations...
 template <typename DTYPE>
-DTYPE GetMax_cpu(const DTYPE* data, int cnt);
+DTYPE GetMax_cpu(const DTYPE* data, uint64_t cnt);
 
 template <typename DTYPE>
-DTYPE GetMin_cpu(const DTYPE* data, int cnt);
+DTYPE GetMin_cpu(const DTYPE* data, uint64_t cnt);
 
 void ElementwiseMult_cpu(const float* in, size_t cnt, float factor, float* out);
 
@@ -172,7 +172,7 @@ void* MemoryAllocation_cpu(size_t bytes);
 void MemoryFree_cpu(void* data);
 
 template <typename DTYPE>
-void GetHistogram_cpu(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
+void GetHistogram_cpu(const DTYPE* data, uint64_t cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
                       const DTYPE pdf_offset, const bool is_signed);
 
 /**
@@ -192,10 +192,10 @@ std::tuple<DTYPE, DTYPE> findOriginalRange(const PDF& pdf);
  * @param tpp histogram of float numbers seen so far.
  */
 template <typename DTYPE>
-void updateTensorHistogram(const DTYPE* data, int tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp);
+void updateTensorHistogram(const DTYPE* data, uint64_t tensorSize, ComputationMode mode_cpu_gpu, TensorProfilingParams& tpp);
 
 template <typename DTYPE>
-void updateTensorHistogram_cpu(const DTYPE* data, int tensorSize, TensorProfilingParams& tpp);
+void updateTensorHistogram_cpu(const DTYPE* data, uint64_t tensorSize, TensorProfilingParams& tpp);
 
 /**
  * @brief Function to rescale the input histogram srcHist initially computed in the
@@ -211,13 +211,13 @@ std::vector<double> rescaleHistogram(const std::vector<double>& srcHist, const d
 #ifdef GPU_QUANTIZATION_ENABLED
 
 template <typename DTYPE>
-DTYPE GetMax_gpu(const DTYPE* data, int cnt);
+DTYPE GetMax_gpu(const DTYPE* data, uint64_t cnt);
 
 template <typename DTYPE>
-DTYPE GetMin_gpu(const DTYPE* data, int cnt);
+DTYPE GetMin_gpu(const DTYPE* data, uint64_t cnt);
 
 template <typename DTYPE>
-std::tuple<DTYPE, DTYPE> GetMinMax_gpu(const DTYPE* data, int cnt);
+std::tuple<DTYPE, DTYPE> GetMinMax_gpu(const DTYPE* data, uint64_t cnt);
 
 void ElementwiseMult_gpu(const float* in, size_t cnt, float factor, float* out);
 
@@ -226,7 +226,7 @@ void* MemoryAllocation_gpu(size_t bytes);
 bool MemoryFree_gpu(void* data);
 
 template <typename DTYPE>
-void GetHistogram_gpu(const DTYPE* data, int cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
+void GetHistogram_gpu(const DTYPE* data, uint64_t cnt, uint32_t histogram[PDF_SIZE], const DTYPE bucket_size,
                       const DTYPE pdf_offset, const bool is_signed, IAllocator* allocator);
 
 #endif   // GPU_QUANTIZATION_ENABLED

--- a/ModelOptimizations/DlQuantization/src/trim_functions.cpp
+++ b/ModelOptimizations/DlQuantization/src/trim_functions.cpp
@@ -92,7 +92,7 @@ Lambda parallelize(const uint32_t number_of_threads, Lambda lambda)
 
 // encoding: TF: rounded
 template <typename DTYPE>
-void quantizeDequantize(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
+void quantizeDequantize(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
                         RoundingMode rounding_mode, void* stream)
 {
     switch (mode_cpu_gpu)
@@ -115,7 +115,7 @@ void quantizeDequantize(const DTYPE* in, int cnt, const TfEncoding& encoding, DT
 
 // encoding: TF: rounded
 template <typename DTYPE>
-void quantizeToFxp(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
+void quantizeToFxp(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
                    RoundingMode rounding_mode, bool shiftToSigned)
 {
     switch (mode_cpu_gpu)
@@ -172,9 +172,9 @@ inline void dequantizeValueCpu(DTYPE* out, DTYPE encoding_delta, DTYPE encoding_
 }
 
 template <typename DTYPE>
-void quantizeDequantizeCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode)
+void quantizeDequantizeCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         quantizeValueCpu<DTYPE>(&in[i], &out[i], encoding.min, encoding.max, encoding.delta, encoding.offset,
                                 rounding_mode);
@@ -184,7 +184,7 @@ void quantizeDequantizeCpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
 
 
 template <typename DTYPE>
-void quantizeToFxpPacked(const DTYPE* in, int cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
+void quantizeToFxpPacked(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
                          ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned)
 {
     switch (mode_cpu_gpu)
@@ -201,7 +201,7 @@ void quantizeToFxpPacked(const DTYPE* in, int cnt, const TfEncoding& encoding, u
     }
 }
 template <typename DTYPE>
-void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
+void quantizeToFxpCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                       bool shiftToSigned)
 {
     // Using unsigned int to account for case of signed symmetric 32 bit, when shift will be 2^31
@@ -210,7 +210,7 @@ void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYP
     {
         shift = pow(2, encoding.bw - 1);
     }
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         quantizeValueCpu<DTYPE>(&in[i], &out[i], encoding.min, encoding.max, encoding.delta, encoding.offset,
                                 rounding_mode);
@@ -219,7 +219,7 @@ void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYP
 }
 
 template <typename DTYPE>
-void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
+void quantizeToFxpPackedCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
                             RoundingMode rounding_mode, bool shiftToSigned)
 {
     size_t min_out_size = ceil(max(encoding.bw, 8) * cnt / 8.0);
@@ -236,14 +236,14 @@ void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding
     number_of_threads = 1;
   }
 #endif
-    int iteration_per_threads = (int) ceil((double) cnt / (double) number_of_threads);
+    uint64_t iteration_per_threads = (uint64_t) ceil((double) cnt / (double) number_of_threads);
     auto quantize_job         = [&](int thread_id)
     {
-        int start = thread_id * iteration_per_threads;
-        int end   = std::min(start + iteration_per_threads, cnt);
+        uint64_t start = thread_id * iteration_per_threads;
+        uint64_t end   = std::min(start + iteration_per_threads, cnt);
 
         double data_quantized;
-        for (int i = start; i < end; ++i)
+        for (uint64_t i = start; i < end; ++i)
         {
             // Saturate
             data_quantized = max(min((double) in[i], encoding.max), encoding.min);
@@ -387,7 +387,7 @@ void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding
 
 
 template <typename DTYPE>
-void dequantizeFromPackedFxp(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxp(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                              ComputationMode mode_cpu_gpu, bool shiftToSigned)
 {
     switch (mode_cpu_gpu)
@@ -405,11 +405,11 @@ void dequantizeFromPackedFxp(const uint8_t* input, int cnt, const TfEncoding& en
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxpCpuMt(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                                   bool shiftToSigned)
 {
-    int32_t num_threads = std::max(1, std::min(cnt / 120000, 4));
-    int32_t chunkSize   = cnt / num_threads;
+    int32_t num_threads = std::max(1, std::min((int32_t)(cnt / 120000), 4));
+    uint64_t chunkSize   = cnt / num_threads;
     int32_t bw_adj      = encoding.bw / 8;
 
     if (cnt % num_threads)
@@ -420,8 +420,8 @@ void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt, const TfEncodin
     std::vector<std::thread> threads;
     for (int i = 0; i < num_threads; ++i)
     {
-        int chunkStart = chunkSize * i;
-        int chunkEnd   = std::min(chunkStart + chunkSize, cnt);
+        uint64_t chunkStart = chunkSize * i;
+        uint64_t chunkEnd   = std::min(chunkStart + chunkSize, cnt);
         threads.push_back(std::thread(dequantizeFromPackedFxpCpu<DTYPE>, input + (chunkStart * bw_adj),
                                       chunkEnd - chunkStart, encoding, output + chunkStart, shiftToSigned));
     }
@@ -430,14 +430,14 @@ void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt, const TfEncodin
 
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpTfBitsCpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpTfBitsCpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
     double data_quantized;
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // Extract next value from packed data stream
         // The packed data is unsigned in TF-style quantization
-        int bit_offset = encoding.bw * i;
+        uint64_t bit_offset = encoding.bw * i;
         uint32_t tmp   = input[bit_offset / 8] >> (bit_offset % 8);
         data_quantized = (double) (tmp & (uint32_t) ((1 << encoding.bw) - 1));
 
@@ -447,9 +447,9 @@ void dequantizeFromPackedFxpTfBitsCpu(const uint8_t* input, int cnt, const TfEnc
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpTf8Cpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpTf8Cpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // De-quantize the data and write it to output vector.
         output[i] = (encoding.delta * ((double) input[i] + encoding.offset));
@@ -457,9 +457,9 @@ void dequantizeFromPackedFxpTf8Cpu(const uint8_t* input, int cnt, const TfEncodi
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpTf16Cpu(const uint16_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpTf16Cpu(const uint16_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // De-quantize the data and write it to output vector.
         output[i] = (encoding.delta * ((double) input[i] + encoding.offset));
@@ -467,9 +467,9 @@ void dequantizeFromPackedFxpTf16Cpu(const uint16_t* input, int cnt, const TfEnco
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpTf32Cpu(const uint32_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpTf32Cpu(const uint32_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // De-quantize the data and write it to output vector.
         output[i] = (encoding.delta * ((double) input[i] + encoding.offset));
@@ -477,10 +477,10 @@ void dequantizeFromPackedFxpTf32Cpu(const uint32_t* input, int cnt, const TfEnco
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpSymmetricBitsCpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpSymmetricBitsCpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
     double data_quantized;
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
 // Removed packed support, no current use case
 #if 0
@@ -515,9 +515,9 @@ void dequantizeFromPackedFxpSymmetricBitsCpu(const uint8_t* input, int cnt, cons
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpSymmetric8Cpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpSymmetric8Cpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         int8_t* ptr = (int8_t*) input;
         // De-quantize the data and write it to output vector.
@@ -526,9 +526,9 @@ void dequantizeFromPackedFxpSymmetric8Cpu(const uint8_t* input, int cnt, const T
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpSymmetric16Cpu(const int16_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpSymmetric16Cpu(const int16_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // De-quantize the data and write it to output vector.
         output[i] = (encoding.delta * ((double) input[i] + encoding.offset));
@@ -536,9 +536,9 @@ void dequantizeFromPackedFxpSymmetric16Cpu(const int16_t* input, int cnt, const 
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpSymmetric32Cpu(const int32_t* input, int cnt, const TfEncoding& encoding, DTYPE* output)
+void dequantizeFromPackedFxpSymmetric32Cpu(const int32_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         // De-quantize the data and write it to output vector.
         output[i] = (encoding.delta * ((double) input[i] + encoding.offset));
@@ -546,7 +546,7 @@ void dequantizeFromPackedFxpSymmetric32Cpu(const int32_t* input, int cnt, const 
 }
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpCpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxpCpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                                 bool shiftToSigned)
 {
     if (!shiftToSigned)
@@ -665,7 +665,7 @@ void quantizeDequantizePerChannelCpu(const DTYPE* in, int numChannel, int numEle
                                      DTYPE* out, DTYPE* encodingMin, DTYPE* encodingMax, DTYPE* encodingDelta,
                                      DTYPE* encodingOffset, RoundingMode roundingMode)
 {
-    for (int i = 0; i < numElement; ++i)
+    for (uint64_t i = 0; i < numElement; ++i)
     {
         int channelIdx = (i / numElementPerChannel) % numChannel;
         quantizeValueCpu<DTYPE>(&in[i], &out[i], encodingMin[channelIdx], encodingMax[channelIdx],
@@ -716,25 +716,25 @@ void quantizeDequantizeBroadcast(const T* inTensor, T* outTensor, const Encoding
 
 
 // Explicit instantiations
-template void quantizeDequantize(const double* in, int cnt, const TfEncoding& encoding, double* out,
+template void quantizeDequantize(const double* in, uint64_t cnt, const TfEncoding& encoding, double* out,
                                  ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, void* stream);
 
-template void quantizeDequantize(const float* in, int cnt, const TfEncoding& encoding, float* out,
+template void quantizeDequantize(const float* in, uint64_t cnt, const TfEncoding& encoding, float* out,
                                  ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, void* stream);
 
-template void quantizeToFxp(const double* in, int cnt, const TfEncoding& encoding, double* out,
+template void quantizeToFxp(const double* in, uint64_t cnt, const TfEncoding& encoding, double* out,
                             ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
 
-template void quantizeToFxp(const float* in, int cnt, const TfEncoding& encoding, float* out,
+template void quantizeToFxp(const float* in, uint64_t cnt, const TfEncoding& encoding, float* out,
                             ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
 
-template void quantizeToFxpPacked(const float* in, int cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
+template void quantizeToFxpPacked(const float* in, uint64_t cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
                                   ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
-template void quantizeToFxpPacked(const double* in, int cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
+template void quantizeToFxpPacked(const double* in, uint64_t cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
                                   ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
-template void dequantizeFromPackedFxp(const uint8_t* input, int cnt, const TfEncoding& encoding, double* output,
+template void dequantizeFromPackedFxp(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, double* output,
                                       ComputationMode mode_cpu_gpu, bool shiftToSigned);
-template void dequantizeFromPackedFxp(const uint8_t* input, int cnt, const TfEncoding& encoding, float* output,
+template void dequantizeFromPackedFxp(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, float* output,
                                       ComputationMode mode_cpu_gpu, bool shiftToSigned);
 
 template void quantizeDequantizePerChannel(const float* in, int numChannel, int numElement, int numElementPerChannel,

--- a/ModelOptimizations/DlQuantization/src/trim_functions.cu
+++ b/ModelOptimizations/DlQuantization/src/trim_functions.cu
@@ -44,7 +44,7 @@
 namespace DlQuantization
 {
 template <typename DTYPE>
-__global__ void quantizeDequantizeKernel(const DTYPE* in, int cnt, DTYPE* out,
+__global__ void quantizeDequantizeKernel(const DTYPE* in, uint64_t cnt, DTYPE* out,
                                          DTYPE encoding_min, DTYPE encoding_max,
                                          DTYPE encoding_delta, DTYPE encoding_offset,
                                          RoundingMode rounding_mode)
@@ -60,7 +60,7 @@ __global__ void quantizeDequantizeKernel(const DTYPE* in, int cnt, DTYPE* out,
 }
 
 template <typename DTYPE>
-__global__ void quantizeToFxpKernel(const DTYPE* in, int cnt, DTYPE* out,
+__global__ void quantizeToFxpKernel(const DTYPE* in, uint64_t cnt, DTYPE* out,
                                     DTYPE encoding_min, DTYPE encoding_max,
                                     DTYPE encoding_delta, DTYPE encoding_offset,
                                     RoundingMode rounding_mode, unsigned int shift)
@@ -123,7 +123,7 @@ __global__ void quantizeDequantizeBroadcastKernel(const DTYPE* in, DTYPE* out, i
 
 
 template <typename DTYPE>
-void quantizeDequantizeGpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
+void quantizeDequantizeGpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                            void* stream)
 {
     quantizeDequantizeKernel<DTYPE>
@@ -132,7 +132,7 @@ void quantizeDequantizeGpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
 }
 
 
-__global__ void quantizeDequantizeFp16Kernel(const float* in, int cnt, float* out)
+__global__ void quantizeDequantizeFp16Kernel(const float* in, uint64_t cnt, float* out)
 {
     CUDA_KERNEL_LOOP(i, cnt)
     {
@@ -141,7 +141,7 @@ __global__ void quantizeDequantizeFp16Kernel(const float* in, int cnt, float* ou
 }
 
 
-void quantizeDequantizeFp16ForGPU(const float* in, int cnt, float* out, void* stream)
+void quantizeDequantizeFp16ForGPU(const float* in, uint64_t cnt, float* out, void* stream)
 {
     quantizeDequantizeFp16Kernel<<<CUDA_NUM_BLOCKS(cnt), CUDA_NUM_THREADS, 0, reinterpret_cast<cudaStream_t>(stream)>>>(
         in, cnt, out);
@@ -149,7 +149,7 @@ void quantizeDequantizeFp16ForGPU(const float* in, int cnt, float* out, void* st
 
 
 template <typename DTYPE>
-void quantizeToFxpGpu(const DTYPE* in, int cnt, const TfEncoding& encoding,
+void quantizeToFxpGpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding,
                       DTYPE* out, RoundingMode rounding_mode, bool shiftToSigned)
 {
     unsigned int shift = 0;
@@ -226,17 +226,17 @@ void quantizeDequantizeBroadcastGpu(const DTYPE* in, DTYPE* out, const Encodings
 
 
 // Explicit instantiations
-template void quantizeDequantizeGpu(const double* in, int cnt, const TfEncoding& encoding, double* out,
+template void quantizeDequantizeGpu(const double* in, uint64_t cnt, const TfEncoding& encoding, double* out,
                                     RoundingMode rounding_mode, void* stream);
 
-template void quantizeDequantizeGpu(const float* in, int cnt, const TfEncoding& encoding, float* out,
+template void quantizeDequantizeGpu(const float* in, uint64_t cnt, const TfEncoding& encoding, float* out,
                                     RoundingMode rounding_mode, void* stream);
 
-template void quantizeToFxpGpu(const double* in, int cnt, const TfEncoding& encoding, double* out,
+template void quantizeToFxpGpu(const double* in, uint64_t cnt, const TfEncoding& encoding, double* out,
                                RoundingMode rounding_mode, bool shiftToSigned);
 
 
-template void quantizeToFxpGpu(const float* in, int cnt, const TfEncoding& encoding, float* out,
+template void quantizeToFxpGpu(const float* in, uint64_t cnt, const TfEncoding& encoding, float* out,
                                RoundingMode rounding_mode, bool shiftToSigned);
 
 template void quantizeDequantizePerChannelGpu(const float* in, int numChannel, int numElement, int numElementPerChannel,

--- a/ModelOptimizations/DlQuantization/src/trim_functions.hpp
+++ b/ModelOptimizations/DlQuantization/src/trim_functions.hpp
@@ -50,44 +50,44 @@ namespace DlQuantization
 inline double randUniformCpu();
 
 template <typename DTYPE>
-void quantizeDequantize(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
+void quantizeDequantize(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
                         RoundingMode rounding_mode, void* stream);
 
 
-void quantizeDequantizeFp16ForGPU(const float* in, int cnt, float* out, void* stream);
+void quantizeDequantizeFp16ForGPU(const float* in, uint64_t cnt, float* out, void* stream);
 
 
 template <typename DTYPE>
-void quantizeToFxp(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
+void quantizeToFxp(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, ComputationMode mode_cpu_gpu,
                    RoundingMode rounding_mode, bool shiftToSigned);
 
 template <typename DTYPE>
-void quantizeToFxpPacked(const DTYPE* in, int cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
+void quantizeToFxpPacked(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, uint8_t* out, size_t out_size,
                          ComputationMode mode_cpu_gpu, RoundingMode rounding_mode, bool shiftToSigned);
 
 template <typename DTYPE>
-void dequantizeFromPackedFxp(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxp(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                              ComputationMode mode_cpu_gpu, bool shiftToSigned);
 
 template <typename DTYPE>
-void quantizeDequantizeCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out,
+void quantizeDequantizeCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out,
                            RoundingMode rounding_mode);
 
 template <typename DTYPE>
-void quantizeToFxpCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
+void quantizeToFxpCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                       bool shiftToSigned);
 
 template <typename DTYPE>
-void quantizeToFxpPackedCpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, size_t out_size,
+void quantizeToFxpPackedCpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, size_t out_size,
                             RoundingMode rounding_mode, bool shiftToSigned);
 
 // Multi-threading implementation
 template <typename DTYPE>
-void dequantizeFromPackedFxpCpuMt(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxpCpuMt(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                                   bool shiftToSigned);
 
 template <typename DTYPE>
-void dequantizeFromPackedFxpCpu(const uint8_t* input, int cnt, const TfEncoding& encoding, DTYPE* output,
+void dequantizeFromPackedFxpCpu(const uint8_t* input, uint64_t cnt, const TfEncoding& encoding, DTYPE* output,
                                 bool shiftToSigned);
 
 double computeDelta(double encodingMin, double encodingMax, double numSteps);
@@ -109,11 +109,11 @@ void quantizeDequantizeBroadcastCpu(const DTYPE* in, DTYPE* out, const Encodings
 #ifdef GPU_QUANTIZATION_ENABLED
 
 template <typename DTYPE>
-void quantizeToFxpGpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
+void quantizeToFxpGpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                       bool shiftToSigned);
 
 template <typename DTYPE>
-void quantizeDequantizeGpu(const DTYPE* in, int cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
+void quantizeDequantizeGpu(const DTYPE* in, uint64_t cnt, const TfEncoding& encoding, DTYPE* out, RoundingMode rounding_mode,
                            void* stream);
 
 template <typename DTYPE>

--- a/ModelOptimizations/DlQuantization/test/test_quantization_lib.hpp
+++ b/ModelOptimizations/DlQuantization/test/test_quantization_lib.hpp
@@ -112,7 +112,7 @@ class Blob
 
 public:
     // Blob is initialized with data from CPU
-    Blob(DataType* cpuDataPtr, int cnt)
+    Blob(DataType* cpuDataPtr, uint64_t cnt)
     {
         _cpuDataPtr = (DataType*) malloc(cnt * sizeof(DataType));
         memcpy(_cpuDataPtr, cpuDataPtr, cnt * sizeof(DataType));

--- a/TrainingExtensions/onnx/src/AimetOpUtils.cpp
+++ b/TrainingExtensions/onnx/src/AimetOpUtils.cpp
@@ -57,9 +57,9 @@ void copyInputTensorsToOutputTensors(const T* inTensor, size_t count, T* outTens
 }
 
 
-void quantizeDequantizeFp16Cpu(const float* in, int cnt, float* out)
+void quantizeDequantizeFp16Cpu(const float* in, uint64_t cnt, float* out)
 {
-    for (int i = 0; i < cnt; ++i)
+    for (uint64_t i = 0; i < cnt; ++i)
     {
         *(out + i) = Eigen::half_impl::half_to_float(Eigen::half_impl::float_to_half_rtne(*(in + i)));
     }

--- a/TrainingExtensions/onnx/src/AimetOpUtils.h
+++ b/TrainingExtensions/onnx/src/AimetOpUtils.h
@@ -55,7 +55,7 @@
 template <typename T>
 void copyInputTensorsToOutputTensors(const T* inTensor, size_t count, T* outTensor, bool useCuda, void* stream);
 
-void quantizeDequantizeFp16Cpu(const float* in, int cnt, float* out);
+void quantizeDequantizeFp16Cpu(const float* in, uint64_t cnt, float* out);
 
 template <typename T>
 void modeSpecificActionBroadcastInt(const T* inTensor, T* outTensor, const std::vector<int64_t> inputShape,


### PR DESCRIPTION
Dear AIMET team,

In the C++/CUDA quantization kernel, many functions use `int cnt`. However, for some large models (e.g., LLaMA, Stable Diffusion), cnt can overflow the range of a 32-bit int. Since cnt should always be non-negative, I modified its type to uint64_t. I did consider uint32_t, but it still carries a risk of overflow.

The issue I faced was when I applied quantization to a large ONNX model. The parameter size of a layer exceeded the integer limit, so the calibration process entered an infinite loop.

Please let me know if you see any issues.