### PR TITLE
Fix CUDA dependencies discrepancy against CPU wheel

### DIFF
--- a/packaging/dependencies/reqs_pip_common.txt
+++ b/packaging/dependencies/reqs_pip_common.txt
@@ -1,5 +1,4 @@
-bokeh==3.2.2
-dataclasses
+bokeh
 h5py
 holoviews==1.18.3
 hvplot==0.9.2
@@ -9,6 +8,6 @@ osqp
 pybind11
 PyYAML
 scikit-learn
-scipy==1.8.1
+scipy
 setuptools
 tqdm

--- a/packaging/dependencies/reqs_pip_onnx_common.txt
+++ b/packaging/dependencies/reqs_pip_onnx_common.txt
@@ -1,7 +1,7 @@
 cvxpy
 matplotlib>=3
 networkx
-numpy<=1.24.4,>=1.16.6
+numpy<=2,>=1.16.6
 onnx
 onnxruntime-extensions
 onnxscript>=0.2.0


### PR DESCRIPTION
I've noticed that the CPU and CUDA wheels for `aimet_onnx` have different dependencies, which are quite restrictive in the case of the latter. Specifically, these differences currently affect me in the CUDA backend enablement:

```bash
# >>> CPU wheel
$ cat aimet_onnx-2.21.0+cpu.dist-info/METADATA | grep dataclasses
$ cat aimet_onnx-2.21.0+cpu.dist-info/METADATA | grep scipy
$ cat aimet_onnx-2.21.0+cpu.dist-info/METADATA | grep numpy
Requires-Dist: numpy<2
$ cat aimet_onnx-2.21.0+cpu.dist-info/METADATA | grep bokeh
Requires-Dist: bokeh

# >>> CUDA wheel
$ cat aimet_onnx-2.21.0+cu121.dist-info/METADATA | grep dataclasses
Requires-Dist: dataclasses
$ cat aimet_onnx-2.21.0+cu121.dist-info/METADATA | grep scipy
Requires-Dist: scipy==1.8.1
$ cat aimet_onnx-2.21.0+cu121.dist-info/METADATA | grep numpy
Requires-Dist: numpy<=1.24.4,>=1.16.6
$ cat aimet_onnx-2.21.0+cu121.dist-info/METADATA | grep bokeh
Requires-Dist: bokeh==3.2.2
```

This PR follows up on the discussion started on Slack:  
https://qualcomm-ai-hub.slack.com/archives/C08JKBE0UHY/p1766585701934399 